### PR TITLE
fix: Remove unnecessary reset of metrics_data on fetch failure

### DIFF
--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -466,7 +466,6 @@ class QvantumAPI:
                 case _:
                     _LOGGER.error(f"Failed to fetch data, status: {response.status}")
                     _LOGGER.debug(f"Failed to fetch data, status: {response}")
-                    self._metrics_data = {}
 
         return self._metrics_data
 


### PR DESCRIPTION
This pull request makes a minor change to the error handling in the `get_metrics` method of `api.py`. The line resetting `self._metrics_data` to an empty dictionary on failed data fetches has been removed.