### PR TITLE
feat: Add Magyar, French and Polish as new translations

### DIFF
--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -154,7 +154,7 @@
       "smart_dhw_control_status": {
         "name": "Smart DHW-Steuerstatus",
         "state": {
-          "0": "Nicht verfügbar",
+          "0": "Warten auf Energiepreise",
           "1": "Bereitschaft",
           "2": "Steigend",
           "3": "Sinkend",

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -154,7 +154,7 @@
       "smart_dhw_control_status": {
         "name": "Smart DHW control status",
         "state": {
-          "0": "Unavailable",
+          "0": "Waiting for energy prices",
           "1": "Standby",
           "2": "Raising",
           "3": "Lowering",

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -154,7 +154,7 @@
       "smart_dhw_control_status": {
         "name": "Estado control DHW inteligente",
         "state": {
-          "0": "No disponible",
+          "0": "Esperando precios de la energía",
           "1": "En espera",
           "2": "Elevando",
           "3": "Descendiendo",

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -1,0 +1,571 @@
+{
+  "device": {
+    "qvantum_flvp": {
+      "name": "Qvantum"
+    }
+  },
+  "entity": {
+    "switch": {
+      "extra_tap_water": {
+        "name": "Extra eau chaude"
+      },
+      "op_man_addition": {
+        "name": "Manual mode de fmarchectimarchenement: Additimarche"
+      },
+      "op_man_dhw": {
+        "name": "Manual mode de fmarchectimarchenement: eau chaude"
+      },
+      "op_mode": {
+        "name": "Manual mode de fmarchectimarchenement"
+      },
+      "man_mode": {
+        "name": "Manual mode de fmarchectimarchenement: chauffage"
+      },
+      "enable_sc_dhw": {
+        "name": "SmartCmarchetrol: DHW"
+      },
+      "enable_sc_sh": {
+        "name": "SmartCmarchetrol: chauffage"
+      }
+    },
+    "select": {
+      "use_adaptive": {
+        "name": "SmartCmarchetrol",
+        "state": {
+          "off": "arret",
+          "0": "Eco",
+          "1": "Balanced",
+          "2": "Comfort"
+        }
+      },
+      "smart_sh_mode": {
+        "name": "Smart SH mode",
+        "state": {
+          "0": "Eco",
+          "1": "Balanced",
+          "2": "Comfort"
+        }
+      },
+      "smart_dhw_mode": {
+        "name": "Smart DHW mode",
+        "state": {
+          "0": "Eco",
+          "1": "Balanced",
+          "2": "Comfort"
+        }
+      }
+    },
+    "button": {
+      "extra_tap_water_60min": {
+        "name": "Extra eau chaude 60 min"
+      },
+      "elevate_access": {
+        "name": "Elevate access"
+      }
+    },
+    "binary_sensor": {
+      "op_man_addition": {
+        "name": "Manual mode de fmarchectimarchenement: Additimarche"
+      },
+      "op_man_cooling": {
+        "name": "Manual mode de fmarchectimarchenement: refroidissement"
+      },
+      "op_man_dhw": {
+        "name": "Manual mode de fmarchectimarchenement: eau chaude"
+      },
+      "cooling_enabled": {
+        "name": "refroidissement active"
+      },
+      "use_adaptive": {
+        "name": "SmartCmarchetrol"
+      },
+      "enable_sc_dhw": {
+        "name": "SmartCmarchetrol: DHW"
+      },
+      "enable_sc_sh": {
+        "name": "SmartCmarchetrol: chauffage"
+      },
+      "picpin_relay_heat_l1": {
+        "name": "Additimarcheal power L1"
+      },
+      "picpin_relay_heat_l2": {
+        "name": "Additimarcheal power L2"
+      },
+      "picpin_relay_heat_l3": {
+        "name": "Additimarcheal power L3"
+      },
+      "picpin_relay_gp10": {
+        "name": "Circulatimarche pompe (GP10)"
+      },
+      "picpin_relay_qm10": {
+        "name": "Divertingvalve, DHW/chauffage (QM10)"
+      },
+      "picpin_relay_qn8_1": {
+        "name": "Shunt valve additimarche (QN8_1)"
+      },
+      "picpin_relay_qn8_2": {
+        "name": "Shunt valve additimarche (QN8_2)"
+      },
+      "picpin_relay_gp3": {
+        "name": "Circulatimarche pompe (GP3)"
+      },
+      "picpin_relay_pump": {
+        "name": "Circulatimarche pompe"
+      },
+      "picpin_relay_ha12": {
+        "name": "chauffage circuit pompe (HA12)"
+      },
+      "dhwdemand": {
+        "name": "eau chaude demand"
+      },
+      "heatingdemand": {
+        "name": "chauffage demand"
+      },
+      "coolingdemand": {
+        "name": "refroidissement demand"
+      },
+      "additiondemand": {
+        "name": "Additimarche demand"
+      },
+      "additiondhwdemand": {
+        "name": "Additimarche eau chaude demand"
+      }
+    },
+    "sensor": {
+      "compressor_state": {
+        "name": "compresseur etat",
+        "state": {
+          "0": "arret",
+          "1": "Idle",
+          "2": "Prepare for chauffage",
+          "3": "Prepare for refroidissement",
+          "4": "Prepare 1 for eau chaude",
+          "5": "Prepare 2 for eau chaude",
+          "6": "chauffage",
+          "7": "refroidissement",
+          "8": "eau chaude",
+          "9": "degivrage eau chaude passive",
+          "10": "degivrage chauffage passive",
+          "11": "Prepare for pool",
+          "12": "Pool",
+          "13": "degivrage pool passive"
+        }
+      },
+      "smart_dhw_control_status": {
+        "name": "Smart DHW cmarchetrol etat",
+        "state": {
+          "0": "En attente des prix de l'energie",
+          "1": "Veille",
+          "2": "Augmentation",
+          "3": "Reduction",
+          "4": "Reduction a long terme",
+          "5": "En pause"
+        }
+      },
+      "powertotal": {
+        "name": "Total Power"
+      },
+      "heatingpower": {
+        "name": "chauffage Power"
+      },
+      "dhwpower": {
+        "name": "DHW Power"
+      },
+      "compressor_power": {
+        "name": "compresseur Power"
+      },
+      "heatingenergy": {
+        "name": "chauffage Energy"
+      },
+      "dhwenergy": {
+        "name": "DHW Energy"
+      },
+      "inputcurrent1": {
+        "name": "Input actuel L1"
+      },
+      "inputcurrent2": {
+        "name": "Input actuel L2"
+      },
+      "inputcurrent3": {
+        "name": "Input actuel L3"
+      },
+      "degree_minute": {
+        "name": "Degree Minute"
+      },
+      "bf1_l_min": {
+        "name": "debit capteur DHW (BF1)"
+      },
+      "bf1_rpm": {
+        "name": "debit capteur DHW pompe speed (BF1)"
+      },
+      "bp1_pressure": {
+        "name": "Low pressimarche bar (BP1)"
+      },
+      "bp1_temp": {
+        "name": "Low pressimarche temp (BP1)"
+      },
+      "bp2_pressure": {
+        "name": "High pressimarche bar (BP2)"
+      },
+      "bp2_temp": {
+        "name": "High pressimarche temp (BP2)"
+      },
+      "bt10": {
+        "name": "Cmarchedenser temp out (BT10)"
+      },
+      "bt12": {
+        "name": "chauffage medium, external debit line (BT12)"
+      },
+      "bt13": {
+        "name": "Cmarchedenser temp in (BT13)"
+      },
+      "bt14": {
+        "name": "Exhaust temp air (BT14)"
+      },
+      "bt15": {
+        "name": "Extract temp air (BT15)"
+      },
+      "bt20": {
+        "name": "Discharge line (BT20)"
+      },
+      "bt21": {
+        "name": "Liquid line (BT21)"
+      },
+      "bt22": {
+        "name": "Evaporator inlet temp (BT22)"
+      },
+      "bt23": {
+        "name": "Suctimarche line (BT23)"
+      },
+      "bt31": {
+        "name": "DHW primary, chargetemp in (BT31)"
+      },
+      "bt33": {
+        "name": "DHW secmarchedary, Coldeau in (BT33)"
+      },
+      "bt34": {
+        "name": "DHW secmarchedary, Hoteau out (BT34)"
+      },
+      "compressormeasuredspeed": {
+        "name": "compresseur speed"
+      },
+      "dhw_outl_temp_15": {
+        "name": "DHW outlet temperature 15"
+      },
+      "dhw_outl_temp_5": {
+        "name": "DHW outlet temperature 5"
+      },
+      "dhw_outl_temp_max": {
+        "name": "DHW outlet temperature max"
+      },
+      "dhw_prioritytime": {
+        "name": "DHW priority time"
+      },
+      "fan0_10v": {
+        "name": "ventilateur speed"
+      },
+      "fanrpm": {
+        "name": "ventilateur speed"
+      },
+      "qn8position": {
+        "name": "Shuntvalve, additimarche (QN8)"
+      },
+      "gp1_speed": {
+        "name": "Circulatimarche pompe (GP1)"
+      },
+      "gp2_speed": {
+        "name": "DHW charge pompe (GP2)"
+      },
+      "guide_des_temp": {
+        "name": "Guide desired temperature"
+      },
+      "guide_he": {
+        "name": "Guide chauffage"
+      },
+      "man_mode": {
+        "name": "Manual mode"
+      },
+      "op_mode": {
+        "name": "mode de fmarchectimarchenement",
+        "state": {
+          "0": "Auto",
+          "1": "Manual",
+          "2": "Additimarche"
+        }
+      },
+      "op_mode_sensor": {
+        "name": "mode de fmarchectimarchenement capteur"
+      },
+      "price_region": {
+        "name": "Price regimarche"
+      },
+      "room_temp_ext": {
+        "name": "piece temperature external"
+      },
+      "compressorenergy": {
+        "name": "compresseur energy"
+      },
+      "totalenergy": {
+        "name": "Total energy"
+      },
+      "bt1": {
+        "name": "Outdoor (BT1)"
+      },
+      "bt2": {
+        "name": "Indoor (BT2)"
+      },
+      "bt4": {
+        "name": "BT4"
+      },
+      "btx": {
+        "name": "BTX"
+      },
+      "smart_sh_status": {
+        "name": "Smart etat for chauffage"
+      },
+      "bt11": {
+        "name": "chauffage medium, debit line (BT11)"
+      },
+      "cal_heat_temp": {
+        "name": "chauffage medium, debit line, cible."
+      },
+      "start_cooling_temp": {
+        "name": "refroidissement start temperature"
+      },
+      "bt30": {
+        "name": "eau chaude tank (BT30)"
+      },
+      "tap_water_start": {
+        "name": "eau chaude tank lower limit"
+      },
+      "tap_water_stop": {
+        "name": "eau chaude tank upper limit"
+      },
+      "tap_water_cap": {
+        "name": "eau chaude capacity"
+      },
+      "additionalenergy": {
+        "name": "Additimarcheal energy"
+      },
+      "hpid": {
+        "name": "Id"
+      },
+      "smart_sh_mode": {
+        "name": "Smart SH mode",
+        "state": {
+          "0": "Eco",
+          "1": "Balanced",
+          "2": "Comfort"
+        }
+      },
+      "hp_status": {
+        "name": "pompe a chaleur etat",
+        "state": {
+          "0": "Idle",
+          "1": "degivrageing",
+          "2": "eau chaude",
+          "3": "chauffage",
+          "4": "refroidissement"
+        }
+      },
+      "smart_dhw_status": {
+        "name": "Smart etat for eau chaude"
+      },
+      "smart_dhw_mode": {
+        "name": "Smart DHW mode",
+        "state": {
+          "0": "Eco",
+          "1": "Balanced",
+          "2": "Comfort"
+        }
+      },
+      "tap_stop": {
+        "name": "Extra eau chaude stop"
+      },
+      "ventilation_boost_stop": {
+        "name": "Augmentatimarche ventilatimarche stop"
+      },
+      "timestamp": {
+        "name": "Last update"
+      },
+      "latency": {
+        "name": "Latency"
+      },
+      "disconnect_reason": {
+        "name": "Discmarchenect reasmarche",
+        "state": {
+          "client-disconnect": "Client discmarchenected"
+        }
+      },
+      "heatingreleased": {
+        "name": "chauffage Released"
+      },
+      "coolingreleased": {
+        "name": "refroidissement Released"
+      },
+      "compressorreleased": {
+        "name": "compresseur Released"
+      },
+      "additionreleased": {
+        "name": "Additimarcheal Released"
+      },
+      "dhw_prioritytimeleft": {
+        "name": "DHW Priority Time Left"
+      },
+      "heating_prioritytimeleft": {
+        "name": "chauffage Priority Time Left"
+      },
+      "cooling_prioritytimeleft": {
+        "name": "refroidissement Priority Time Left"
+      },
+      "switch_state": {
+        "name": "Switch etat"
+      },
+      "dhwstop_temp": {
+        "name": "DHW Stop temperature"
+      },
+      "dhwstart_temp": {
+        "name": "DHW Start temperature"
+      },
+      "filtered60sec_outdoortemp": {
+        "name": "Filtered temperature exterieure (60s)"
+      },
+      "max_freq_env": {
+        "name": "Max frequence Envirmarchement"
+      },
+      "calc_suppy_cpr": {
+        "name": "Calculated Supply CPR"
+      },
+      "dhw_set": {
+        "name": "DHW Set"
+      },
+      "bp1_temp_20min_filter": {
+        "name": "BP1 Temp 20min Filter"
+      },
+      "max_bp2_env": {
+        "name": "Max BP2 Envirmarchement"
+      },
+      "picpin_mask": {
+        "name": "PIC Pin Mask"
+      },
+      "firmware_display_fw_version": {
+        "name": "Display firmware versimarche"
+      },
+      "firmware_cc_fw_version": {
+        "name": "CC firmware versimarche"
+      },
+      "firmware_inv_fw_version": {
+        "name": "Inverter firmware versimarche"
+      },
+      "firmware_last_check": {
+        "name": "Firmware last checked"
+      },
+      "expires_at": {
+        "name": "Elevated access expiratimarche"
+      }
+    },
+    "number": {
+      "indoor_temperature_offset": {
+        "name": "Parallel curve arretset"
+      },
+      "tap_water_capacity_target": {
+        "name": "eau chaude capacity cible"
+      },
+      "room_comp_factor": {
+        "name": "piece compensatimarche factor"
+      },
+      "tap_water_stop": {
+        "name": "eau chaude tank upper temperature limit"
+      },
+      "tap_water_start": {
+        "name": "eau chaude tank lower temperature limit"
+      },
+      "fan_normal": {
+        "name": "Normal ventilateur speed"
+      },
+      "fan_speed_2": {
+        "name": "Minimum ventilateur speed for compresseur"
+      },
+      "dhw_stop_extra": {
+        "name": "Extra eau chaude stop temperature"
+      }
+    },
+    "climate": {
+      "indoor_climate": {
+        "name": "Indoor climate"
+      }
+    },
+    "fan": {
+      "fanspeedselector": {
+        "name": "ventilateur speed",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off": "arret",
+              "normal": "Normal",
+              "extra": "Extra"
+            }
+          }
+        }
+      }
+    }
+  },
+  "config": {
+    "title": "Qvantum pompe a chaleur",
+    "abort": {
+      "already_configured": "Device is already cmarchefigured",
+      "reconfigure_successful": "Recmarchefiguratimarche successful"
+    },
+    "error": {
+      "cannot_connect": "Failed to cmarchenect",
+      "invalid_auth": "Invalid authenticatimarche",
+      "unknown": "Unexpected erreur"
+    },
+    "step": {
+      "user": {
+        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be active in Installer settings marche the pompe app/display before enabling here. Note that it marchely reads via Modbus, write/cmarchetrols are still via HTTP API",
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "modbus_tcp": "Use Modbus TCP instead of HTTP polling"
+        }
+      },
+      "reconfigure": {
+        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be active in Installer settings marche the pompe app/display before enabling here. Note that it marchely reads via Modbus, write/cmarchetrols are still via HTTP API",
+        "data": {
+          "password": "Password",
+          "username": "Username"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "HTTP Scan Interval (secmarcheds)",
+          "modbus_tcp": "Use Modbus TCP instead of HTTP polling",
+          "modbus_host": "Qvantum Host/IP"
+        },
+        "description": "Amend your optimarches.",
+        "title": "Optimarches"
+      }
+    }
+  },
+  "services": {
+    "extra_hot_water": {
+      "name": "Extra eau chaude",
+      "description": "Active extra eau chaude for a period",
+      "fields": {
+        "device_id": {
+          "name": "Device Id",
+          "description": "The Qvantum device id"
+        },
+        "minutes": {
+          "name": "Minutes",
+          "description": "Minutes to produce extra eau chaude (0 minutes turns arret)"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -10,48 +10,48 @@
         "name": "Extra eau chaude"
       },
       "op_man_addition": {
-        "name": "Manual mode de fmarchectimarchenement: Additimarche"
+        "name": "Mode manuel de fonctionnement : appoint"
       },
       "op_man_dhw": {
-        "name": "Manual mode de fmarchectimarchenement: eau chaude"
+        "name": "Mode manuel de fonctionnement : eau chaude"
       },
       "op_mode": {
-        "name": "Manual mode de fmarchectimarchenement"
+        "name": "Mode manuel de fonctionnement"
       },
       "man_mode": {
-        "name": "Manual mode de fmarchectimarchenement: chauffage"
+        "name": "Mode manuel de fonctionnement : chauffage"
       },
       "enable_sc_dhw": {
-        "name": "SmartCmarchetrol: DHW"
+        "name": "Smart Control : ECS"
       },
       "enable_sc_sh": {
-        "name": "SmartCmarchetrol: chauffage"
+        "name": "Smart Control : chauffage"
       }
     },
     "select": {
       "use_adaptive": {
-        "name": "SmartCmarchetrol",
+        "name": "Smart Control",
         "state": {
-          "off": "arret",
-          "0": "Eco",
-          "1": "Balanced",
-          "2": "Comfort"
+          "off": "Arrêt",
+          "0": "Éco",
+          "1": "Équilibré",
+          "2": "Confort"
         }
       },
       "smart_sh_mode": {
-        "name": "Smart SH mode",
+        "name": "Mode Smart SH",
         "state": {
-          "0": "Eco",
-          "1": "Balanced",
-          "2": "Comfort"
+          "0": "Éco",
+          "1": "Équilibré",
+          "2": "Confort"
         }
       },
       "smart_dhw_mode": {
-        "name": "Smart DHW mode",
+        "name": "Mode Smart ECS",
         "state": {
-          "0": "Eco",
-          "1": "Balanced",
-          "2": "Comfort"
+          "0": "Éco",
+          "1": "Équilibré",
+          "2": "Confort"
         }
       }
     },
@@ -60,259 +60,259 @@
         "name": "Extra eau chaude 60 min"
       },
       "elevate_access": {
-        "name": "Elevate access"
+        "name": "Élever l'accès"
       }
     },
     "binary_sensor": {
       "op_man_addition": {
-        "name": "Manual mode de fmarchectimarchenement: Additimarche"
+        "name": "Mode manuel de fonctionnement : appoint"
       },
       "op_man_cooling": {
-        "name": "Manual mode de fmarchectimarchenement: refroidissement"
+        "name": "Mode manuel de fonctionnement : refroidissement"
       },
       "op_man_dhw": {
-        "name": "Manual mode de fmarchectimarchenement: eau chaude"
+        "name": "Mode manuel de fonctionnement : eau chaude"
       },
       "cooling_enabled": {
-        "name": "refroidissement active"
+        "name": "Refroidissement activé"
       },
       "use_adaptive": {
-        "name": "SmartCmarchetrol"
+        "name": "Smart Control"
       },
       "enable_sc_dhw": {
-        "name": "SmartCmarchetrol: DHW"
+        "name": "Smart Control : ECS"
       },
       "enable_sc_sh": {
-        "name": "SmartCmarchetrol: chauffage"
+        "name": "Smart Control : chauffage"
       },
       "picpin_relay_heat_l1": {
-        "name": "Additimarcheal power L1"
+        "name": "Puissance d'appoint L1"
       },
       "picpin_relay_heat_l2": {
-        "name": "Additimarcheal power L2"
+        "name": "Puissance d'appoint L2"
       },
       "picpin_relay_heat_l3": {
-        "name": "Additimarcheal power L3"
+        "name": "Puissance d'appoint L3"
       },
       "picpin_relay_gp10": {
-        "name": "Circulatimarche pompe (GP10)"
+        "name": "Pompe de circulation (GP10)"
       },
       "picpin_relay_qm10": {
-        "name": "Divertingvalve, DHW/chauffage (QM10)"
+        "name": "Vanne de diversion, ECS/chauffage (QM10)"
       },
       "picpin_relay_qn8_1": {
-        "name": "Shunt valve additimarche (QN8_1)"
+        "name": "Vanne de dérivation appoint (QN8_1)"
       },
       "picpin_relay_qn8_2": {
-        "name": "Shunt valve additimarche (QN8_2)"
+        "name": "Vanne de dérivation appoint (QN8_2)"
       },
       "picpin_relay_gp3": {
-        "name": "Circulatimarche pompe (GP3)"
+        "name": "Pompe de circulation (GP3)"
       },
       "picpin_relay_pump": {
-        "name": "Circulatimarche pompe"
+        "name": "Pompe de circulation"
       },
       "picpin_relay_ha12": {
-        "name": "chauffage circuit pompe (HA12)"
+        "name": "Pompe de circuit de chauffage (HA12)"
       },
       "dhwdemand": {
-        "name": "eau chaude demand"
+        "name": "Demande eau chaude"
       },
       "heatingdemand": {
-        "name": "chauffage demand"
+        "name": "Demande de chauffage"
       },
       "coolingdemand": {
-        "name": "refroidissement demand"
+        "name": "Demande de refroidissement"
       },
       "additiondemand": {
-        "name": "Additimarche demand"
+        "name": "Demande d'appoint"
       },
       "additiondhwdemand": {
-        "name": "Additimarche eau chaude demand"
+        "name": "Demande d'appoint eau chaude"
       }
     },
     "sensor": {
       "compressor_state": {
-        "name": "compresseur etat",
+        "name": "État du compresseur",
         "state": {
-          "0": "arret",
-          "1": "Idle",
-          "2": "Prepare for chauffage",
-          "3": "Prepare for refroidissement",
-          "4": "Prepare 1 for eau chaude",
-          "5": "Prepare 2 for eau chaude",
-          "6": "chauffage",
-          "7": "refroidissement",
-          "8": "eau chaude",
-          "9": "degivrage eau chaude passive",
-          "10": "degivrage chauffage passive",
-          "11": "Prepare for pool",
-          "12": "Pool",
-          "13": "degivrage pool passive"
+          "0": "Arrêt",
+          "1": "Inactif",
+          "2": "Préparation pour chauffage",
+          "3": "Préparation pour refroidissement",
+          "4": "Préparation 1 pour eau chaude",
+          "5": "Préparation 2 pour eau chaude",
+          "6": "Chauffage",
+          "7": "Refroidissement",
+          "8": "Eau chaude",
+          "9": "Dégivrage eau chaude passif",
+          "10": "Dégivrage chauffage passif",
+          "11": "Préparation pour piscine",
+          "12": "Piscine",
+          "13": "Dégivrage piscine passif"
         }
       },
       "smart_dhw_control_status": {
-        "name": "Smart DHW cmarchetrol etat",
+        "name": "Statut contrôle Smart ECS",
         "state": {
-          "0": "En attente des prix de l'energie",
+          "0": "En attente des prix de l'énergie",
           "1": "Veille",
           "2": "Augmentation",
-          "3": "Reduction",
-          "4": "Reduction a long terme",
+          "3": "Réduction",
+          "4": "Réduction à long terme",
           "5": "En pause"
         }
       },
       "powertotal": {
-        "name": "Total Power"
+        "name": "Puissance totale"
       },
       "heatingpower": {
-        "name": "chauffage Power"
+        "name": "Puissance de chauffage"
       },
       "dhwpower": {
-        "name": "DHW Power"
+        "name": "Puissance ECS"
       },
       "compressor_power": {
-        "name": "compresseur Power"
+        "name": "Puissance compresseur"
       },
       "heatingenergy": {
-        "name": "chauffage Energy"
+        "name": "Énergie de chauffage"
       },
       "dhwenergy": {
-        "name": "DHW Energy"
+        "name": "Énergie ECS"
       },
       "inputcurrent1": {
-        "name": "Input actuel L1"
+        "name": "Courant d'entrée L1"
       },
       "inputcurrent2": {
-        "name": "Input actuel L2"
+        "name": "Courant d'entrée L2"
       },
       "inputcurrent3": {
-        "name": "Input actuel L3"
+        "name": "Courant d'entrée L3"
       },
       "degree_minute": {
-        "name": "Degree Minute"
+        "name": "Degré Minute"
       },
       "bf1_l_min": {
-        "name": "debit capteur DHW (BF1)"
+        "name": "Capteur de débit ECS (BF1)"
       },
       "bf1_rpm": {
-        "name": "debit capteur DHW pompe speed (BF1)"
+        "name": "Vitesse pompe capteur débit ECS (BF1)"
       },
       "bp1_pressure": {
-        "name": "Low pressimarche bar (BP1)"
+        "name": "Basse pression bar (BP1)"
       },
       "bp1_temp": {
-        "name": "Low pressimarche temp (BP1)"
+        "name": "Température basse pression (BP1)"
       },
       "bp2_pressure": {
-        "name": "High pressimarche bar (BP2)"
+        "name": "Haute pression bar (BP2)"
       },
       "bp2_temp": {
-        "name": "High pressimarche temp (BP2)"
+        "name": "Température haute pression (BP2)"
       },
       "bt10": {
-        "name": "Cmarchedenser temp out (BT10)"
+        "name": "Température sortie condenseur (BT10)"
       },
       "bt12": {
-        "name": "chauffage medium, external debit line (BT12)"
+        "name": "Fluide chauffage, ligne d'alimentation externe (BT12)"
       },
       "bt13": {
-        "name": "Cmarchedenser temp in (BT13)"
+        "name": "Température entrée condenseur (BT13)"
       },
       "bt14": {
-        "name": "Exhaust temp air (BT14)"
+        "name": "Température air soufflé (BT14)"
       },
       "bt15": {
-        "name": "Extract temp air (BT15)"
+        "name": "Température air extrait (BT15)"
       },
       "bt20": {
-        "name": "Discharge line (BT20)"
+        "name": "Ligne de refoulement (BT20)"
       },
       "bt21": {
-        "name": "Liquid line (BT21)"
+        "name": "Ligne liquide (BT21)"
       },
       "bt22": {
-        "name": "Evaporator inlet temp (BT22)"
+        "name": "Température entrée évaporateur (BT22)"
       },
       "bt23": {
-        "name": "Suctimarche line (BT23)"
+        "name": "Ligne d'aspiration (BT23)"
       },
       "bt31": {
-        "name": "DHW primary, chargetemp in (BT31)"
+        "name": "ECS primaire, température de charge entrée (BT31)"
       },
       "bt33": {
-        "name": "DHW secmarchedary, Coldeau in (BT33)"
+        "name": "ECS secondaire, eau froide entrée (BT33)"
       },
       "bt34": {
-        "name": "DHW secmarchedary, Hoteau out (BT34)"
+        "name": "ECS secondaire, eau chaude sortie (BT34)"
       },
       "compressormeasuredspeed": {
-        "name": "compresseur speed"
+        "name": "Vitesse compresseur"
       },
       "dhw_outl_temp_15": {
-        "name": "DHW outlet temperature 15"
+        "name": "Température sortie ECS 15"
       },
       "dhw_outl_temp_5": {
-        "name": "DHW outlet temperature 5"
+        "name": "Température sortie ECS 5"
       },
       "dhw_outl_temp_max": {
-        "name": "DHW outlet temperature max"
+        "name": "Température sortie ECS max"
       },
       "dhw_prioritytime": {
-        "name": "DHW priority time"
+        "name": "Temps de priorité ECS"
       },
       "fan0_10v": {
-        "name": "ventilateur speed"
+        "name": "Vitesse ventilateur"
       },
       "fanrpm": {
-        "name": "ventilateur speed"
+        "name": "Vitesse ventilateur"
       },
       "qn8position": {
-        "name": "Shuntvalve, additimarche (QN8)"
+        "name": "Vanne de dérivation, appoint (QN8)"
       },
       "gp1_speed": {
-        "name": "Circulatimarche pompe (GP1)"
+        "name": "Pompe de circulation (GP1)"
       },
       "gp2_speed": {
-        "name": "DHW charge pompe (GP2)"
+        "name": "Pompe de charge ECS (GP2)"
       },
       "guide_des_temp": {
-        "name": "Guide desired temperature"
+        "name": "Température désirée guide"
       },
       "guide_he": {
         "name": "Guide chauffage"
       },
       "man_mode": {
-        "name": "Manual mode"
+        "name": "Mode manuel"
       },
       "op_mode": {
-        "name": "mode de fmarchectimarchenement",
+        "name": "Mode de fonctionnement",
         "state": {
-          "0": "Auto",
-          "1": "Manual",
-          "2": "Additimarche"
+          "0": "Automatique",
+          "1": "Manuel",
+          "2": "Appoint"
         }
       },
       "op_mode_sensor": {
-        "name": "mode de fmarchectimarchenement capteur"
+        "name": "Capteur mode de fonctionnement"
       },
       "price_region": {
-        "name": "Price regimarche"
+        "name": "Région tarifaire"
       },
       "room_temp_ext": {
-        "name": "piece temperature external"
+        "name": "Température extérieure pièce"
       },
       "compressorenergy": {
-        "name": "compresseur energy"
+        "name": "Énergie compresseur"
       },
       "totalenergy": {
-        "name": "Total energy"
+        "name": "Énergie totale"
       },
       "bt1": {
-        "name": "Outdoor (BT1)"
+        "name": "Extérieur (BT1)"
       },
       "bt2": {
-        "name": "Indoor (BT2)"
+        "name": "Intérieur (BT2)"
       },
       "bt4": {
         "name": "BT4"
@@ -321,187 +321,187 @@
         "name": "BTX"
       },
       "smart_sh_status": {
-        "name": "Smart etat for chauffage"
+        "name": "Statut Smart pour chauffage"
       },
       "bt11": {
-        "name": "chauffage medium, debit line (BT11)"
+        "name": "Fluide chauffage, ligne d'alimentation (BT11)"
       },
       "cal_heat_temp": {
-        "name": "chauffage medium, debit line, cible."
+        "name": "Fluide chauffage, ligne d'alimentation, cible."
       },
       "start_cooling_temp": {
-        "name": "refroidissement start temperature"
+        "name": "Température de démarrage refroidissement"
       },
       "bt30": {
-        "name": "eau chaude tank (BT30)"
+        "name": "Ballon eau chaude (BT30)"
       },
       "tap_water_start": {
-        "name": "eau chaude tank lower limit"
+        "name": "Limite inférieure ballon eau chaude"
       },
       "tap_water_stop": {
-        "name": "eau chaude tank upper limit"
+        "name": "Limite supérieure ballon eau chaude"
       },
       "tap_water_cap": {
-        "name": "eau chaude capacity"
+        "name": "Capacité eau chaude"
       },
       "additionalenergy": {
-        "name": "Additimarcheal energy"
+        "name": "Énergie d'appoint"
       },
       "hpid": {
         "name": "Id"
       },
       "smart_sh_mode": {
-        "name": "Smart SH mode",
+        "name": "Mode Smart SH",
         "state": {
-          "0": "Eco",
-          "1": "Balanced",
-          "2": "Comfort"
+          "0": "Éco",
+          "1": "Équilibré",
+          "2": "Confort"
         }
       },
       "hp_status": {
-        "name": "pompe a chaleur etat",
+        "name": "Statut pompe à chaleur",
         "state": {
-          "0": "Idle",
-          "1": "degivrageing",
-          "2": "eau chaude",
-          "3": "chauffage",
-          "4": "refroidissement"
+          "0": "Inactif",
+          "1": "Dégivrage",
+          "2": "Eau chaude",
+          "3": "Chauffage",
+          "4": "Refroidissement"
         }
       },
       "smart_dhw_status": {
-        "name": "Smart etat for eau chaude"
+        "name": "Statut Smart pour eau chaude"
       },
       "smart_dhw_mode": {
-        "name": "Smart DHW mode",
+        "name": "Mode Smart ECS",
         "state": {
-          "0": "Eco",
-          "1": "Balanced",
-          "2": "Comfort"
+          "0": "Éco",
+          "1": "Équilibré",
+          "2": "Confort"
         }
       },
       "tap_stop": {
-        "name": "Extra eau chaude stop"
+        "name": "Arrêt extra eau chaude"
       },
       "ventilation_boost_stop": {
-        "name": "Augmentatimarche ventilatimarche stop"
+        "name": "Arrêt ventilation boostée"
       },
       "timestamp": {
-        "name": "Last update"
+        "name": "Dernière mise à jour"
       },
       "latency": {
-        "name": "Latency"
+        "name": "Latence"
       },
       "disconnect_reason": {
-        "name": "Discmarchenect reasmarche",
+        "name": "Raison de déconnexion",
         "state": {
-          "client-disconnect": "Client discmarchenected"
+          "client-disconnect": "Client déconnecté"
         }
       },
       "heatingreleased": {
-        "name": "chauffage Released"
+        "name": "Chauffage autorisé"
       },
       "coolingreleased": {
-        "name": "refroidissement Released"
+        "name": "Refroidissement autorisé"
       },
       "compressorreleased": {
-        "name": "compresseur Released"
+        "name": "Compresseur autorisé"
       },
       "additionreleased": {
-        "name": "Additimarcheal Released"
+        "name": "Appoint autorisé"
       },
       "dhw_prioritytimeleft": {
-        "name": "DHW Priority Time Left"
+        "name": "Temps restant priorité ECS"
       },
       "heating_prioritytimeleft": {
-        "name": "chauffage Priority Time Left"
+        "name": "Temps restant priorité chauffage"
       },
       "cooling_prioritytimeleft": {
-        "name": "refroidissement Priority Time Left"
+        "name": "Temps restant priorité refroidissement"
       },
       "switch_state": {
-        "name": "Switch etat"
+        "name": "État commutateur"
       },
       "dhwstop_temp": {
-        "name": "DHW Stop temperature"
+        "name": "Température d'arrêt ECS"
       },
       "dhwstart_temp": {
-        "name": "DHW Start temperature"
+        "name": "Température de démarrage ECS"
       },
       "filtered60sec_outdoortemp": {
-        "name": "Filtered temperature exterieure (60s)"
+        "name": "Température extérieure filtrée (60s)"
       },
       "max_freq_env": {
-        "name": "Max frequence Envirmarchement"
+        "name": "Fréquence max environnement"
       },
       "calc_suppy_cpr": {
-        "name": "Calculated Supply CPR"
+        "name": "Alimentation calculée CPR"
       },
       "dhw_set": {
-        "name": "DHW Set"
+        "name": "Réglage ECS"
       },
       "bp1_temp_20min_filter": {
-        "name": "BP1 Temp 20min Filter"
+        "name": "Filtre température BP1 20min"
       },
       "max_bp2_env": {
-        "name": "Max BP2 Envirmarchement"
+        "name": "Max BP2 environnement"
       },
       "picpin_mask": {
-        "name": "PIC Pin Mask"
+        "name": "Masque PIC Pin"
       },
       "firmware_display_fw_version": {
-        "name": "Display firmware versimarche"
+        "name": "Version firmware affichage"
       },
       "firmware_cc_fw_version": {
-        "name": "CC firmware versimarche"
+        "name": "Version firmware CC"
       },
       "firmware_inv_fw_version": {
-        "name": "Inverter firmware versimarche"
+        "name": "Version firmware onduleur"
       },
       "firmware_last_check": {
-        "name": "Firmware last checked"
+        "name": "Dernière vérification firmware"
       },
       "expires_at": {
-        "name": "Elevated access expiratimarche"
+        "name": "Expiration accès élevé"
       }
     },
     "number": {
       "indoor_temperature_offset": {
-        "name": "Parallel curve arretset"
+        "name": "Décalage courbe parallèle"
       },
       "tap_water_capacity_target": {
-        "name": "eau chaude capacity cible"
+        "name": "Capacité cible eau chaude"
       },
       "room_comp_factor": {
-        "name": "piece compensatimarche factor"
+        "name": "Facteur de compensation pièce"
       },
       "tap_water_stop": {
-        "name": "eau chaude tank upper temperature limit"
+        "name": "Limite supérieure température ballon eau chaude"
       },
       "tap_water_start": {
-        "name": "eau chaude tank lower temperature limit"
+        "name": "Limite inférieure température ballon eau chaude"
       },
       "fan_normal": {
-        "name": "Normal ventilateur speed"
+        "name": "Vitesse ventilateur normale"
       },
       "fan_speed_2": {
-        "name": "Minimum ventilateur speed for compresseur"
+        "name": "Vitesse ventilateur minimale pour compresseur"
       },
       "dhw_stop_extra": {
-        "name": "Extra eau chaude stop temperature"
+        "name": "Température d'arrêt extra eau chaude"
       }
     },
     "climate": {
       "indoor_climate": {
-        "name": "Indoor climate"
+        "name": "Climat intérieur"
       }
     },
     "fan": {
       "fanspeedselector": {
-        "name": "ventilateur speed",
+        "name": "Vitesse ventilateur",
         "state_attributes": {
           "preset_mode": {
             "state": {
-              "off": "arret",
+              "off": "Arrêt",
               "normal": "Normal",
               "extra": "Extra"
             }
@@ -511,30 +511,30 @@
     }
   },
   "config": {
-    "title": "Qvantum pompe a chaleur",
+    "title": "Pompe à chaleur Qvantum",
     "abort": {
-      "already_configured": "Device is already cmarchefigured",
-      "reconfigure_successful": "Recmarchefiguratimarche successful"
+      "already_configured": "L'appareil est déjà configuré",
+      "reconfigure_successful": "Reconfiguration réussie"
     },
     "error": {
-      "cannot_connect": "Failed to cmarchenect",
-      "invalid_auth": "Invalid authenticatimarche",
-      "unknown": "Unexpected erreur"
+      "cannot_connect": "Échec de connexion",
+      "invalid_auth": "Authentification invalide",
+      "unknown": "Erreur inattendue"
     },
     "step": {
       "user": {
-        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be active in Installer settings marche the pompe app/display before enabling here. Note that it marchely reads via Modbus, write/cmarchetrols are still via HTTP API",
+        "description": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il ne fait que lire via Modbus, les écritures/contrôles se font toujours via l'API HTTP",
         "data": {
-          "password": "Password",
-          "username": "Username",
-          "modbus_tcp": "Use Modbus TCP instead of HTTP polling"
+          "password": "Mot de passe",
+          "username": "Nom d'utilisateur",
+          "modbus_tcp": "Utiliser Modbus TCP au lieu du polling HTTP"
         }
       },
       "reconfigure": {
-        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be active in Installer settings marche the pompe app/display before enabling here. Note that it marchely reads via Modbus, write/cmarchetrols are still via HTTP API",
+        "description": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il ne fait que lire via Modbus, les écritures/contrôles se font toujours via l'API HTTP",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Mot de passe",
+          "username": "Nom d'utilisateur"
         }
       }
     }
@@ -543,27 +543,27 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP Scan Interval (secmarcheds)",
-          "modbus_tcp": "Use Modbus TCP instead of HTTP polling",
-          "modbus_host": "Qvantum Host/IP"
+          "scan_interval": "Intervalle de scan HTTP (secondes)",
+          "modbus_tcp": "Utiliser Modbus TCP au lieu du polling HTTP",
+          "modbus_host": "Hôte/IP Qvantum"
         },
-        "description": "Amend your optimarches.",
-        "title": "Optimarches"
+        "description": "Modifiez vos options.",
+        "title": "Options"
       }
     }
   },
   "services": {
     "extra_hot_water": {
       "name": "Extra eau chaude",
-      "description": "Active extra eau chaude for a period",
+      "description": "Active l'eau chaude extra pour une période",
       "fields": {
         "device_id": {
-          "name": "Device Id",
-          "description": "The Qvantum device id"
+          "name": "Id appareil",
+          "description": "L'identifiant de l'appareil Qvantum"
         },
         "minutes": {
           "name": "Minutes",
-          "description": "Minutes to produce extra eau chaude (0 minutes turns arret)"
+          "description": "Minutes de production d'eau chaude extra (0 minutes arrête)"
         }
       }
     }

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -1,0 +1,571 @@
+{
+  "device": {
+    "qvantum_flvp": {
+      "name": "Qvantum"
+    }
+  },
+  "entity": {
+    "switch": {
+      "extra_tap_water": {
+        "name": "Extra melegvíz"
+      },
+      "op_man_addition": {
+        "name": "Kézi üzemmód: rásegítés"
+      },
+      "op_man_dhw": {
+        "name": "Kézi üzemmód: melegvíz"
+      },
+      "op_mode": {
+        "name": "Kézi üzemmód"
+      },
+      "man_mode": {
+        "name": "Kézi üzemmód: fűtés"
+      },
+      "enable_sc_dhw": {
+        "name": "Intelligens vezérlés: DHW"
+      },
+      "enable_sc_sh": {
+        "name": "Intelligens vezérlés: fűtés"
+      }
+    },
+    "select": {
+      "use_adaptive": {
+        "name": "Intelligens vezérlés",
+        "state": {
+          "off": "Ki",
+          "0": "Takarékos",
+          "1": "Kiegyensúlyozott",
+          "2": "Komfort"
+        }
+      },
+      "smart_sh_mode": {
+        "name": "Intelligens SH mód",
+        "state": {
+          "0": "Takarékos",
+          "1": "Kiegyensúlyozott",
+          "2": "Komfort"
+        }
+      },
+      "smart_dhw_mode": {
+        "name": "Intelligens DHW mód",
+        "state": {
+          "0": "Takarékos",
+          "1": "Kiegyensúlyozott",
+          "2": "Komfort"
+        }
+      }
+    },
+    "button": {
+      "extra_tap_water_60min": {
+        "name": "Extra melegvíz 60 perc"
+      },
+      "elevate_access": {
+        "name": "Emelt hozzáférés"
+      }
+    },
+    "binary_sensor": {
+      "op_man_addition": {
+        "name": "Kézi üzemmód: rásegítés"
+      },
+      "op_man_cooling": {
+        "name": "Kézi üzemmód: hűtés"
+      },
+      "op_man_dhw": {
+        "name": "Kézi üzemmód: melegvíz"
+      },
+      "cooling_enabled": {
+        "name": "Hűtés engedélyezve"
+      },
+      "use_adaptive": {
+        "name": "Intelligens vezérlés"
+      },
+      "enable_sc_dhw": {
+        "name": "Intelligens vezérlés: DHW"
+      },
+      "enable_sc_sh": {
+        "name": "Intelligens vezérlés: fűtés"
+      },
+      "picpin_relay_heat_l1": {
+        "name": "Kiegészítő teljesítmény L1"
+      },
+      "picpin_relay_heat_l2": {
+        "name": "Kiegészítő teljesítmény L2"
+      },
+      "picpin_relay_heat_l3": {
+        "name": "Kiegészítő teljesítmény L3"
+      },
+      "picpin_relay_gp10": {
+        "name": "Keringető szivattyú (GP10)"
+      },
+      "picpin_relay_qm10": {
+        "name": "Váltószelep, DHW/fűtés (QM10)"
+      },
+      "picpin_relay_qn8_1": {
+        "name": "Keverőszelep rásegítés (QN8_1)"
+      },
+      "picpin_relay_qn8_2": {
+        "name": "Keverőszelep rásegítés (QN8_2)"
+      },
+      "picpin_relay_gp3": {
+        "name": "Keringető szivattyú (GP3)"
+      },
+      "picpin_relay_pump": {
+        "name": "Keringető szivattyú"
+      },
+      "picpin_relay_ha12": {
+        "name": "Fűtőkör szivattyú (HA12)"
+      },
+      "dhwdemand": {
+        "name": "Melegvíz igény"
+      },
+      "heatingdemand": {
+        "name": "Fűtési igény"
+      },
+      "coolingdemand": {
+        "name": "Hűtési igény"
+      },
+      "additiondemand": {
+        "name": "Rásegítési igény"
+      },
+      "additiondhwdemand": {
+        "name": "Rásegítési használati melegvíz igény"
+      }
+    },
+    "sensor": {
+      "compressor_state": {
+        "name": "Kompresszor állapot",
+        "state": {
+          "0": "Ki",
+          "1": "Készenlét",
+          "2": "Előkészítés fűtéshez",
+          "3": "Előkészítés hűtéshez",
+          "4": "1. előkészítés melegvízhez",
+          "5": "2. előkészítés melegvízhez",
+          "6": "Fűtés",
+          "7": "Hűtés",
+          "8": "Használati melegvíz",
+          "9": "Passzív leolvasztás melegvíznél",
+          "10": "Passzív leolvasztás fűtésnél",
+          "11": "Előkészítés medencéhez",
+          "12": "Medence",
+          "13": "Passzív leolvasztás medencénél"
+        }
+      },
+      "smart_dhw_control_status": {
+        "name": "Intelligens DHW vezérlési állapot",
+        "state": {
+          "0": "Energiaárakra vár",
+          "1": "Készenlét",
+          "2": "Emelés",
+          "3": "Csökkentés",
+          "4": "Hosszú távú csökkentés",
+          "5": "Szüneteltetve"
+        }
+      },
+      "powertotal": {
+        "name": "Összes teljesítmény"
+      },
+      "heatingpower": {
+        "name": "Fűtési teljesítmény"
+      },
+      "dhwpower": {
+        "name": "HMV teljesítmény"
+      },
+      "compressor_power": {
+        "name": "Kompresszor teljesítmény"
+      },
+      "heatingenergy": {
+        "name": "Fűtési energia"
+      },
+      "dhwenergy": {
+        "name": "HMV energia"
+      },
+      "inputcurrent1": {
+        "name": "Bemeneti áram L1"
+      },
+      "inputcurrent2": {
+        "name": "Bemeneti áram L2"
+      },
+      "inputcurrent3": {
+        "name": "Bemeneti áram L3"
+      },
+      "degree_minute": {
+        "name": "Fokperc"
+      },
+      "bf1_l_min": {
+        "name": "DHW átfolyásérzékelő (BF1)"
+      },
+      "bf1_rpm": {
+        "name": "DHW szivattyú fordulatszám érzékelő (BF1)"
+      },
+      "bp1_pressure": {
+        "name": "Alacsony nyomás bar (BP1)"
+      },
+      "bp1_temp": {
+        "name": "Alacsony nyomás hőmérséklet (BP1)"
+      },
+      "bp2_pressure": {
+        "name": "Magasnyomás bar (BP2)"
+      },
+      "bp2_temp": {
+        "name": "Magasnyomás hőmérséklet (BP2)"
+      },
+      "bt10": {
+        "name": "Kondenzátor kilépő hőmérséklet (BT10)"
+      },
+      "bt12": {
+        "name": "Fűtőközeg, külső előremenő ág (BT12)"
+      },
+      "bt13": {
+        "name": "Kondenzátor belépő hőmérséklet (BT13)"
+      },
+      "bt14": {
+        "name": "Elhasznált levegő hőmérséklet (BT14)"
+      },
+      "bt15": {
+        "name": "Elszívott levegő hőmérséklet (BT15)"
+      },
+      "bt20": {
+        "name": "Nyomóvezeték (BT20)"
+      },
+      "bt21": {
+        "name": "Folyadékvezeték (BT21)"
+      },
+      "bt22": {
+        "name": "Elpárologtató belépő hőmérséklet (BT22)"
+      },
+      "bt23": {
+        "name": "Szívóvezeték (BT23)"
+      },
+      "bt31": {
+        "name": "HMV primer, töltési hőmérséklet be (BT31)"
+      },
+      "bt33": {
+        "name": "HMV szekunder, hidegvíz be (BT33)"
+      },
+      "bt34": {
+        "name": "HMV szekunder, melegvíz ki (BT34)"
+      },
+      "compressormeasuredspeed": {
+        "name": "Kompresszor fordulatszám"
+      },
+      "dhw_outl_temp_15": {
+        "name": "HMV kilépő hőmérséklet 15"
+      },
+      "dhw_outl_temp_5": {
+        "name": "HMV kilépő hőmérséklet 5"
+      },
+      "dhw_outl_temp_max": {
+        "name": "HMV kilépő hőmérséklet max"
+      },
+      "dhw_prioritytime": {
+        "name": "HMV prioritási idő"
+      },
+      "fan0_10v": {
+        "name": "Ventilátor fordulatszám"
+      },
+      "fanrpm": {
+        "name": "Ventilátor fordulatszám"
+      },
+      "qn8position": {
+        "name": "Keverőszelep, rásegítés (QN8)"
+      },
+      "gp1_speed": {
+        "name": "Keringető szivattyú (GP1)"
+      },
+      "gp2_speed": {
+        "name": "HMV töltőszivattyú (GP2)"
+      },
+      "guide_des_temp": {
+        "name": "Irányított kívánt hőmérséklet"
+      },
+      "guide_he": {
+        "name": "Irányított fűtés"
+      },
+      "man_mode": {
+        "name": "Kézi mód"
+      },
+      "op_mode": {
+        "name": "Üzemmód",
+        "state": {
+          "0": "Automatikus",
+          "1": "Kézi",
+          "2": "Rásegítés"
+        }
+      },
+      "op_mode_sensor": {
+        "name": "Üzemmód érzékelő"
+      },
+      "price_region": {
+        "name": "Ár régió"
+      },
+      "room_temp_ext": {
+        "name": "Külső szobahőmérséklet"
+      },
+      "compressorenergy": {
+        "name": "Kompresszor energia"
+      },
+      "totalenergy": {
+        "name": "Összes energia"
+      },
+      "bt1": {
+        "name": "Kültéri (BT1)"
+      },
+      "bt2": {
+        "name": "Beltéri (BT2)"
+      },
+      "bt4": {
+        "name": "BT4"
+      },
+      "btx": {
+        "name": "BTX"
+      },
+      "smart_sh_status": {
+        "name": "Intelligens állapot fűtéshez"
+      },
+      "bt11": {
+        "name": "Fűtőközeg, előremenő ág (BT11)"
+      },
+      "cal_heat_temp": {
+        "name": "Fűtőközeg, előremenő ág célérték."
+      },
+      "start_cooling_temp": {
+        "name": "Hűtés indítási hőmérséklet"
+      },
+      "bt30": {
+        "name": "Melegvíz tartály (BT30)"
+      },
+      "tap_water_start": {
+        "name": "Melegvíz tartály alsó határ"
+      },
+      "tap_water_stop": {
+        "name": "Melegvíz tartály felső határ"
+      },
+      "tap_water_cap": {
+        "name": "Melegvíz kapacitás"
+      },
+      "additionalenergy": {
+        "name": "Rásegítési energia"
+      },
+      "hpid": {
+        "name": "Azonosító"
+      },
+      "smart_sh_mode": {
+        "name": "Intelligens SH mód",
+        "state": {
+          "0": "Takarékos",
+          "1": "Kiegyensúlyozott",
+          "2": "Komfort"
+        }
+      },
+      "hp_status": {
+        "name": "Hőszivattyú állapot",
+        "state": {
+          "0": "Készenlét",
+          "1": "Leolvasztás",
+          "2": "Használati melegvíz",
+          "3": "Fűtés",
+          "4": "Hűtés"
+        }
+      },
+      "smart_dhw_status": {
+        "name": "Intelligens állapot melegvízhez"
+      },
+      "smart_dhw_mode": {
+        "name": "Intelligens DHW mód",
+        "state": {
+          "0": "Takarékos",
+          "1": "Kiegyensúlyozott",
+          "2": "Komfort"
+        }
+      },
+      "tap_stop": {
+        "name": "Extra melegvíz leállítás"
+      },
+      "ventilation_boost_stop": {
+        "name": "Szellőztetés ráerősítés leállítása"
+      },
+      "timestamp": {
+        "name": "Utolsó frissítés"
+      },
+      "latency": {
+        "name": "Késleltetés"
+      },
+      "disconnect_reason": {
+        "name": "Lecsatlakozás oka",
+        "state": {
+          "client-disconnect": "Kliens lecsatlakozott"
+        }
+      },
+      "heatingreleased": {
+        "name": "Fűtés engedélyezve"
+      },
+      "coolingreleased": {
+        "name": "Hűtés engedélyezve"
+      },
+      "compressorreleased": {
+        "name": "Kompresszor engedélyezve"
+      },
+      "additionreleased": {
+        "name": "Rásegítés engedélyezve"
+      },
+      "dhw_prioritytimeleft": {
+        "name": "HMV prioritás hátralévő ideje"
+      },
+      "heating_prioritytimeleft": {
+        "name": "Fűtési prioritás hátralévő ideje"
+      },
+      "cooling_prioritytimeleft": {
+        "name": "Hűtési prioritás hátralévő ideje"
+      },
+      "switch_state": {
+        "name": "Kapcsoló állapot"
+      },
+      "dhwstop_temp": {
+        "name": "HMV leállítási hőmérséklet"
+      },
+      "dhwstart_temp": {
+        "name": "HMV indítási hőmérséklet"
+      },
+      "filtered60sec_outdoortemp": {
+        "name": "Szűrt külső hőmérséklet (60 mp)"
+      },
+      "max_freq_env": {
+        "name": "Max frekvencia környezet"
+      },
+      "calc_suppy_cpr": {
+        "name": "Számított előremenő CPR"
+      },
+      "dhw_set": {
+        "name": "HMV beállítás"
+      },
+      "bp1_temp_20min_filter": {
+        "name": "BP1 hőmérséklet 20 perces szűrő"
+      },
+      "max_bp2_env": {
+        "name": "Max BP2 környezet"
+      },
+      "picpin_mask": {
+        "name": "PIC láb maszk"
+      },
+      "firmware_display_fw_version": {
+        "name": "Kijelző firmware verzió"
+      },
+      "firmware_cc_fw_version": {
+        "name": "CC firmware verzió"
+      },
+      "firmware_inv_fw_version": {
+        "name": "Inverter firmware verzió"
+      },
+      "firmware_last_check": {
+        "name": "Firmware utolsó ellenőrzése"
+      },
+      "expires_at": {
+        "name": "Emelt hozzáférés lejárata"
+      }
+    },
+    "number": {
+      "indoor_temperature_offset": {
+        "name": "Párhuzamos görbe eltolás"
+      },
+      "tap_water_capacity_target": {
+        "name": "Melegvíz kapacitás célérték"
+      },
+      "room_comp_factor": {
+        "name": "Szobahőmérséklet kompenzációs tényező"
+      },
+      "tap_water_stop": {
+        "name": "Melegvíz tartály felső hőmérséklet-határ"
+      },
+      "tap_water_start": {
+        "name": "Melegvíz tartály alsó hőmérséklet-határ"
+      },
+      "fan_normal": {
+        "name": "Normál ventilátor fordulatszám"
+      },
+      "fan_speed_2": {
+        "name": "Kompresszor minimális ventilátor fordulatszám"
+      },
+      "dhw_stop_extra": {
+        "name": "Extra melegvíz leállítási hőmérséklet"
+      }
+    },
+    "climate": {
+      "indoor_climate": {
+        "name": "Beltéri klíma"
+      }
+    },
+    "fan": {
+      "fanspeedselector": {
+        "name": "Ventilátor fordulatszám",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off": "Ki",
+              "normal": "Normál",
+              "extra": "Extra fokozat"
+            }
+          }
+        }
+      }
+    }
+  },
+  "config": {
+    "title": "Qvantum hőszivattyú",
+    "abort": {
+      "already_configured": "Az eszköz már konfigurálva van",
+      "reconfigure_successful": "Újrakonfigurálás sikeres"
+    },
+    "error": {
+      "cannot_connect": "Sikertelen csatlakozás",
+      "invalid_auth": "Érvénytelen hitelesítés",
+      "unknown": "Váratlan hiba"
+    },
+    "step": {
+      "user": {
+        "description": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: a Modbus csak olvas, az írás/vezérlés továbbra is HTTP API-n keresztül történik.",
+        "data": {
+          "password": "Jelszó",
+          "username": "Felhasználónév",
+          "modbus_tcp": "Modbus TCP használata HTTP lekérdezés helyett"
+        }
+      },
+      "reconfigure": {
+        "description": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: a Modbus csak olvas, az írás/vezérlés továbbra is HTTP API-n keresztül történik.",
+        "data": {
+          "password": "Jelszó",
+          "username": "Felhasználónév"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "HTTP lekérdezési időköz (másodperc)",
+          "modbus_tcp": "Modbus TCP használata HTTP lekérdezés helyett",
+          "modbus_host": "Qvantum Hoszt/IP"
+        },
+        "description": "Módosítsa a beállításait.",
+        "title": "Beállítások"
+      }
+    }
+  },
+  "services": {
+    "extra_hot_water": {
+      "name": "Extra melegvíz",
+      "description": "Extra használati melegvíz aktiválása egy időszakra",
+      "fields": {
+        "device_id": {
+          "name": "Eszközazonosító",
+          "description": "A Qvantum eszköz azonosítója"
+        },
+        "minutes": {
+          "name": "Percek",
+          "description": "Percek száma extra melegvíz előállításához (0 perc kikapcsol)"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -154,7 +154,7 @@
       "smart_dhw_control_status": {
         "name": "Smart DHW-controlestatus",
         "state": {
-          "0": "Niet beschikbaar",
+          "0": "Wachten op energieprijzen",
           "1": "Standby",
           "2": "Stijgen",
           "3": "Dalen",

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -7,312 +7,312 @@
   "entity": {
     "switch": {
       "extra_tap_water": {
-        "name": "Extra ciepla woda"
+        "name": "Extra ciepła woda"
       },
       "op_man_addition": {
-        "name": "Manual tryb pracy: Additiwl."
+        "name": "Ręczny tryb pracy: Dogrzewanie"
       },
       "op_man_dhw": {
-        "name": "Manual tryb pracy: ciepla woda"
+        "name": "Ręczny tryb pracy: Ciepła woda"
       },
       "op_mode": {
-        "name": "Manual tryb pracy"
+        "name": "Ręczny tryb pracy"
       },
       "man_mode": {
-        "name": "Manual tryb pracy: ogrzewanie"
+        "name": "Ręczny tryb pracy: Ogrzewanie"
       },
       "enable_sc_dhw": {
-        "name": "SmartCwl.trol: DHW"
+        "name": "SmartControl: DHW"
       },
       "enable_sc_sh": {
-        "name": "SmartCwl.trol: ogrzewanie"
+        "name": "SmartControl: Ogrzewanie"
       }
     },
     "select": {
       "use_adaptive": {
-        "name": "SmartCwl.trol",
+        "name": "SmartControl",
         "state": {
-          "off": "wyl.",
+          "off": "Wył.",
           "0": "Eco",
-          "1": "Balanced",
-          "2": "Comfort"
+          "1": "Zrównoważony",
+          "2": "Komfort"
         }
       },
       "smart_sh_mode": {
-        "name": "Smart SH tryb",
+        "name": "Smart tryb SH",
         "state": {
           "0": "Eco",
-          "1": "Balanced",
-          "2": "Comfort"
+          "1": "Zrównoważony",
+          "2": "Komfort"
         }
       },
       "smart_dhw_mode": {
-        "name": "Smart DHW tryb",
+        "name": "Smart tryb DHW",
         "state": {
           "0": "Eco",
-          "1": "Balanced",
-          "2": "Comfort"
+          "1": "Zrównoważony",
+          "2": "Komfort"
         }
       }
     },
     "button": {
       "extra_tap_water_60min": {
-        "name": "Extra ciepla woda 60 min"
+        "name": "Extra ciepła woda 60 min"
       },
       "elevate_access": {
-        "name": "Elevate access"
+        "name": "Podnieś dostęp"
       }
     },
     "binary_sensor": {
       "op_man_addition": {
-        "name": "Manual tryb pracy: Additiwl."
+        "name": "Ręczny tryb pracy: Dogrzewanie"
       },
       "op_man_cooling": {
-        "name": "Manual tryb pracy: chlodzenie"
+        "name": "Ręczny tryb pracy: Chłodzenie"
       },
       "op_man_dhw": {
-        "name": "Manual tryb pracy: ciepla woda"
+        "name": "Ręczny tryb pracy: Ciepła woda"
       },
       "cooling_enabled": {
-        "name": "chlodzenie wlaczwl.e"
+        "name": "Chłodzenie włączone"
       },
       "use_adaptive": {
-        "name": "SmartCwl.trol"
+        "name": "SmartControl"
       },
       "enable_sc_dhw": {
-        "name": "SmartCwl.trol: DHW"
+        "name": "SmartControl: DHW"
       },
       "enable_sc_sh": {
-        "name": "SmartCwl.trol: ogrzewanie"
+        "name": "SmartControl: Ogrzewanie"
       },
       "picpin_relay_heat_l1": {
-        "name": "Additiwl.al power L1"
+        "name": "Moc dodatkowa L1"
       },
       "picpin_relay_heat_l2": {
-        "name": "Additiwl.al power L2"
+        "name": "Moc dodatkowa L2"
       },
       "picpin_relay_heat_l3": {
-        "name": "Additiwl.al power L3"
+        "name": "Moc dodatkowa L3"
       },
       "picpin_relay_gp10": {
-        "name": "Circulatiwl. pompa (GP10)"
+        "name": "Pompa cyrkulacyjna (GP10)"
       },
       "picpin_relay_qm10": {
-        "name": "Divertingvalve, DHW/ogrzewanie (QM10)"
+        "name": "Zawór przełączający, DHW/ogrzewanie (QM10)"
       },
       "picpin_relay_qn8_1": {
-        "name": "Shunt valve additiwl. (QN8_1)"
+        "name": "Zawór mieszający dogrzewanie (QN8_1)"
       },
       "picpin_relay_qn8_2": {
-        "name": "Shunt valve additiwl. (QN8_2)"
+        "name": "Zawór mieszający dogrzewanie (QN8_2)"
       },
       "picpin_relay_gp3": {
-        "name": "Circulatiwl. pompa (GP3)"
+        "name": "Pompa cyrkulacyjna (GP3)"
       },
       "picpin_relay_pump": {
-        "name": "Circulatiwl. pompa"
+        "name": "Pompa cyrkulacyjna"
       },
       "picpin_relay_ha12": {
-        "name": "ogrzewanie circuit pompa (HA12)"
+        "name": "Pompa obiegu grzewczego (HA12)"
       },
       "dhwdemand": {
-        "name": "ciepla woda demand"
+        "name": "Zapotrzebowanie na ciepłą wodę"
       },
       "heatingdemand": {
-        "name": "ogrzewanie demand"
+        "name": "Zapotrzebowanie na ogrzewanie"
       },
       "coolingdemand": {
-        "name": "chlodzenie demand"
+        "name": "Zapotrzebowanie na chłodzenie"
       },
       "additiondemand": {
-        "name": "Additiwl. demand"
+        "name": "Zapotrzebowanie na dogrzewanie"
       },
       "additiondhwdemand": {
-        "name": "Additiwl. ciepla woda demand"
+        "name": "Zapotrzebowanie na dogrzewanie ciepłej wody"
       }
     },
     "sensor": {
       "compressor_state": {
-        "name": "sprezarka stan",
+        "name": "Stan sprężarki",
         "state": {
-          "0": "wyl.",
-          "1": "Idle",
-          "2": "Prepare for ogrzewanie",
-          "3": "Prepare for chlodzenie",
-          "4": "Prepare 1 for ciepla woda",
-          "5": "Prepare 2 for ciepla woda",
-          "6": "ogrzewanie",
-          "7": "chlodzenie",
-          "8": "ciepla woda",
-          "9": "odszranianie ciepla woda passive",
-          "10": "odszranianie ogrzewanie passive",
-          "11": "Prepare for pool",
-          "12": "Pool",
-          "13": "odszranianie pool passive"
+          "0": "Wył.",
+          "1": "Bezczynność",
+          "2": "Przygotowanie do ogrzewania",
+          "3": "Przygotowanie do chłodzenia",
+          "4": "Przygotowanie 1 do ciepłej wody",
+          "5": "Przygotowanie 2 do ciepłej wody",
+          "6": "Ogrzewanie",
+          "7": "Chłodzenie",
+          "8": "Ciepła woda",
+          "9": "Odszranianie ciepłej wody pasywne",
+          "10": "Odszranianie ogrzewania pasywne",
+          "11": "Przygotowanie do basenu",
+          "12": "Basen",
+          "13": "Odszranianie basenu pasywne"
         }
       },
       "smart_dhw_control_status": {
-        "name": "Smart DHW cwl.trol status",
+        "name": "Status sterowania Smart DHW",
         "state": {
           "0": "Oczekiwanie na ceny energii",
-          "1": "Tryb gotowosci",
+          "1": "Tryb gotowości",
           "2": "Podnoszenie",
-          "3": "Obnizanie",
-          "4": "Obnizanie dlugoterminowe",
+          "3": "Obniżanie",
+          "4": "Obniżanie długoterminowe",
           "5": "Wstrzymane"
         }
       },
       "powertotal": {
-        "name": "Total Power"
+        "name": "Całkowita moc"
       },
       "heatingpower": {
-        "name": "ogrzewanie Power"
+        "name": "Moc ogrzewania"
       },
       "dhwpower": {
-        "name": "DHW Power"
+        "name": "Moc DHW"
       },
       "compressor_power": {
-        "name": "sprezarka Power"
+        "name": "Moc sprężarki"
       },
       "heatingenergy": {
-        "name": "ogrzewanie Energy"
+        "name": "Energia ogrzewania"
       },
       "dhwenergy": {
-        "name": "DHW Energy"
+        "name": "Energia DHW"
       },
       "inputcurrent1": {
-        "name": "Input biezacy L1"
+        "name": "Prąd wejściowy L1"
       },
       "inputcurrent2": {
-        "name": "Input biezacy L2"
+        "name": "Prąd wejściowy L2"
       },
       "inputcurrent3": {
-        "name": "Input biezacy L3"
+        "name": "Prąd wejściowy L3"
       },
       "degree_minute": {
-        "name": "Degree Minute"
+        "name": "Stopień minutowy"
       },
       "bf1_l_min": {
-        "name": "przeplyw czujnik DHW (BF1)"
+        "name": "Czujnik przepływu DHW (BF1)"
       },
       "bf1_rpm": {
-        "name": "przeplyw czujnik DHW pompa speed (BF1)"
+        "name": "Prędkość pompy czujnika przepływu DHW (BF1)"
       },
       "bp1_pressure": {
-        "name": "Low cisnienie bar (BP1)"
+        "name": "Niskie ciśnienie bar (BP1)"
       },
       "bp1_temp": {
-        "name": "Low cisnienie temp (BP1)"
+        "name": "Temperatura niskiego ciśnienia (BP1)"
       },
       "bp2_pressure": {
-        "name": "High cisnienie bar (BP2)"
+        "name": "Wysokie ciśnienie bar (BP2)"
       },
       "bp2_temp": {
-        "name": "High cisnienie temp (BP2)"
+        "name": "Temperatura wysokiego ciśnienia (BP2)"
       },
       "bt10": {
-        "name": "Cwl.denser temp out (BT10)"
+        "name": "Temperatura wyjścia skraplacza (BT10)"
       },
       "bt12": {
-        "name": "ogrzewanie medium, external przeplyw line (BT12)"
+        "name": "Czynnik grzewczy, zewnętrzna linia zasilająca (BT12)"
       },
       "bt13": {
-        "name": "Cwl.denser temp in (BT13)"
+        "name": "Temperatura wejścia skraplacza (BT13)"
       },
       "bt14": {
-        "name": "Exhaust temp air (BT14)"
+        "name": "Temperatura powietrza wylotowego (BT14)"
       },
       "bt15": {
-        "name": "Extract temp air (BT15)"
+        "name": "Temperatura powietrza wywiewanego (BT15)"
       },
       "bt20": {
-        "name": "Discharge line (BT20)"
+        "name": "Linia tłoczna (BT20)"
       },
       "bt21": {
-        "name": "Liquid line (BT21)"
+        "name": "Linia cieczowa (BT21)"
       },
       "bt22": {
-        "name": "Evaporator inlet temp (BT22)"
+        "name": "Temperatura wejścia parownika (BT22)"
       },
       "bt23": {
-        "name": "Suctiwl. line (BT23)"
+        "name": "Linia ssania (BT23)"
       },
       "bt31": {
-        "name": "DHW primary, chargetemp in (BT31)"
+        "name": "DHW pierwotny, temperatura ładowania wejście (BT31)"
       },
       "bt33": {
-        "name": "DHW secwl.dary, Coldwoda in (BT33)"
+        "name": "DHW wtórny, zimna woda wejście (BT33)"
       },
       "bt34": {
-        "name": "DHW secwl.dary, Hotwoda out (BT34)"
+        "name": "DHW wtórny, ciepła woda wyjście (BT34)"
       },
       "compressormeasuredspeed": {
-        "name": "sprezarka speed"
+        "name": "Prędkość sprężarki"
       },
       "dhw_outl_temp_15": {
-        "name": "DHW outlet temperatura 15"
+        "name": "Temperatura wyjścia DHW 15"
       },
       "dhw_outl_temp_5": {
-        "name": "DHW outlet temperatura 5"
+        "name": "Temperatura wyjścia DHW 5"
       },
       "dhw_outl_temp_max": {
-        "name": "DHW outlet temperatura max"
+        "name": "Temperatura wyjścia DHW max"
       },
       "dhw_prioritytime": {
-        "name": "DHW priority time"
+        "name": "Czas priorytetu DHW"
       },
       "fan0_10v": {
-        "name": "wentylator speed"
+        "name": "Prędkość wentylatora"
       },
       "fanrpm": {
-        "name": "wentylator speed"
+        "name": "Prędkość wentylatora"
       },
       "qn8position": {
-        "name": "Shuntvalve, additiwl. (QN8)"
+        "name": "Zawór mieszający, dogrzewanie (QN8)"
       },
       "gp1_speed": {
-        "name": "Circulatiwl. pompa (GP1)"
+        "name": "Pompa cyrkulacyjna (GP1)"
       },
       "gp2_speed": {
-        "name": "DHW charge pompa (GP2)"
+        "name": "Pompa ładowania DHW (GP2)"
       },
       "guide_des_temp": {
-        "name": "Guide desired temperatura"
+        "name": "Temperatura docelowa sterownika"
       },
       "guide_he": {
-        "name": "Guide ogrzewanie"
+        "name": "Ogrzewanie sterownika"
       },
       "man_mode": {
-        "name": "Manual tryb"
+        "name": "Tryb ręczny"
       },
       "op_mode": {
-        "name": "tryb pracy",
+        "name": "Tryb pracy",
         "state": {
-          "0": "Auto",
-          "1": "Manual",
-          "2": "Additiwl."
+          "0": "Automatyczny",
+          "1": "Ręczny",
+          "2": "Dogrzewanie"
         }
       },
       "op_mode_sensor": {
-        "name": "tryb pracy czujnik"
+        "name": "Czujnik trybu pracy"
       },
       "price_region": {
-        "name": "Price regiwl."
+        "name": "Region cenowy"
       },
       "room_temp_ext": {
-        "name": "pomieszczenie temperatura external"
+        "name": "Zewnętrzna temperatura pokojowa"
       },
       "compressorenergy": {
-        "name": "sprezarka energy"
+        "name": "Energia sprężarki"
       },
       "totalenergy": {
-        "name": "Total energy"
+        "name": "Całkowita energia"
       },
       "bt1": {
-        "name": "Outdoor (BT1)"
+        "name": "Zewnętrzna (BT1)"
       },
       "bt2": {
-        "name": "Indoor (BT2)"
+        "name": "Wewnętrzna (BT2)"
       },
       "bt4": {
         "name": "BT4"
@@ -321,188 +321,188 @@
         "name": "BTX"
       },
       "smart_sh_status": {
-        "name": "Smart status for ogrzewanie"
+        "name": "Status Smart dla ogrzewania"
       },
       "bt11": {
-        "name": "ogrzewanie medium, przeplyw line (BT11)"
+        "name": "Czynnik grzewczy, linia zasilająca (BT11)"
       },
       "cal_heat_temp": {
-        "name": "ogrzewanie medium, przeplyw line, docelowy."
+        "name": "Czynnik grzewczy, linia zasilająca, docelowa."
       },
       "start_cooling_temp": {
-        "name": "chlodzenie start temperatura"
+        "name": "Temperatura startu chłodzenia"
       },
       "bt30": {
-        "name": "ciepla woda tank (BT30)"
+        "name": "Zbiornik ciepłej wody (BT30)"
       },
       "tap_water_start": {
-        "name": "ciepla woda tank lower limit"
+        "name": "Dolna granica zbiornika ciepłej wody"
       },
       "tap_water_stop": {
-        "name": "ciepla woda tank upper limit"
+        "name": "Górna granica zbiornika ciepłej wody"
       },
       "tap_water_cap": {
-        "name": "ciepla woda capacity"
+        "name": "Pojemność ciepłej wody"
       },
       "additionalenergy": {
-        "name": "Additiwl.al energy"
+        "name": "Energia dogrzewania"
       },
       "hpid": {
         "name": "Id"
       },
       "smart_sh_mode": {
-        "name": "Smart SH tryb",
+        "name": "Smart tryb SH",
         "state": {
           "0": "Eco",
-          "1": "Balanced",
-          "2": "Comfort"
+          "1": "Zrównoważony",
+          "2": "Komfort"
         }
       },
       "hp_status": {
-        "name": "pompa ciepla status",
+        "name": "Status pompy ciepła",
         "state": {
-          "0": "Idle",
-          "1": "odszranianieing",
-          "2": "ciepla woda",
-          "3": "ogrzewanie",
-          "4": "chlodzenie"
+          "0": "Bezczynność",
+          "1": "Odszranianie",
+          "2": "Ciepła woda",
+          "3": "Ogrzewanie",
+          "4": "Chłodzenie"
         }
       },
       "smart_dhw_status": {
-        "name": "Smart status for ciepla woda"
+        "name": "Status Smart dla ciepłej wody"
       },
       "smart_dhw_mode": {
-        "name": "Smart DHW tryb",
+        "name": "Smart tryb DHW",
         "state": {
           "0": "Eco",
-          "1": "Balanced",
-          "2": "Comfort"
+          "1": "Zrównoważony",
+          "2": "Komfort"
         }
       },
       "tap_stop": {
-        "name": "Extra ciepla woda stop"
+        "name": "Stop extra ciepłej wody"
       },
       "ventilation_boost_stop": {
-        "name": "Podnoszenie ventilatiwl. stop"
+        "name": "Stop wentylacji boost"
       },
       "timestamp": {
-        "name": "Last update"
+        "name": "Ostatnia aktualizacja"
       },
       "latency": {
-        "name": "Latency"
+        "name": "Opóźnienie"
       },
       "disconnect_reason": {
-        "name": "Discwl.nect reaswl.",
+        "name": "Powód rozłączenia",
         "state": {
-          "client-disconnect": "Client discwl.nected"
+          "client-disconnect": "Klient rozłączony"
         }
       },
       "heatingreleased": {
-        "name": "ogrzewanie Released"
+        "name": "Ogrzewanie zwolnione"
       },
       "coolingreleased": {
-        "name": "chlodzenie Released"
+        "name": "Chłodzenie zwolnione"
       },
       "compressorreleased": {
-        "name": "sprezarka Released"
+        "name": "Sprężarka zwolniona"
       },
       "additionreleased": {
-        "name": "Additiwl.al Released"
+        "name": "Dogrzewanie zwolnione"
       },
       "dhw_prioritytimeleft": {
-        "name": "DHW Priority Time Left"
+        "name": "Pozostały czas priorytetu DHW"
       },
       "heating_prioritytimeleft": {
-        "name": "ogrzewanie Priority Time Left"
+        "name": "Pozostały czas priorytetu ogrzewania"
       },
       "cooling_prioritytimeleft": {
-        "name": "chlodzenie Priority Time Left"
+        "name": "Pozostały czas priorytetu chłodzenia"
       },
       "switch_state": {
-        "name": "Switch stan"
+        "name": "Stan przełącznika"
       },
       "dhwstop_temp": {
-        "name": "DHW Stop temperatura"
+        "name": "Temperatura zatrzymania DHW"
       },
       "dhwstart_temp": {
-        "name": "DHW Start temperatura"
+        "name": "Temperatura startu DHW"
       },
       "filtered60sec_outdoortemp": {
-        "name": "Filtered temperatura zewnetrzna (60s)"
+        "name": "Filtrowana temperatura zewnętrzna (60s)"
       },
       "max_freq_env": {
-        "name": "Max czestotliwosc Envirwl.ment"
+        "name": "Maks. częstotliwość środowiska"
       },
       "calc_suppy_cpr": {
-        "name": "Calculated Supply CPR"
+        "name": "Wyliczone zasilanie CPR"
       },
       "dhw_set": {
-        "name": "DHW Set"
+        "name": "Ustawienie DHW"
       },
       "bp1_temp_20min_filter": {
-        "name": "BP1 Temp 20min Filter"
+        "name": "Filtr temperatury BP1 20 min"
       },
       "max_bp2_env": {
-        "name": "Max BP2 Envirwl.ment"
+        "name": "Maks. BP2 środowisko"
       },
       "picpin_mask": {
-        "name": "PIC Pin Mask"
+        "name": "Maska PIC Pin"
       },
       "firmware_display_fw_version": {
-        "name": "Display firmware versiwl."
+        "name": "Wersja firmware wyświetlacza"
       },
       "firmware_cc_fw_version": {
-        "name": "CC firmware versiwl."
+        "name": "Wersja firmware CC"
       },
       "firmware_inv_fw_version": {
-        "name": "Inverter firmware versiwl."
+        "name": "Wersja firmware inwertera"
       },
       "firmware_last_check": {
-        "name": "Firmware last checked"
+        "name": "Ostatnie sprawdzenie firmware"
       },
       "expires_at": {
-        "name": "Elevated access expiratiwl."
+        "name": "Wygaśnięcie podwyższonego dostępu"
       }
     },
     "number": {
       "indoor_temperature_offset": {
-        "name": "Parallel curve wyl.set"
+        "name": "Krzywa równoległa, przesunięcie"
       },
       "tap_water_capacity_target": {
-        "name": "ciepla woda capacity docelowy"
+        "name": "Docelowa pojemność ciepłej wody"
       },
       "room_comp_factor": {
-        "name": "pomieszczenie compensatiwl. factor"
+        "name": "Współczynnik kompensacji pokojowej"
       },
       "tap_water_stop": {
-        "name": "ciepla woda tank upper temperatura limit"
+        "name": "Górna granica temperatury zbiornika ciepłej wody"
       },
       "tap_water_start": {
-        "name": "ciepla woda tank lower temperatura limit"
+        "name": "Dolna granica temperatury zbiornika ciepłej wody"
       },
       "fan_normal": {
-        "name": "Normal wentylator speed"
+        "name": "Normalna prędkość wentylatora"
       },
       "fan_speed_2": {
-        "name": "Minimum wentylator speed for sprezarka"
+        "name": "Minimalna prędkość wentylatora dla sprężarki"
       },
       "dhw_stop_extra": {
-        "name": "Extra ciepla woda stop temperatura"
+        "name": "Extra temperatura zatrzymania ciepłej wody"
       }
     },
     "climate": {
       "indoor_climate": {
-        "name": "Indoor climate"
+        "name": "Klimat wewnętrzny"
       }
     },
     "fan": {
       "fanspeedselector": {
-        "name": "wentylator speed",
+        "name": "Prędkość wentylatora",
         "state_attributes": {
           "preset_mode": {
             "state": {
-              "off": "wyl.",
-              "normal": "Normal",
+              "off": "Wył.",
+              "normal": "Normalny",
               "extra": "Extra"
             }
           }
@@ -511,30 +511,30 @@
     }
   },
   "config": {
-    "title": "Qvantum pompa ciepla",
+    "title": "Pompa ciepła Qvantum",
     "abort": {
-      "already_configured": "Device is already cwl.figured",
-      "reconfigure_successful": "Recwl.figuratiwl. successful"
+      "already_configured": "Urządzenie jest już skonfigurowane",
+      "reconfigure_successful": "Rekonfiguracja powiodła się"
     },
     "error": {
-      "cannot_connect": "Failed to cwl.nect",
-      "invalid_auth": "Invalid authenticatiwl.",
-      "unknown": "Unexpected blad"
+      "cannot_connect": "Nie udało się połączyć",
+      "invalid_auth": "Nieprawidłowe uwierzytelnienie",
+      "unknown": "Nieoczekiwany błąd"
     },
     "step": {
       "user": {
-        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be wlaczwl.e in Installer settings wl. the pompa app/display before enabling here. Note that it wl.ly reads via Modbus, write/cwl.trols are still via HTTP API",
+        "description": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: odczytuje tylko przez Modbus, zapis/sterowanie nadal odbywa się przez HTTP API",
         "data": {
-          "password": "Password",
-          "username": "Username",
-          "modbus_tcp": "Use Modbus TCP instead of HTTP polling"
+          "password": "Hasło",
+          "username": "Nazwa użytkownika",
+          "modbus_tcp": "Użyj Modbus TCP zamiast odpytywania HTTP"
         }
       },
       "reconfigure": {
-        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be wlaczwl.e in Installer settings wl. the pompa app/display before enabling here. Note that it wl.ly reads via Modbus, write/cwl.trols are still via HTTP API",
+        "description": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: odczytuje tylko przez Modbus, zapis/sterowanie nadal odbywa się przez HTTP API",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Hasło",
+          "username": "Nazwa użytkownika"
         }
       }
     }
@@ -543,27 +543,27 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP Scan Interval (secwl.ds)",
-          "modbus_tcp": "Use Modbus TCP instead of HTTP polling",
-          "modbus_host": "Qvantum Host/IP"
+          "scan_interval": "Interwał skanowania HTTP (sekundy)",
+          "modbus_tcp": "Użyj Modbus TCP zamiast odpytywania HTTP",
+          "modbus_host": "Host/IP Qvantum"
         },
-        "description": "Amend your optiwl.s.",
-        "title": "Optiwl.s"
+        "description": "Zmień swoje opcje.",
+        "title": "Opcje"
       }
     }
   },
   "services": {
     "extra_hot_water": {
-      "name": "Extra ciepla woda",
-      "description": "Active extra ciepla woda for a period",
+      "name": "Extra ciepła woda",
+      "description": "Aktywuj extra ciepłą wodę na okres",
       "fields": {
         "device_id": {
-          "name": "Device Id",
-          "description": "The Qvantum device id"
+          "name": "Id urządzenia",
+          "description": "Identyfikator urządzenia Qvantum"
         },
         "minutes": {
-          "name": "Minutes",
-          "description": "Minutes to produce extra ciepla woda (0 minutes turns wyl.)"
+          "name": "Minuty",
+          "description": "Minuty produkcji extra ciepłej wody (0 minut wyłącza)"
         }
       }
     }

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -1,0 +1,571 @@
+{
+  "device": {
+    "qvantum_flvp": {
+      "name": "Qvantum"
+    }
+  },
+  "entity": {
+    "switch": {
+      "extra_tap_water": {
+        "name": "Extra ciepla woda"
+      },
+      "op_man_addition": {
+        "name": "Manual tryb pracy: Additiwl."
+      },
+      "op_man_dhw": {
+        "name": "Manual tryb pracy: ciepla woda"
+      },
+      "op_mode": {
+        "name": "Manual tryb pracy"
+      },
+      "man_mode": {
+        "name": "Manual tryb pracy: ogrzewanie"
+      },
+      "enable_sc_dhw": {
+        "name": "SmartCwl.trol: DHW"
+      },
+      "enable_sc_sh": {
+        "name": "SmartCwl.trol: ogrzewanie"
+      }
+    },
+    "select": {
+      "use_adaptive": {
+        "name": "SmartCwl.trol",
+        "state": {
+          "off": "wyl.",
+          "0": "Eco",
+          "1": "Balanced",
+          "2": "Comfort"
+        }
+      },
+      "smart_sh_mode": {
+        "name": "Smart SH tryb",
+        "state": {
+          "0": "Eco",
+          "1": "Balanced",
+          "2": "Comfort"
+        }
+      },
+      "smart_dhw_mode": {
+        "name": "Smart DHW tryb",
+        "state": {
+          "0": "Eco",
+          "1": "Balanced",
+          "2": "Comfort"
+        }
+      }
+    },
+    "button": {
+      "extra_tap_water_60min": {
+        "name": "Extra ciepla woda 60 min"
+      },
+      "elevate_access": {
+        "name": "Elevate access"
+      }
+    },
+    "binary_sensor": {
+      "op_man_addition": {
+        "name": "Manual tryb pracy: Additiwl."
+      },
+      "op_man_cooling": {
+        "name": "Manual tryb pracy: chlodzenie"
+      },
+      "op_man_dhw": {
+        "name": "Manual tryb pracy: ciepla woda"
+      },
+      "cooling_enabled": {
+        "name": "chlodzenie wlaczwl.e"
+      },
+      "use_adaptive": {
+        "name": "SmartCwl.trol"
+      },
+      "enable_sc_dhw": {
+        "name": "SmartCwl.trol: DHW"
+      },
+      "enable_sc_sh": {
+        "name": "SmartCwl.trol: ogrzewanie"
+      },
+      "picpin_relay_heat_l1": {
+        "name": "Additiwl.al power L1"
+      },
+      "picpin_relay_heat_l2": {
+        "name": "Additiwl.al power L2"
+      },
+      "picpin_relay_heat_l3": {
+        "name": "Additiwl.al power L3"
+      },
+      "picpin_relay_gp10": {
+        "name": "Circulatiwl. pompa (GP10)"
+      },
+      "picpin_relay_qm10": {
+        "name": "Divertingvalve, DHW/ogrzewanie (QM10)"
+      },
+      "picpin_relay_qn8_1": {
+        "name": "Shunt valve additiwl. (QN8_1)"
+      },
+      "picpin_relay_qn8_2": {
+        "name": "Shunt valve additiwl. (QN8_2)"
+      },
+      "picpin_relay_gp3": {
+        "name": "Circulatiwl. pompa (GP3)"
+      },
+      "picpin_relay_pump": {
+        "name": "Circulatiwl. pompa"
+      },
+      "picpin_relay_ha12": {
+        "name": "ogrzewanie circuit pompa (HA12)"
+      },
+      "dhwdemand": {
+        "name": "ciepla woda demand"
+      },
+      "heatingdemand": {
+        "name": "ogrzewanie demand"
+      },
+      "coolingdemand": {
+        "name": "chlodzenie demand"
+      },
+      "additiondemand": {
+        "name": "Additiwl. demand"
+      },
+      "additiondhwdemand": {
+        "name": "Additiwl. ciepla woda demand"
+      }
+    },
+    "sensor": {
+      "compressor_state": {
+        "name": "sprezarka stan",
+        "state": {
+          "0": "wyl.",
+          "1": "Idle",
+          "2": "Prepare for ogrzewanie",
+          "3": "Prepare for chlodzenie",
+          "4": "Prepare 1 for ciepla woda",
+          "5": "Prepare 2 for ciepla woda",
+          "6": "ogrzewanie",
+          "7": "chlodzenie",
+          "8": "ciepla woda",
+          "9": "odszranianie ciepla woda passive",
+          "10": "odszranianie ogrzewanie passive",
+          "11": "Prepare for pool",
+          "12": "Pool",
+          "13": "odszranianie pool passive"
+        }
+      },
+      "smart_dhw_control_status": {
+        "name": "Smart DHW cwl.trol status",
+        "state": {
+          "0": "Oczekiwanie na ceny energii",
+          "1": "Tryb gotowosci",
+          "2": "Podnoszenie",
+          "3": "Obnizanie",
+          "4": "Obnizanie dlugoterminowe",
+          "5": "Wstrzymane"
+        }
+      },
+      "powertotal": {
+        "name": "Total Power"
+      },
+      "heatingpower": {
+        "name": "ogrzewanie Power"
+      },
+      "dhwpower": {
+        "name": "DHW Power"
+      },
+      "compressor_power": {
+        "name": "sprezarka Power"
+      },
+      "heatingenergy": {
+        "name": "ogrzewanie Energy"
+      },
+      "dhwenergy": {
+        "name": "DHW Energy"
+      },
+      "inputcurrent1": {
+        "name": "Input biezacy L1"
+      },
+      "inputcurrent2": {
+        "name": "Input biezacy L2"
+      },
+      "inputcurrent3": {
+        "name": "Input biezacy L3"
+      },
+      "degree_minute": {
+        "name": "Degree Minute"
+      },
+      "bf1_l_min": {
+        "name": "przeplyw czujnik DHW (BF1)"
+      },
+      "bf1_rpm": {
+        "name": "przeplyw czujnik DHW pompa speed (BF1)"
+      },
+      "bp1_pressure": {
+        "name": "Low cisnienie bar (BP1)"
+      },
+      "bp1_temp": {
+        "name": "Low cisnienie temp (BP1)"
+      },
+      "bp2_pressure": {
+        "name": "High cisnienie bar (BP2)"
+      },
+      "bp2_temp": {
+        "name": "High cisnienie temp (BP2)"
+      },
+      "bt10": {
+        "name": "Cwl.denser temp out (BT10)"
+      },
+      "bt12": {
+        "name": "ogrzewanie medium, external przeplyw line (BT12)"
+      },
+      "bt13": {
+        "name": "Cwl.denser temp in (BT13)"
+      },
+      "bt14": {
+        "name": "Exhaust temp air (BT14)"
+      },
+      "bt15": {
+        "name": "Extract temp air (BT15)"
+      },
+      "bt20": {
+        "name": "Discharge line (BT20)"
+      },
+      "bt21": {
+        "name": "Liquid line (BT21)"
+      },
+      "bt22": {
+        "name": "Evaporator inlet temp (BT22)"
+      },
+      "bt23": {
+        "name": "Suctiwl. line (BT23)"
+      },
+      "bt31": {
+        "name": "DHW primary, chargetemp in (BT31)"
+      },
+      "bt33": {
+        "name": "DHW secwl.dary, Coldwoda in (BT33)"
+      },
+      "bt34": {
+        "name": "DHW secwl.dary, Hotwoda out (BT34)"
+      },
+      "compressormeasuredspeed": {
+        "name": "sprezarka speed"
+      },
+      "dhw_outl_temp_15": {
+        "name": "DHW outlet temperatura 15"
+      },
+      "dhw_outl_temp_5": {
+        "name": "DHW outlet temperatura 5"
+      },
+      "dhw_outl_temp_max": {
+        "name": "DHW outlet temperatura max"
+      },
+      "dhw_prioritytime": {
+        "name": "DHW priority time"
+      },
+      "fan0_10v": {
+        "name": "wentylator speed"
+      },
+      "fanrpm": {
+        "name": "wentylator speed"
+      },
+      "qn8position": {
+        "name": "Shuntvalve, additiwl. (QN8)"
+      },
+      "gp1_speed": {
+        "name": "Circulatiwl. pompa (GP1)"
+      },
+      "gp2_speed": {
+        "name": "DHW charge pompa (GP2)"
+      },
+      "guide_des_temp": {
+        "name": "Guide desired temperatura"
+      },
+      "guide_he": {
+        "name": "Guide ogrzewanie"
+      },
+      "man_mode": {
+        "name": "Manual tryb"
+      },
+      "op_mode": {
+        "name": "tryb pracy",
+        "state": {
+          "0": "Auto",
+          "1": "Manual",
+          "2": "Additiwl."
+        }
+      },
+      "op_mode_sensor": {
+        "name": "tryb pracy czujnik"
+      },
+      "price_region": {
+        "name": "Price regiwl."
+      },
+      "room_temp_ext": {
+        "name": "pomieszczenie temperatura external"
+      },
+      "compressorenergy": {
+        "name": "sprezarka energy"
+      },
+      "totalenergy": {
+        "name": "Total energy"
+      },
+      "bt1": {
+        "name": "Outdoor (BT1)"
+      },
+      "bt2": {
+        "name": "Indoor (BT2)"
+      },
+      "bt4": {
+        "name": "BT4"
+      },
+      "btx": {
+        "name": "BTX"
+      },
+      "smart_sh_status": {
+        "name": "Smart status for ogrzewanie"
+      },
+      "bt11": {
+        "name": "ogrzewanie medium, przeplyw line (BT11)"
+      },
+      "cal_heat_temp": {
+        "name": "ogrzewanie medium, przeplyw line, docelowy."
+      },
+      "start_cooling_temp": {
+        "name": "chlodzenie start temperatura"
+      },
+      "bt30": {
+        "name": "ciepla woda tank (BT30)"
+      },
+      "tap_water_start": {
+        "name": "ciepla woda tank lower limit"
+      },
+      "tap_water_stop": {
+        "name": "ciepla woda tank upper limit"
+      },
+      "tap_water_cap": {
+        "name": "ciepla woda capacity"
+      },
+      "additionalenergy": {
+        "name": "Additiwl.al energy"
+      },
+      "hpid": {
+        "name": "Id"
+      },
+      "smart_sh_mode": {
+        "name": "Smart SH tryb",
+        "state": {
+          "0": "Eco",
+          "1": "Balanced",
+          "2": "Comfort"
+        }
+      },
+      "hp_status": {
+        "name": "pompa ciepla status",
+        "state": {
+          "0": "Idle",
+          "1": "odszranianieing",
+          "2": "ciepla woda",
+          "3": "ogrzewanie",
+          "4": "chlodzenie"
+        }
+      },
+      "smart_dhw_status": {
+        "name": "Smart status for ciepla woda"
+      },
+      "smart_dhw_mode": {
+        "name": "Smart DHW tryb",
+        "state": {
+          "0": "Eco",
+          "1": "Balanced",
+          "2": "Comfort"
+        }
+      },
+      "tap_stop": {
+        "name": "Extra ciepla woda stop"
+      },
+      "ventilation_boost_stop": {
+        "name": "Podnoszenie ventilatiwl. stop"
+      },
+      "timestamp": {
+        "name": "Last update"
+      },
+      "latency": {
+        "name": "Latency"
+      },
+      "disconnect_reason": {
+        "name": "Discwl.nect reaswl.",
+        "state": {
+          "client-disconnect": "Client discwl.nected"
+        }
+      },
+      "heatingreleased": {
+        "name": "ogrzewanie Released"
+      },
+      "coolingreleased": {
+        "name": "chlodzenie Released"
+      },
+      "compressorreleased": {
+        "name": "sprezarka Released"
+      },
+      "additionreleased": {
+        "name": "Additiwl.al Released"
+      },
+      "dhw_prioritytimeleft": {
+        "name": "DHW Priority Time Left"
+      },
+      "heating_prioritytimeleft": {
+        "name": "ogrzewanie Priority Time Left"
+      },
+      "cooling_prioritytimeleft": {
+        "name": "chlodzenie Priority Time Left"
+      },
+      "switch_state": {
+        "name": "Switch stan"
+      },
+      "dhwstop_temp": {
+        "name": "DHW Stop temperatura"
+      },
+      "dhwstart_temp": {
+        "name": "DHW Start temperatura"
+      },
+      "filtered60sec_outdoortemp": {
+        "name": "Filtered temperatura zewnetrzna (60s)"
+      },
+      "max_freq_env": {
+        "name": "Max czestotliwosc Envirwl.ment"
+      },
+      "calc_suppy_cpr": {
+        "name": "Calculated Supply CPR"
+      },
+      "dhw_set": {
+        "name": "DHW Set"
+      },
+      "bp1_temp_20min_filter": {
+        "name": "BP1 Temp 20min Filter"
+      },
+      "max_bp2_env": {
+        "name": "Max BP2 Envirwl.ment"
+      },
+      "picpin_mask": {
+        "name": "PIC Pin Mask"
+      },
+      "firmware_display_fw_version": {
+        "name": "Display firmware versiwl."
+      },
+      "firmware_cc_fw_version": {
+        "name": "CC firmware versiwl."
+      },
+      "firmware_inv_fw_version": {
+        "name": "Inverter firmware versiwl."
+      },
+      "firmware_last_check": {
+        "name": "Firmware last checked"
+      },
+      "expires_at": {
+        "name": "Elevated access expiratiwl."
+      }
+    },
+    "number": {
+      "indoor_temperature_offset": {
+        "name": "Parallel curve wyl.set"
+      },
+      "tap_water_capacity_target": {
+        "name": "ciepla woda capacity docelowy"
+      },
+      "room_comp_factor": {
+        "name": "pomieszczenie compensatiwl. factor"
+      },
+      "tap_water_stop": {
+        "name": "ciepla woda tank upper temperatura limit"
+      },
+      "tap_water_start": {
+        "name": "ciepla woda tank lower temperatura limit"
+      },
+      "fan_normal": {
+        "name": "Normal wentylator speed"
+      },
+      "fan_speed_2": {
+        "name": "Minimum wentylator speed for sprezarka"
+      },
+      "dhw_stop_extra": {
+        "name": "Extra ciepla woda stop temperatura"
+      }
+    },
+    "climate": {
+      "indoor_climate": {
+        "name": "Indoor climate"
+      }
+    },
+    "fan": {
+      "fanspeedselector": {
+        "name": "wentylator speed",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off": "wyl.",
+              "normal": "Normal",
+              "extra": "Extra"
+            }
+          }
+        }
+      }
+    }
+  },
+  "config": {
+    "title": "Qvantum pompa ciepla",
+    "abort": {
+      "already_configured": "Device is already cwl.figured",
+      "reconfigure_successful": "Recwl.figuratiwl. successful"
+    },
+    "error": {
+      "cannot_connect": "Failed to cwl.nect",
+      "invalid_auth": "Invalid authenticatiwl.",
+      "unknown": "Unexpected blad"
+    },
+    "step": {
+      "user": {
+        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be wlaczwl.e in Installer settings wl. the pompa app/display before enabling here. Note that it wl.ly reads via Modbus, write/cwl.trols are still via HTTP API",
+        "data": {
+          "password": "Password",
+          "username": "Username",
+          "modbus_tcp": "Use Modbus TCP instead of HTTP polling"
+        }
+      },
+      "reconfigure": {
+        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be wlaczwl.e in Installer settings wl. the pompa app/display before enabling here. Note that it wl.ly reads via Modbus, write/cwl.trols are still via HTTP API",
+        "data": {
+          "password": "Password",
+          "username": "Username"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "HTTP Scan Interval (secwl.ds)",
+          "modbus_tcp": "Use Modbus TCP instead of HTTP polling",
+          "modbus_host": "Qvantum Host/IP"
+        },
+        "description": "Amend your optiwl.s.",
+        "title": "Optiwl.s"
+      }
+    }
+  },
+  "services": {
+    "extra_hot_water": {
+      "name": "Extra ciepla woda",
+      "description": "Active extra ciepla woda for a period",
+      "fields": {
+        "device_id": {
+          "name": "Device Id",
+          "description": "The Qvantum device id"
+        },
+        "minutes": {
+          "name": "Minutes",
+          "description": "Minutes to produce extra ciepla woda (0 minutes turns wyl.)"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -157,7 +157,7 @@
       "smart_dhw_control_status": {
         "name": "Smart DHW-kontrollstatus",
         "state": {
-          "0": "Inte tillgänglig",
+          "0": "Väntar på elpriser",
           "1": "Standby",
           "2": "Ökar",
           "3": "Minskar",


### PR DESCRIPTION
This pull request add Magyar, French and Polish as new translations. Also updates the translation for the "0" state of the `smart_dhw_control_status` across all supported languages, changing its meaning from "Unavailable" to "Waiting for energy prices". This provides a more accurate description of the system's state in all translations.

Localization updates:

* Changed the "0" state of `smart_dhw_control_status` from "Unavailable" (or equivalent) to "Waiting for energy prices" (or equivalent) in the following translation files:
  - English (`en.json`)
  - German (`de.json`)
  - Spanish (`es.json`)
  - Dutch (`nl.json`)
  - Swedish (`sv.json`)