### PR TITLE
feat: enable fan support

### DIFF
--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -38,7 +38,7 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.BUTTON,
     Platform.SELECT,
-    # Platform.FAN,
+    Platform.FAN,
 ]
 
 type MyConfigEntry = ConfigEntry[RuntimeData]

--- a/custom_components/qvantum/fan.py
+++ b/custom_components/qvantum/fan.py
@@ -26,12 +26,14 @@ async def async_setup_entry(
     config_entry: MyConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ):
-    """Set up the Select."""
+    """Set up the Fan."""
     coordinator: QvantumDataUpdateCoordinator = config_entry.runtime_data.coordinator
     device: DeviceInfo = config_entry.runtime_data.device
 
     fans = []
-    fans.append(QvantumFanEntity(coordinator, "fanspeedselector", device))
+    # Only create fan entity if the device supports fan speed control
+    if "fanspeedselector" in coordinator.data.get("settings", {}):
+        fans.append(QvantumFanEntity(coordinator, "fanspeedselector", device))
 
     async_add_entities(fans)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -419,7 +419,7 @@ class TestQvantumAPI:
         cm, mock_response = mock_session.make_cm_response(
             status=200, json_data=update_data
         )
-        mock_session.patch.return_value = cm
+        mock_session.post.return_value = cm
 
         api = QvantumAPI(
             "test@example.com", "password", "test-agent", session=mock_session
@@ -547,7 +547,7 @@ class TestQvantumAPI:
         cm, mock_response = mock_session.make_cm_response(
             status=200, json_data=update_data
         )
-        mock_session.patch.return_value = cm
+        mock_session.post.return_value = cm
 
         api = QvantumAPI(
             "test@example.com", "password", "test-agent", session=mock_session
@@ -567,7 +567,7 @@ class TestQvantumAPI:
         cm, mock_response = mock_session.make_cm_response(
             status=200, json_data=update_data
         )
-        mock_session.patch.return_value = cm
+        mock_session.post.return_value = cm
 
         api = QvantumAPI(
             "test@example.com", "password", "test-agent", session=mock_session
@@ -578,11 +578,6 @@ class TestQvantumAPI:
         result = await api.set_fanspeedselector("test_device", "extra")
 
         assert result == update_data
-        # Verify ventilation_boost_stop is included
-        call_args = mock_session.patch.call_args
-        payload = call_args[1]["json"]
-        assert len(payload["settings"]) == 2
-        assert payload["settings"][1]["name"] == "ventilation_boost_stop"
 
     @pytest.mark.asyncio
     async def test_set_fanspeedselector_invalid_preset(self, mock_session):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,8 +5,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # Import real functions before mocking
-from custom_components.qvantum import async_setup_entry, async_unload_entry
-from custom_components.qvantum.api import QvantumAPI
+from custom_components.qvantum import async_setup_entry, async_unload_entry, PLATFORMS
 
 # Mock HA imports after importing real functions
 # sys.modules['custom_components.qvantum'] = MagicMock()
@@ -50,6 +49,10 @@ class TestIntegrationSetup:
             result = await async_setup_entry(hass, mock_config_entry)
 
             assert result is True
+            # Verify that all platforms are forwarded
+            hass.config_entries.async_forward_entry_setups.assert_called_once_with(
+                mock_config_entry, PLATFORMS
+            )
 
     @pytest.mark.asyncio
     async def test_async_setup_entry_no_device_data(


### PR DESCRIPTION
This pull request adds support for fan entities to the integration, refactors the fan speed control API to use a new command format, and updates related tests to reflect these changes. It ensures that fan entities are only created if the device supports fan speed control, and adapts the API and tests to use `POST` requests with the new payload structure.

**Fan Entity Support and Setup:**
- Enabled the `Platform.FAN` in the list of supported platforms, allowing the integration to register fan entities.
- Updated `async_setup_entry` in `fan.py` to only add a fan entity if the device supports fan speed control (i.e., if `"fanspeedselector"` is present in the device settings).
- Added tests to verify that fan entities are only created when supported by the device, and not otherwise.

**Fan Speed Control API Refactor:**
- Refactored `set_fanspeedselector` in `api.py` to use a new command payload structure and switched from patching settings to sending a command via `POST` requests. The payload now uses `set_fan_mode` with `mode`, `stopTime`, and `indefinite` parameters, and the logic for handling different preset modes was updated accordingly.

**Test Updates:**
- Updated tests in `test_api.py` to use `mock_session.post` instead of `mock_session.patch`, and removed assertions related to the old payload structure. [[1]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79L422-R422) [[2]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79L550-R550) [[3]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79L570-R570) [[4]](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79L581-L585)
- Improved imports and test coverage for fan entity setup in `test_fan_working.py`.
- Updated `test_init.py` to verify that all platforms, including the new fan platform, are forwarded during setup. [[1]](diffhunk://#diff-056c6b0b13b9539a120e8832b32e9cf5e681eb230fda35a261267d6381a0599eL8-R8) [[2]](diffhunk://#diff-056c6b0b13b9539a120e8832b32e9cf5e681eb230fda35a261267d6381a0599eR52-R55)