### PR TITLE
fix: update firmware coordinator reference to maintenance coordinator in unload entry

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -106,7 +106,9 @@ class TestIntegrationSetup:
 
         # Add runtime_data to config entry
         mock_config_entry.runtime_data = MagicMock()
-        mock_config_entry.runtime_data.firmware_coordinator = mock_firmware_coordinator
+        mock_config_entry.runtime_data.maintenance_coordinator = (
+            mock_firmware_coordinator
+        )
 
         with patch(
             "custom_components.qvantum.async_dismiss", new_callable=AsyncMock


### PR DESCRIPTION
This pull request refactors the coordinator responsible for firmware updates and maintenance tasks, consolidating its responsibilities under a single `maintenance_coordinator` identifier. This change improves clarity and consistency in naming throughout the codebase and test suite.

Coordinator renaming and usage updates:

* Replaced all instances of `firmware_coordinator` with `maintenance_coordinator` in the initialization logic and runtime data assignment in `custom_components/qvantum/__init__.py`.
* Updated the unloading logic to reference `maintenance_coordinator` instead of `firmware_coordinator`, ensuring notifications and device handling are consistent with the new naming.

Test suite adjustments:

* Modified the test `test_async_unload_entry_with_firmware_notifications` to use `maintenance_coordinator` in place of `firmware_coordinator` for runtime data mocking.