### PR TITLE
feat: Add room comp factor to required metrics and enhance value retrieval logic

### DIFF
--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -115,6 +115,7 @@ REQUIRED_METRICS = [
     "smart_sh_mode",  # Required by select component
     "smart_dhw_mode",  # Required by select component
     "use_adaptive",  # Required by select component and switch components
+    "room_comp_factor",  # Required by number component
 ]
 
 # Sensor filtering patterns

--- a/custom_components/qvantum/number.py
+++ b/custom_components/qvantum/number.py
@@ -110,7 +110,11 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
             start = self.coordinator.data.get("settings", {}).get("tap_water_start")
             if (stop, start) in TAP_WATER_CAPACITY_MAPPINGS:
                 return TAP_WATER_CAPACITY_MAPPINGS[(stop, start)]
-        return self.coordinator.data.get("settings", {}).get(self._metric_key)
+
+        value = self.coordinator.data.get("settings", {}).get(self._metric_key)
+        if value is None:
+            value = self.coordinator.data.get("metrics", {}).get(self._metric_key)
+        return value
 
     @property
     def available(self):
@@ -120,5 +124,11 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
             self._metric_key in self.coordinator.data.get("settings")
             and self.coordinator.data.get("settings").get(self._metric_key) is not None
         )
+        if not avail:
+            avail = (
+                self._metric_key in self.coordinator.data.get("metrics")
+                and self.coordinator.data.get("metrics").get(self._metric_key)
+                is not None
+            )
 
         return avail


### PR DESCRIPTION
This pull request improves the handling of number components by ensuring that the `room_comp_factor` attribute is included and that the code can retrieve and check values from both the `settings` and `metrics` data sources. This makes the integration more robust in cases where a value may be missing from one source but present in the other.

Enhancements to number component support:

* Added `"room_comp_factor"` to the list of required attributes for the number component in `const.py`.

Improved data retrieval and availability logic:

* Updated the `state` property in `number.py` to check both `settings` and `metrics` for the metric key, returning the value from `metrics` if it's not found in `settings`.
* Enhanced the `available` property in `number.py` to consider the metric key available if it exists and is not `None` in either `settings` or `metrics`.