### PR TITLE
feat: Update sensor handling for qn8position and adjust related tests

### DIFF
--- a/custom_components/qvantum/binary_sensor.py
+++ b/custom_components/qvantum/binary_sensor.py
@@ -44,7 +44,6 @@ async def async_setup_entry(
         "picpin_relay_heat_l2",
         "picpin_relay_heat_l3",
         "picpin_relay_qm10",
-        "qn8position",
     ]
 
     for sensor_name in sensor_names:

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -51,6 +51,7 @@ DEFAULT_ENABLED_METRICS = [
     "use_adaptive",
     "smart_sh_mode",
     "smart_dhw_mode",
+    "qn8position",
 ]
 
 DEFAULT_DISABLED_METRICS = [
@@ -79,7 +80,6 @@ DEFAULT_DISABLED_METRICS = [
     "op_mode_sensor",
     "picpin_relay_qm10",
     "price_region",
-    "qn8position",
     "room_temp_ext",
     "dhwdemand",
     "heatingdemand",
@@ -124,7 +124,6 @@ EXCLUDED_METRIC_PATTERNS = [
     "enable",
     "smart_",
     "picpin_",
-    "qn8",
     "use_",
 ]
 

--- a/custom_components/qvantum/sensor.py
+++ b/custom_components/qvantum/sensor.py
@@ -139,7 +139,11 @@ class QvantumBaseSensorEntity(QvantumEntity, SensorEntity):
         """Set appropriate units based on metric key patterns."""
         if metric_key in ["compressormeasuredspeed", "fanrpm"]:
             self._attr_native_unit_of_measurement = "rpm"
-        elif "fan" in metric_key or metric_key.startswith("gp"):
+        elif (
+            "fan" in metric_key
+            or metric_key.startswith("gp")
+            or metric_key.startswith("qn8")
+        ):
             self._attr_native_unit_of_measurement = "%"
         elif "bf1_l_min" == metric_key:
             self._attr_native_unit_of_measurement = "l/m"

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -96,9 +96,6 @@
       },
       "picpin_relay_qm10": {
         "name": "Drei-Wege-Ventil, Brauchwasser/Heizung (QM10)"
-      },
-      "qn8position": {
-        "name": "Mischventil, Zusatz (QN8)"
       }
     },
     "sensor": {
@@ -192,6 +189,9 @@
       },
       "fanrpm": {
         "name": "Lüftergeschwindigkeit"
+      },
+      "qn8position": {
+        "name": "Mischventil, Zusatz (QN8)"
       },
       "gp1_speed": {
         "name": "Heizmedium-Pumpe (GP1)"

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -96,9 +96,6 @@
       },
       "picpin_relay_qm10": {
         "name": "Divertingvalve, DHW/heating (QM10)"
-      },
-      "qn8position": {
-        "name": "Shuntvalve, addition (QN8)"
       }
     },
     "sensor": {
@@ -192,6 +189,9 @@
       },
       "fanrpm": {
         "name": "Fan speed"
+      },
+      "qn8position": {
+        "name": "Shuntvalve, addition (QN8)"
       },
       "gp1_speed": {
         "name": "Circulation pump (GP1)"

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -96,9 +96,6 @@
       },
       "picpin_relay_qm10": {
         "name": "Omloopklep, tapwater/verwarming (QM10)"
-      },
-      "qn8position": {
-        "name": "Sluitklep, toevoeging (QN8)"
       }
     },
     "sensor": {
@@ -192,6 +189,9 @@
       },
       "fanrpm": {
         "name": "Ventilatorsnelheid"
+      },
+      "qn8position": {
+        "name": "Sluitklep, toevoeging (QN8)"
       },
       "gp1_speed": {
         "name": "Circulatiepomp (GP1)"

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -99,9 +99,6 @@
       },
       "picpin_relay_qm10": {
         "name": "Växelventil, Varmvatten/Uppvärmning (QM10)"
-      },
-      "qn8position": {
-        "name": "Shuntventil, tillsats (QN8)"
       }
     },
     "sensor": {
@@ -195,6 +192,9 @@
       },
       "fanrpm": {
         "name": "Fläkthastighet"
+      },
+      "qn8position": {
+        "name": "Shuntventil, tillsats (QN8)"
       },
       "gp1_speed": {
         "name": "Cirkulationspump (GP1)"

--- a/tests/test_binary_sensor_working.py
+++ b/tests/test_binary_sensor_working.py
@@ -203,7 +203,7 @@ async def test_async_setup_entry(
         # Check that entities were added
         assert async_add_entities.called
         entities = async_add_entities.call_args[0][0]
-        assert len(entities) == 11  # 11 sensor names
+        assert len(entities) == 10  # 10 sensor names
 
         # Check that we have the expected sensor types
         sensor_names = [
@@ -217,7 +217,6 @@ async def test_async_setup_entry(
             "picpin_relay_heat_l2",
             "picpin_relay_heat_l3",
             "picpin_relay_qm10",
-            "qn8position",
         ]
 
         for i, sensor_name in enumerate(sensor_names):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -69,6 +69,7 @@ def mock_coordinator():
             "fan0_10v": 75,  # Fan percentage
             "compressormeasuredspeed": 3000,  # RPM
             "bf1_l_min": 25.5,  # Flow rate
+            "qn8position": 1,  # Position sensor
         },
         "settings": {
             "tap_water_start": 3600,

--- a/tests/test_sensor_working.py
+++ b/tests/test_sensor_working.py
@@ -89,6 +89,7 @@ def mock_coordinator():
             "fan0_10v": 75,  # Fan percentage
             "compressormeasuredspeed": 3000,  # RPM
             "bf1_l_min": 25.5,  # Flow rate
+            "qn8position": 1,  # Position sensor
         },
         "settings": {
             "tap_water_start": 3600,


### PR DESCRIPTION
This pull request primarily updates how the `qn8position` metric is handled across the integration, moving it from being treated as a binary sensor to a regular sensor metric. It also ensures `qn8position` is properly included in the supported metrics, unit assignment logic, translations, and test coverage.

**Sensor and Metric Handling Updates:**

* Removed `qn8position` from the list of binary sensors in `binary_sensor.py` and from related tests, so it is no longer created as a binary sensor. [[1]](diffhunk://#diff-3a9e900020101e3e4430e89aa19f99516316fca8c52985153eb65056097356adL47) [[2]](diffhunk://#diff-aef867fc5be94cbd5f34b448147557de092c1e80117a8703668a82f892367b12L206-R206) [[3]](diffhunk://#diff-aef867fc5be94cbd5f34b448147557de092c1e80117a8703668a82f892367b12L220)
* Added `qn8position` to the list of supported metrics in `const.py`, ensuring it is recognized as a regular sensor.
* Updated the metric pattern logic in `sensor.py` to assign the correct unit (`%`) to metrics starting with `qn8`.

**Translations:**

* Moved the `qn8position` translation entries from the binary sensor section to the sensor section in all supported languages (`en.json`, `de.json`, `nl.json`, `sv.json`). [[1]](diffhunk://#diff-acfc3b0627ed2bb0327c528addfe1335670f607c305117c84c6eaf8b8c31e780L99-L101) [[2]](diffhunk://#diff-acfc3b0627ed2bb0327c528addfe1335670f607c305117c84c6eaf8b8c31e780R193-R195) [[3]](diffhunk://#diff-c38b12eee4843bd1f813526f2a1d519a00e26c744de32799eae5b19f0e992a4fL99-L101) [[4]](diffhunk://#diff-c38b12eee4843bd1f813526f2a1d519a00e26c744de32799eae5b19f0e992a4fR193-R195) [[5]](diffhunk://#diff-109634c5949fae269ebe22ad819b8beeaeec637b0fe83e1fcda3b18fb3ba1c0dL99-L101) [[6]](diffhunk://#diff-109634c5949fae269ebe22ad819b8beeaeec637b0fe83e1fcda3b18fb3ba1c0dR193-R195) [[7]](diffhunk://#diff-17731185892f92368a0a463c8d218030c11e775fab898134846ab991a29440f0L102-L104) [[8]](diffhunk://#diff-17731185892f92368a0a463c8d218030c11e775fab898134846ab991a29440f0R196-R198)

**Testing:**

* Added `qn8position` to the mock coordinator data in sensor tests to ensure it is covered as a regular sensor. [[1]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330R72) [[2]](diffhunk://#diff-20896223bd7845352544547a303e7968d1ff44fbd8d9d180bd6dc9ab79027dc7R92)

**Other Adjustments:**

* Cleaned up the `const.py` file by removing `qn8position` from disabled metrics and `qn8` from the ignored metric prefixes, reflecting its new handling as a regular sensor. [[1]](diffhunk://#diff-07fd7ac76e58c80e95bb6c9ca3ff34f8c124f4a881a23cd946cfefaa5719e953L82) [[2]](diffhunk://#diff-07fd7ac76e58c80e95bb6c9ca3ff34f8c124f4a881a23cd946cfefaa5719e953L127)