### PR TITLE
fix: allow setting Parallel Offset when using Outdoor Sensor

### DIFF
--- a/custom_components/qvantum/number.py
+++ b/custom_components/qvantum/number.py
@@ -76,9 +76,6 @@ class QvantumNumberEntity(CoordinatorEntity, NumberEntity):
         self._attr_native_max_value = max
         self._attr_native_step = step
 
-        if self._metric_key == "indoor_temperature_offset":
-            self._attr_entity_registry_enabled_default = self.available
-
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
 
@@ -122,12 +119,5 @@ class QvantumNumberEntity(CoordinatorEntity, NumberEntity):
             self._metric_key in self.coordinator.data.get("settings")
             and self.coordinator.data.get("settings").get(self._metric_key) is not None
         )
-
-        # if using outdoor sensor, allow setting parallel offset
-        if (
-            self._metric_key == "indoor_temperature_offset"
-            and self.coordinator.data.get("settings").get("sensor_mode") != "bt1"
-        ):
-            return False
 
         return avail


### PR DESCRIPTION
When using outdoor sensor mode, the sensor_mode does not return "bt2"; but instead "off". According to the manual all available modes of operation (indoor and outdoor) allow setting the Parallel Offset.

From debug logging:
```[custom_components.qvantum.api] Settings fetched: {'meta': {'last_reported': '2025-11-08T14:00:34.300Z', 'validity': 'valid_now'}, 'settings': [{'name': 'indoor_temperature_offset', 'value': 3, 'read_only': False}, {'name': 'vacation_mode', 'value': 'off', 'read_only': False}, {'name': 'indoor_temperature_target', 'value': 21, 'read_only': False}, {'name': 'sensor_mode', 'value': 'off', 'read_only': True}, {'name': 'tap_water_stop', 'value': 62, 'read_only': False}, {'name': 'extra_tap_water', 'value': 'off', 'read_only': True}, {'name': 'tap_water_capacity_target', 'value': 2, 'read_only': False}, {'name': 'tap_water_start', 'value': 52, 'read_only': False}]}```