### PR TITLE
feat: Add new switches for SmartControl and Manual operation mode

### DIFF
--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -180,17 +180,9 @@ class QvantumAPI:
     async def update_setting(self, device_id: str, name: str, value: any):
         """Update one setting."""
 
-        payload = {"settings": [{"name": name, "value": value}]}
-        await self._ensure_valid_token()
+        payload = {"update_settings": {name: value}}
 
-        async with self._session.patch(
-            f"{self._api_url}/api/device-info/v1/devices/{device_id}/settings?dispatch=false",
-            json=payload,
-            headers=self._request_headers(),
-        ) as response:
-            data = await response.json()
-            _LOGGER.debug(f"Response received {response.status}: {data}")
-            return data
+        return await self._send_command(device_id, payload)
 
     async def _update_settings(self, device_id: str, payload: dict):
         """Update one or several settings."""

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -45,6 +45,10 @@ DEFAULT_ENABLED_METRICS = [
     "op_man_addition",
     "op_man_dhw",
     "op_mode",
+    "man_mode",
+    "enable_sc_dhw",
+    "enable_sc_sh",
+    "use_adaptive",
 ]
 
 DEFAULT_DISABLED_METRICS = [
@@ -67,11 +71,8 @@ DEFAULT_DISABLED_METRICS = [
     "dhw_outl_temp_5",
     "dhw_outl_temp_max",
     "dhw_prioritytime",
-    "enable_sc_dhw",
-    "enable_sc_sh",
     "guide_des_temp",
     "guide_he",
-    "man_mode",
     "op_man_cooling",
     "op_mode_sensor",
     "picpin_relay_qm10",
@@ -79,7 +80,6 @@ DEFAULT_DISABLED_METRICS = [
     "qn8position",
     "room_temp_ext",
     "smart_sh_mode",
-    "use_adaptive",
     "dhwdemand",
     "heatingdemand",
     "coolingdemand",

--- a/custom_components/qvantum/switch.py
+++ b/custom_components/qvantum/switch.py
@@ -29,9 +29,11 @@ async def async_setup_entry(
     sensors.append(QvantumSwitchEntity(coordinator, "op_mode", device))
     sensors.append(QvantumSwitchEntity(coordinator, "op_man_dhw", device))
     sensors.append(QvantumSwitchEntity(coordinator, "op_man_addition", device))
+    sensors.append(QvantumSwitchEntity(coordinator, "man_mode", device))
 
-    # sensors.append(QvantumSwitchEntity(coordinator, "enable_sc_sh", device))
-    # sensors.append(QvantumSwitchEntity(coordinator, "enable_sc_dhw", device))
+    sensors.append(QvantumSwitchEntity(coordinator, "use_adaptive", device))
+    sensors.append(QvantumSwitchEntity(coordinator, "enable_sc_sh", device))
+    sensors.append(QvantumSwitchEntity(coordinator, "enable_sc_dhw", device))
 
     async_add_entities(sensors)
 
@@ -60,6 +62,8 @@ class QvantumSwitchEntity(CoordinatorEntity, SwitchEntity):
         match self._metric_key:
             case "op_mode":
                 self._attr_icon = "mdi:auto-mode"
+            case "man_mode":
+                self._attr_icon = "mdi:radiator"
             case "op_man_dhw":
                 self._attr_icon = "mdi:water-outline"
             case "op_man_addition":
@@ -76,7 +80,7 @@ class QvantumSwitchEntity(CoordinatorEntity, SwitchEntity):
                     response, self.coordinator, "settings", self._metric_key, "off"
                 )
 
-            case "enable_sc_dhw" | "enable_sc_sh":
+            case "enable_sc_dhw" | "enable_sc_sh" | "use_adaptive":
                 response = await self.coordinator.api.update_setting(
                     self._hpid, self._metric_key, False
                 )
@@ -103,7 +107,7 @@ class QvantumSwitchEntity(CoordinatorEntity, SwitchEntity):
                     response, self.coordinator, "settings", self._metric_key, "on"
                 )
 
-            case "enable_sc_dhw" | "enable_sc_sh":
+            case "enable_sc_dhw" | "enable_sc_sh" | "use_adaptive":
                 response = await self.coordinator.api.update_setting(
                     self._hpid, self._metric_key, True
                 )
@@ -149,10 +153,16 @@ class QvantumSwitchEntity(CoordinatorEntity, SwitchEntity):
                     )
                     is not None
                 )
-            case "op_man_addition" | "op_man_dhw":
+            case "op_man_addition" | "op_man_dhw" | "man_mode":
                 return (
                     self._metric_key in self.coordinator.data.get("metrics", {})
                     and self.coordinator.data.get("metrics", {}).get("op_mode") == 1
+                )
+            case "enable_sc_dhw" | "enable_sc_sh":
+                return (
+                    self._metric_key in self.coordinator.data.get("metrics", {})
+                    and self.coordinator.data.get("metrics", {}).get("use_adaptive")
+                    is True
                 )
             case _:
                 return (

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -10,13 +10,25 @@
         "name": "Extra heißes Wasser"
       },
       "op_man_addition": {
-        "name": "Zusatz im manuellen Modus erlauben"
+        "name": "Manueller Betriebsmodus: Zusatz"
       },
       "op_man_dhw": {
-        "name": "Brauchwasser im manuellen Modus erlauben"
+        "name": "Manueller Betriebsmodus: Brauchwasser"
       },
       "op_mode": {
         "name": "Manueller Betriebsmodus"
+      },
+      "man_mode": {
+        "name": "Manueller Betriebsmodus: Heizung"
+      },
+      "use_adaptive": {
+        "name": "SmartControl"
+      },
+      "enable_sc_dhw": {
+        "name": "SmartControl: Brauchwasser"
+      },
+      "enable_sc_sh": {
+        "name": "SmartControl: Heizung"
       }
     },
     "button": {
@@ -26,25 +38,25 @@
     },
     "binary_sensor": {
       "op_man_addition": {
-        "name": "Betrieb manuell Zusatz"
+        "name": "Manueller Betriebsmodus: Zusatz"
       },
       "op_man_cooling": {
-        "name": "Betrieb manuell Kühlung"
+        "name": "Manueller Betriebsmodus: Kühlung"
       },
       "op_man_dhw": {
-        "name": "Betrieb manuell Brauchwasser"
+        "name": "Manueller Betriebsmodus: Brauchwasser"
       },
       "use_adaptive": {
-        "name": "Intelligente Steuerung"
+        "name": "SmartControl"
       },
       "cooling_enabled": {
         "name": "Kühlung aktiviert"
       },
       "enable_sc_dhw": {
-        "name": "SmartControl Brauchwasser aktivieren"
+        "name": "SmartControl: Brauchwasser"
       },
       "enable_sc_sh": {
-        "name": "SmartControl Heizung aktivieren"
+        "name": "SmartControl: Heizung"
       },
       "picpin_relay_heat_l1": {
         "name": "Zusätzliche Wärme L1"

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -10,13 +10,25 @@
         "name": "Extra hot water"
       },
       "op_man_addition": {
-        "name": "Allow addition in manual mode"
+        "name": "Manual Operation Mode: Addition"
       },
       "op_man_dhw": {
-        "name": "Allow hot water in manual mode"
+        "name": "Manual Operation Mode: Hot Water"
       },
       "op_mode": {
-        "name": "Manual operation mode"
+        "name": "Manual Operation Mode"
+      },
+      "man_mode": {
+        "name": "Manual Operation Mode: Heating"
+      },
+      "use_adaptive": {
+        "name": "SmartControl"
+      },
+      "enable_sc_dhw": {
+        "name": "SmartControl: DHW"
+      },
+      "enable_sc_sh": {
+        "name": "SmartControl: Heating"
       }
     },
     "button": {
@@ -26,25 +38,25 @@
     },
     "binary_sensor": {
       "op_man_addition": {
-        "name": "Operation manual addition"
+        "name": "Manual Operation Mode: Addition"
       },
       "op_man_cooling": {
-        "name": "Operation manual cooling"
+        "name": "Manual Operation Mode: Cooling"
       },
       "op_man_dhw": {
-        "name": "Operation manual DHW"
-      },
-      "use_adaptive": {
-        "name": "Smart Control"
+        "name": "Manual Operation Mode: Hot Water"
       },
       "cooling_enabled": {
         "name": "Cooling enabled"
       },
+      "use_adaptive": {
+        "name": "SmartControl"
+      },
       "enable_sc_dhw": {
-        "name": "Enable SmartControl DHW"
+        "name": "SmartControl: DHW"
       },
       "enable_sc_sh": {
-        "name": "Enable SmartControl heating"
+        "name": "SmartControl: Heating"
       },
       "picpin_relay_heat_l1": {
         "name": "Additional power L1"

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -10,13 +10,25 @@
         "name": "Extra WTW"
       },
       "op_man_addition": {
-        "name": "Toevoeging in handmatige modus toestaan"
+        "name": "Handmatige Bedrijfsmodus: Toevoeging"
       },
       "op_man_dhw": {
-        "name": "WTW in handmatige modus toestaan"
+        "name": "Handmatige Bedrijfsmodus: WTW"
       },
       "op_mode": {
-        "name": "Handmatige bedrijfsmodus"
+        "name": "Handmatige Bedrijfsmodus"
+      },
+      "man_mode": {
+        "name": "Handmatige Bedrijfsmodus: Verwarming"
+      },
+      "use_adaptive": {
+        "name": "SmartControl"
+      },
+      "enable_sc_dhw": {
+        "name": "SmartControl: WTW"
+      },
+      "enable_sc_sh": {
+        "name": "SmartControl: Verwarming"
       }
     },
     "button": {
@@ -26,25 +38,25 @@
     },
     "binary_sensor": {
       "op_man_addition": {
-        "name": "Handmatige toevoeging"
+        "name": "Handmatige Bedrijfsmodus: Toevoeging"
       },
       "op_man_cooling": {
-        "name": "Handmatige koeling"
+        "name": "Handmatige Bedrijfsmodus: Koeling"
       },
       "op_man_dhw": {
-        "name": "Handmatig WTW"
+        "name": "Handmatige Bedrijfsmodus: WTW"
       },
       "use_adaptive": {
-        "name": "Slimme controle"
+        "name": "SmartControl"
       },
       "cooling_enabled": {
         "name": "Koeling ingeschakeld"
       },
       "enable_sc_dhw": {
-        "name": "SmartControl WTW inschakelen"
+        "name": "SmartControl: WTW"
       },
       "enable_sc_sh": {
-        "name": "SmartControl verwarming inschakelen"
+        "name": "SmartControl: Verwarming"
       },
       "picpin_relay_heat_l1": {
         "name": "Extra vermogen L1"

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -10,13 +10,25 @@
         "name": "Extra varmvatten"
       },
       "op_man_addition": {
-        "name": "Tillåt tillsats i manuellt läge"
+        "name": "Manuellt Driftläge: Tillsats"
       },
       "op_man_dhw": {
-        "name": "Tillåt varmvatten i manuellt läge"
+        "name": "Manuellt Driftläge: Varmvatten"
       },
       "op_mode": {
-        "name": "Manuellt driftläge"
+        "name": "Manuellt Driftläge"
+      },
+      "man_mode": {
+        "name": "Manuellt Driftläge: Uppvärmning"
+      },
+      "use_adaptive": {
+        "name": "SmartControl"
+      },
+      "enable_sc_dhw": {
+        "name": "SmartControl: Varmvatten"
+      },
+      "enable_sc_sh": {
+        "name": "SmartControl: Uppvärmning"
       }
     },
     "button": {
@@ -26,25 +38,25 @@
     },
     "binary_sensor": {
       "op_man_addition": {
-        "name": "Driftläge manuell tillsats"
+        "name": "Manuellt Driftläge: Tillsats"
       },
       "op_man_cooling": {
-        "name": "Driftläge manuell kylning"
+        "name": "Manuellt Driftläge: Kylning"
       },
       "op_man_dhw": {
-        "name": "Driftläge manuell varmvatten"
+        "name": "Manuellt Driftläge: Varmvatten"
       },
       "enable_sc_dhw": {
-        "name": "Tillåt smart styrning varmvatten"
+        "name": "SmartControl: Varmvatten"
       },
       "enable_sc_sh": {
-        "name": "Tillåt smart styrning uppvärmning"
+        "name": "SmartControl: Uppvärmning"
       },
       "cooling_enabled": {
         "name": "Kylning aktiverad"
       },
       "use_adaptive": {
-        "name": "Smart Control"
+        "name": "SmartControl"
       },
       "picpin_relay_heat_l1": {
         "name": "Eltillsats L1"


### PR DESCRIPTION
This pull request introduces new "SmartControl" and manual operation mode switches to the Qvantum integration, improves how settings are updated via the API, and enhances translation consistency across multiple languages. The main changes are grouped below.

**Feature Additions and Switch Logic:**

* Added new switches for `man_mode`, `use_adaptive`, `enable_sc_dhw`, and `enable_sc_sh` in `switch.py`, making them available as Home Assistant entities. The switch icons and availability logic were also updated accordingly. [[1]](diffhunk://#diff-6ed57739ccd19bc74180e7c90c9088b9a034e361ada99b8f636dfec7030150ffR32-R36) [[2]](diffhunk://#diff-6ed57739ccd19bc74180e7c90c9088b9a034e361ada99b8f636dfec7030150ffR65-R66) [[3]](diffhunk://#diff-6ed57739ccd19bc74180e7c90c9088b9a034e361ada99b8f636dfec7030150ffL79-R83) [[4]](diffhunk://#diff-6ed57739ccd19bc74180e7c90c9088b9a034e361ada99b8f636dfec7030150ffL106-R110) [[5]](diffhunk://#diff-6ed57739ccd19bc74180e7c90c9088b9a034e361ada99b8f636dfec7030150ffL152-R166)
* Updated the list of supported metrics in `const.py` to include the new switches, and moved them out of the disabled metrics list. [[1]](diffhunk://#diff-07fd7ac76e58c80e95bb6c9ca3ff34f8c124f4a881a23cd946cfefaa5719e953R48-R51) [[2]](diffhunk://#diff-07fd7ac76e58c80e95bb6c9ca3ff34f8c124f4a881a23cd946cfefaa5719e953L70-L82)

**API and Backend Improvements:**

* Changed the `update_setting` method in `api.py` to use the new `update_settings` payload structure and delegate to `_send_command`, aligning with backend API expectations.

**Translations and User Interface:**

* Improved and standardized translations for manual mode and SmartControl switches in English, German, Dutch, and Swedish, ensuring consistent naming and better clarity for users. [[1]](diffhunk://#diff-acfc3b0627ed2bb0327c528addfe1335670f607c305117c84c6eaf8b8c31e780L13-R31) [[2]](diffhunk://#diff-acfc3b0627ed2bb0327c528addfe1335670f607c305117c84c6eaf8b8c31e780L29-R59) [[3]](diffhunk://#diff-c38b12eee4843bd1f813526f2a1d519a00e26c744de32799eae5b19f0e992a4fL13-R31) [[4]](diffhunk://#diff-c38b12eee4843bd1f813526f2a1d519a00e26c744de32799eae5b19f0e992a4fL29-R59) [[5]](diffhunk://#diff-109634c5949fae269ebe22ad819b8beeaeec637b0fe83e1fcda3b18fb3ba1c0dL13-R31) [[6]](diffhunk://#diff-109634c5949fae269ebe22ad819b8beeaeec637b0fe83e1fcda3b18fb3ba1c0dL29-R59) [[7]](diffhunk://#diff-17731185892f92368a0a463c8d218030c11e775fab898134846ab991a29440f0L13-R31) [[8]](diffhunk://#diff-17731185892f92368a0a463c8d218030c11e775fab898134846ab991a29440f0L29-R53)