### PR TITLE
feat: Add tap water capacity calculation for modbus mode

### DIFF
--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -185,14 +185,23 @@ class QvantumCalculationsMixin:
             else tank_temp
         )
 
+        if (
+            effective_hot_temp <= DHW_SHOWER_TEMP_C
+            or cold_temp >= DHW_SHOWER_TEMP_C
+        ):
+            values["tap_water_cap"] = 0.0
+            return
+
         delta_available = effective_hot_temp - cold_temp
         if delta_available < 5:
             values["tap_water_cap"] = 0.0
             return
 
         hot_fraction = (DHW_SHOWER_TEMP_C - cold_temp) / delta_available
+        hot_fraction = min(1.0, max(0.0, hot_fraction))
         hot_per_min = flow_lpm * hot_fraction
         if hot_per_min <= 0:
+            values["tap_water_cap"] = 0.0
             return
 
         minutes = (

--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -117,12 +117,12 @@ class QvantumCalculationsMixin:
     def _calculate_tap_water_cap(self, values: dict) -> None:
         """Derive tap_water_cap (showers remaining) from tank and flow sensor data.
 
-        bt34 (DHW hot water outlet) is the temperature the thermostatic mixer
-        actually receives and is snapshotted during active flow alongside bt33
-        (cold water in) and bf1_l_min (flow), because all three drift when idle.
-        bt30 (tank temp) is used as fallback when no bt34 snapshot exists yet.
-        Formula: effective_hot = bt34_snapshot or bt30,
-                 hot_fraction = (shower_temp - cold) / (effective_hot - cold),
+        bt30 (tank temp) is used directly as the effective hot water temperature,
+        since it represents current stored energy and decreases as hot water is
+        drawn — making capacity correctly decrease during a shower.
+        bt33 (cold water in) and bf1_l_min (flow) are snapshotted during active
+        flow and EMA-smoothed to prevent brief transients from dominating.
+        Formula: hot_fraction = (shower_temp - cold) / (tank_temp - cold),
                  hot_per_min = flow * hot_fraction,
                  minutes = (volume * usable_fraction / hot_per_min) * drop_factor,
                  showers = minutes / shower_duration_min.
@@ -130,11 +130,10 @@ class QvantumCalculationsMixin:
         tank_temp = values.get("bt30")
         flow = values.get("bf1_l_min")
         cold = values.get("bt33")
-        hot_out = values.get("bt34")
 
         # Snapshot realistic shower-time values while water is actually flowing.
-        # EMA-smooth cold and hot_out to prevent a brief transient (e.g. warm pipe
-        # water at the start of a 15-second run) from dominating the estimate.
+        # EMA-smooth cold to prevent a brief transient (e.g. warm pipe water at
+        # the start of a 15-second run) from dominating the estimate.
         if flow is not None and flow > 0.1:
             if cold is not None:
                 prior_cold = (
@@ -144,15 +143,6 @@ class QvantumCalculationsMixin:
                 )
                 self._last_shower_cold_temp = (
                     DHW_EMA_ALPHA * cold + (1 - DHW_EMA_ALPHA) * prior_cold
-                )
-            if hot_out is not None:
-                prior_hot = (
-                    self._last_shower_hot_temp
-                    if self._last_shower_hot_temp is not None
-                    else tank_temp  # seed from bt30 to avoid cold pipe transient on first observation
-                )
-                self._last_shower_hot_temp = (
-                    DHW_EMA_ALPHA * hot_out + (1 - DHW_EMA_ALPHA) * prior_hot
                 )
             prior_flow = (
                 self._last_shower_flow_lpm
@@ -178,12 +168,11 @@ class QvantumCalculationsMixin:
         if tank_temp is None:
             return
 
-        # bt34 is the actual delivery temperature; fall back to bt30 when not yet observed
-        effective_hot_temp = (
-            self._last_shower_hot_temp
-            if self._last_shower_hot_temp is not None
-            else tank_temp
-        )
+        # Use tank_temp (bt30) directly as the hot water temperature.
+        # tank_temp decreases as hot water is drawn, so capacity correctly
+        # decreases during a shower — unlike bt34 outlet temp which rises as
+        # pipes warm up and would cause capacity to appear to increase.
+        effective_hot_temp = tank_temp
 
         if (
             effective_hot_temp <= DHW_SHOWER_TEMP_C
@@ -221,11 +210,10 @@ class QvantumCalculationsMixin:
         # the EMA state in full precision for subsequent calculations.
         values["tap_water_cap"] = round(smoothed, 1)
         _LOGGER.debug(
-            "Calculated tap_water_cap=%.2f showers (raw=%.2f, tank=%.1f°C, hot_out=%.1f°C, cold=%.1f°C, flow=%.1f L/min)",
+            "Calculated tap_water_cap=%.2f showers (raw=%.2f, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min)",
             smoothed,
             raw_showers,
             tank_temp,
-            effective_hot_temp,
             cold_temp,
             flow_lpm,
         )

--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -1,0 +1,222 @@
+"""Calculation mixin for Qvantum coordinator derived metrics."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    DHW_DEFAULT_COLD_TEMP_C,
+    DHW_DEFAULT_FLOW_LPM,
+    DHW_EMA_ALPHA,
+    DHW_SHOWER_DURATION_MIN,
+    DHW_SHOWER_TEMP_C,
+    DHW_TANK_VOLUME_L,
+    DHW_TEMP_DROP_FACTOR,
+    DHW_USABLE_FRACTION,
+    HP_STATUS_HEATING,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class QvantumCalculationsMixin:
+    """Derived metric calculations extracted from the coordinator."""
+
+    def _calculate_mode_power(
+        self,
+        values: dict,
+        *,
+        energy_key: str,
+        power_key: str,
+        is_active: Callable[[dict[str, Any]], bool],
+        last_energy_attr: str,
+        last_time_attr: str,
+        mode_label: str,
+    ) -> None:
+        """Derive a mode-specific power metric from an energy counter delta.
+
+        Uses elapsed real time between counter increments (not poll interval).
+        While active mode is on and the counter is unchanged, holds the previously
+        emitted power value. Outside active mode, writes 0 W and resets baseline.
+        Negative deltas (counter resets) are clamped to 0 W.
+        """
+        now = dt_util.utcnow()
+        current_energy = values.get(energy_key)
+        if current_energy is None:
+            return
+
+        prev_power: float = (self.data or {}).get("values", {}).get(power_key, 0.0)
+        last_energy = getattr(self, last_energy_attr)
+        last_time = getattr(self, last_time_attr)
+
+        if not is_active(values):
+            values[power_key] = 0.0
+            setattr(self, last_energy_attr, current_energy)
+            setattr(self, last_time_attr, now)
+            return
+
+        _LOGGER.debug(
+            "Calculating %s power: current_energy=%.6f kWh, last_energy=%s kWh, last_time=%s",
+            mode_label,
+            current_energy,
+            last_energy,
+            last_time,
+        )
+
+        if last_energy is not None and last_time is not None:
+            delta_kwh = current_energy - last_energy
+            delta_seconds = (now - last_time).total_seconds()
+            if delta_kwh != 0 and delta_seconds > 0:
+                # kWh / s -> W: (kWh * 3_600_000 J/kWh) / s = J/s = W
+                power_w = (delta_kwh * 3_600_000) / delta_seconds
+                prev_power = max(0.0, round(power_w, 1))
+                _LOGGER.debug(
+                    "Calculated %s: %.1f W (delta=%.6f kWh over %.1f s)",
+                    power_key,
+                    prev_power,
+                    delta_kwh,
+                    delta_seconds,
+                )
+
+        values[power_key] = prev_power
+
+        if current_energy != last_energy:
+            setattr(self, last_time_attr, now)
+        setattr(self, last_energy_attr, current_energy)
+
+    def _calculate_heating_power(self, values: dict) -> None:
+        """Derive heatingpower (W) from the heatingenergy (kWh) delta between polls."""
+        self._calculate_mode_power(
+            values,
+            energy_key="heatingenergy",
+            power_key="heatingpower",
+            is_active=lambda v: v.get("hp_status") == HP_STATUS_HEATING,
+            last_energy_attr="_last_heatingenergy",
+            last_time_attr="_last_heatingenergy_time",
+            mode_label="heating",
+        )
+
+    def _calculate_dhw_power(self, values: dict) -> None:
+        """Derive dhwpower (W) from the dhwenergy (kWh) delta between polls."""
+        self._calculate_mode_power(
+            values,
+            energy_key="dhwenergy",
+            power_key="dhwpower",
+            # DHW activity is determined by BF1 flow rate rather than hp_status,
+            # because active tap water production is most reliably indicated by
+            # water flow through the DHW circuit.
+            is_active=lambda v: v.get("bf1_l_min", 0) > 0,
+            last_energy_attr="_last_dhwenergy",
+            last_time_attr="_last_dhwenergy_time",
+            mode_label="dhw",
+        )
+
+    def _calculate_tap_water_cap(self, values: dict) -> None:
+        """Derive tap_water_cap (showers remaining) from tank and flow sensor data.
+
+        bt34 (DHW hot water outlet) is the temperature the thermostatic mixer
+        actually receives and is snapshotted during active flow alongside bt33
+        (cold water in) and bf1_l_min (flow), because all three drift when idle.
+        bt30 (tank temp) is used as fallback when no bt34 snapshot exists yet.
+        Formula: effective_hot = bt34_snapshot or bt30,
+                 hot_fraction = (shower_temp - cold) / (effective_hot - cold),
+                 hot_per_min = flow * hot_fraction,
+                 minutes = (volume * usable_fraction / hot_per_min) * drop_factor,
+                 showers = minutes / shower_duration_min.
+        """
+        tank_temp = values.get("bt30")
+        flow = values.get("bf1_l_min")
+        cold = values.get("bt33")
+        hot_out = values.get("bt34")
+
+        # Snapshot realistic shower-time values while water is actually flowing.
+        # EMA-smooth cold and hot_out to prevent a brief transient (e.g. warm pipe
+        # water at the start of a 15-second run) from dominating the estimate.
+        if flow is not None and flow > 0.1:
+            if cold is not None:
+                prior_cold = (
+                    self._last_shower_cold_temp
+                    if self._last_shower_cold_temp is not None
+                    else DHW_DEFAULT_COLD_TEMP_C
+                )
+                self._last_shower_cold_temp = (
+                    DHW_EMA_ALPHA * cold + (1 - DHW_EMA_ALPHA) * prior_cold
+                )
+            if hot_out is not None:
+                prior_hot = (
+                    self._last_shower_hot_temp
+                    if self._last_shower_hot_temp is not None
+                    else tank_temp  # seed from bt30 to avoid cold pipe transient on first observation
+                )
+                self._last_shower_hot_temp = (
+                    DHW_EMA_ALPHA * hot_out + (1 - DHW_EMA_ALPHA) * prior_hot
+                )
+            prior_flow = (
+                self._last_shower_flow_lpm
+                if self._last_shower_flow_lpm is not None
+                else DHW_DEFAULT_FLOW_LPM
+            )
+            self._last_shower_flow_lpm = (
+                DHW_EMA_ALPHA * flow + (1 - DHW_EMA_ALPHA) * prior_flow
+            )
+
+        # Resolve effective values: use last observed or fall back to defaults
+        cold_temp = (
+            self._last_shower_cold_temp
+            if self._last_shower_cold_temp is not None
+            else DHW_DEFAULT_COLD_TEMP_C
+        )
+        flow_lpm = (
+            self._last_shower_flow_lpm
+            if self._last_shower_flow_lpm is not None
+            else DHW_DEFAULT_FLOW_LPM
+        )
+
+        if tank_temp is None:
+            return
+
+        # bt34 is the actual delivery temperature; fall back to bt30 when not yet observed
+        effective_hot_temp = (
+            self._last_shower_hot_temp
+            if self._last_shower_hot_temp is not None
+            else tank_temp
+        )
+
+        delta_available = effective_hot_temp - cold_temp
+        if delta_available < 5:
+            values["tap_water_cap"] = 0.0
+            return
+
+        hot_fraction = (DHW_SHOWER_TEMP_C - cold_temp) / delta_available
+        hot_per_min = flow_lpm * hot_fraction
+        if hot_per_min <= 0:
+            return
+
+        minutes = (
+            DHW_TANK_VOLUME_L * DHW_USABLE_FRACTION / hot_per_min
+        ) * DHW_TEMP_DROP_FACTOR
+        raw_showers = minutes / DHW_SHOWER_DURATION_MIN
+        if self._last_tap_water_cap is not None:
+            smoothed = (
+                DHW_EMA_ALPHA * raw_showers
+                + (1 - DHW_EMA_ALPHA) * self._last_tap_water_cap
+            )
+        else:
+            smoothed = raw_showers
+        self._last_tap_water_cap = smoothed
+        # Publish the derived value rounded to the sensor's display precision
+        # so small fluctuations do not cause UI flicker between updates. Keep
+        # the EMA state in full precision for subsequent calculations.
+        values["tap_water_cap"] = round(smoothed, 1)
+        _LOGGER.debug(
+            "Calculated tap_water_cap=%.2f showers (raw=%.2f, tank=%.1f°C, hot_out=%.1f°C, cold=%.1f°C, flow=%.1f L/min)",
+            smoothed,
+            raw_showers,
+            tank_temp,
+            effective_hot_temp,
+            cold_temp,
+            flow_lpm,
+        )

--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -11,6 +11,8 @@ from .const import (
     DHW_DEFAULT_COLD_TEMP_C,
     DHW_DEFAULT_FLOW_LPM,
     DHW_EMA_ALPHA,
+    DHW_FLOW_SNAPSHOT_THRESHOLD_LPM,
+    DHW_MIN_TEMPERATURE_DELTA_C,
     DHW_SHOWER_DURATION_MIN,
     DHW_SHOWER_TEMP_C,
     DHW_TANK_VOLUME_L,
@@ -134,7 +136,7 @@ class QvantumCalculationsMixin:
         # Snapshot realistic shower-time values while water is actually flowing.
         # EMA-smooth cold to prevent a brief transient (e.g. warm pipe water at
         # the start of a 15-second run) from dominating the estimate.
-        if flow is not None and flow > 0.1:
+        if flow is not None and flow > DHW_FLOW_SNAPSHOT_THRESHOLD_LPM:
             if cold is not None:
                 prior_cold = (
                     self._last_shower_cold_temp
@@ -182,7 +184,7 @@ class QvantumCalculationsMixin:
             return
 
         delta_available = effective_hot_temp - cold_temp
-        if delta_available < 5:
+        if delta_available < DHW_MIN_TEMPERATURE_DELTA_C:
             values["tap_water_cap"] = 0.0
             return
 

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -227,8 +227,10 @@ DHW_SHOWER_TEMP_C = 36.0  # Target shower temperature (°C) — per Qvantum app 
 DHW_TANK_VOLUME_L = 175  # Hot water tank volume (L) — buffer tank per installer spec
 DHW_USABLE_FRACTION = 0.8  # Usable fraction of tank
 DHW_DEFAULT_FLOW_LPM = 7.0  # Default shower flow rate when no recent observation (L/min)
+DHW_FLOW_SNAPSHOT_THRESHOLD_LPM = 0.1  # Minimum flow used to sample cold/flow values for tap_water_cap
 DHW_DEFAULT_COLD_TEMP_C = 8.0  # Default cold water temperature when no recent observation (°C)
 DHW_TEMP_DROP_FACTOR = 0.75  # Empirical compensation for tank temperature drop during shower
+DHW_MIN_TEMPERATURE_DELTA_C = 5.0  # Minimum spread between tank and cold water before a tap-water capacity estimate is valid
 DHW_SHOWER_DURATION_MIN = 6.0  # Duration of one shower in minutes
 DHW_EMA_ALPHA = (
     0.2  # EMA smoothing factor for tap_water_cap (0=no change, 1=no smoothing)

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -204,7 +204,6 @@ REQUIRED_MODBUS_METRICS = [
     # Required by tap_water_cap derived metric calculation in Modbus mode
     "bt30",  # Tank temperature
     "bt33",  # Cold water inlet temperature
-    "bt34",  # Hot water outlet temperature
     "bf1_l_min",  # DHW flow rate
 ]
 

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -224,8 +224,8 @@ PRESSURE_METRICS = ["pressure"]
 FIRMWARE_KEYS = ["display_fw_version", "cc_fw_version", "inv_fw_version"]
 
 # DHW capacity calculation defaults
-DHW_SHOWER_TEMP_C = 38.0        # Target shower temperature (°C)
-DHW_TANK_VOLUME_L = 235         # Hot water tank volume (L)
+DHW_SHOWER_TEMP_C = 36.0  # Target shower temperature (°C) — per Qvantum app definition
+DHW_TANK_VOLUME_L = 175  # Hot water tank volume (L) — buffer tank per installer spec
 DHW_USABLE_FRACTION = 0.8       # Usable fraction of tank
 DHW_DEFAULT_FLOW_LPM = 7.0      # Default shower flow rate when no recent observation (L/min)
 DHW_DEFAULT_COLD_TEMP_C = 8.0   # Default cold water temperature when no recent observation (°C)

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -225,11 +225,11 @@ FIRMWARE_KEYS = ["display_fw_version", "cc_fw_version", "inv_fw_version"]
 # DHW capacity calculation defaults
 DHW_SHOWER_TEMP_C = 36.0  # Target shower temperature (°C) — per Qvantum app definition
 DHW_TANK_VOLUME_L = 175  # Hot water tank volume (L) — buffer tank per installer spec
-DHW_USABLE_FRACTION = 0.8       # Usable fraction of tank
-DHW_DEFAULT_FLOW_LPM = 7.0      # Default shower flow rate when no recent observation (L/min)
-DHW_DEFAULT_COLD_TEMP_C = 8.0   # Default cold water temperature when no recent observation (°C)
-DHW_TEMP_DROP_FACTOR = 0.75     # Empirical compensation for tank temperature drop during shower
-DHW_SHOWER_DURATION_MIN = 6.0   # Duration of one shower in minutes
+DHW_USABLE_FRACTION = 0.8  # Usable fraction of tank
+DHW_DEFAULT_FLOW_LPM = 7.0  # Default shower flow rate when no recent observation (L/min)
+DHW_DEFAULT_COLD_TEMP_C = 8.0  # Default cold water temperature when no recent observation (°C)
+DHW_TEMP_DROP_FACTOR = 0.75  # Empirical compensation for tank temperature drop during shower
+DHW_SHOWER_DURATION_MIN = 6.0  # Duration of one shower in minutes
 DHW_EMA_ALPHA = (
     0.2  # EMA smoothing factor for tap_water_cap (0=no change, 1=no smoothing)
 )

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -201,6 +201,11 @@ REQUIRED_MODBUS_METRICS = [
     "cooling_kwh",
     "dhw_mwh",
     "dhw_kwh",
+    # Required by tap_water_cap derived metric calculation in Modbus mode
+    "bt30",  # Tank temperature
+    "bt33",  # Cold water inlet temperature
+    "bt34",  # Hot water outlet temperature
+    "bf1_l_min",  # DHW flow rate
 ]
 
 # Sensor type classification

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -74,6 +74,7 @@ DEFAULT_ENABLED_METRICS = [
 DEFAULT_ENABLED_MODBUS_ONLY_METRICS = [
     "heatingpower",  # Derived from heatingenergy delta; only meaningful with fast Modbus polling
     "dhwpower",  # Derived from dhwenergy delta; only meaningful with fast Modbus polling
+    "tap_water_cap",  # Derived from bt30/bt33/bf1_l_min; only computed in Modbus mode
     "smart_dhw_control_status",
     "compressor_state",
     "picpin_relay_pump",
@@ -216,6 +217,18 @@ PRESSURE_METRICS = ["pressure"]
 
 # Firmware component keys
 FIRMWARE_KEYS = ["display_fw_version", "cc_fw_version", "inv_fw_version"]
+
+# DHW capacity calculation defaults
+DHW_SHOWER_TEMP_C = 38.0        # Target shower temperature (°C)
+DHW_TANK_VOLUME_L = 235         # Hot water tank volume (L)
+DHW_USABLE_FRACTION = 0.8       # Usable fraction of tank
+DHW_DEFAULT_FLOW_LPM = 7.0      # Default shower flow rate when no recent observation (L/min)
+DHW_DEFAULT_COLD_TEMP_C = 8.0   # Default cold water temperature when no recent observation (°C)
+DHW_TEMP_DROP_FACTOR = 0.75     # Empirical compensation for tank temperature drop during shower
+DHW_SHOWER_DURATION_MIN = 6.0   # Duration of one shower in minutes
+DHW_EMA_ALPHA = (
+    0.2  # EMA smoothing factor for tap_water_cap (0=no change, 1=no smoothing)
+)
 
 # Tap water capacity mappings (start, stop) -> capacity
 TAP_WATER_CAPACITY_MAPPINGS = {

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -97,7 +97,6 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         self._last_dhwenergy: float | None = None
         self._last_dhwenergy_time: datetime | None = None
         self._last_shower_cold_temp: float | None = None
-        self._last_shower_hot_temp: float | None = None
         self._last_shower_flow_lpm: float | None = None
         self._last_tap_water_cap: float | None = None
 

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -15,6 +15,7 @@ from homeassistant.util import dt as dt_util
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import APIAuthError
+from .calculations import QvantumCalculationsMixin
 from .const import (
     DEFAULT_DISABLED_HTTP_METRICS,
     DEFAULT_DISABLED_MODBUS_METRICS,
@@ -69,7 +70,7 @@ async def handle_setting_update_response(
             coordinator.async_set_updated_data(coordinator.data)
 
 
-class QvantumDataUpdateCoordinator(DataUpdateCoordinator):
+class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinator):
     """Qvantum coordinator."""
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
@@ -95,6 +96,10 @@ class QvantumDataUpdateCoordinator(DataUpdateCoordinator):
         self._last_heatingenergy_time: datetime | None = None
         self._last_dhwenergy: float | None = None
         self._last_dhwenergy_time: datetime | None = None
+        self._last_shower_cold_temp: float | None = None
+        self._last_shower_hot_temp: float | None = None
+        self._last_shower_flow_lpm: float | None = None
+        self._last_tap_water_cap: float | None = None
 
         super().__init__(
             hass,
@@ -303,95 +308,6 @@ class QvantumDataUpdateCoordinator(DataUpdateCoordinator):
                 values.get("tap_water_capacity_target", "none"),
             )
 
-    def _calculate_mode_power(
-        self,
-        values: dict,
-        *,
-        energy_key: str,
-        power_key: str,
-        is_active: Callable[[dict[str, Any]], bool],
-        last_energy_attr: str,
-        last_time_attr: str,
-        mode_label: str,
-    ) -> None:
-        """Derive a mode-specific power metric from an energy counter delta.
-
-        Uses elapsed real time between counter increments (not poll interval).
-        While active mode is on and the counter is unchanged, holds the previously
-        emitted power value. Outside active mode, writes 0 W and resets baseline.
-        Negative deltas (counter resets) are clamped to 0 W.
-        """
-        now = dt_util.utcnow()
-        current_energy = values.get(energy_key)
-        if current_energy is None:
-            return
-
-        prev_power: float = (self.data or {}).get("values", {}).get(power_key, 0.0)
-        last_energy = getattr(self, last_energy_attr)
-        last_time = getattr(self, last_time_attr)
-
-        if not is_active(values):
-            values[power_key] = 0.0
-            setattr(self, last_energy_attr, current_energy)
-            setattr(self, last_time_attr, now)
-            return
-
-        _LOGGER.debug(
-            "Calculating %s power: current_energy=%.6f kWh, last_energy=%s kWh, last_time=%s",
-            mode_label,
-            current_energy,
-            last_energy,
-            last_time,
-        )
-
-        if last_energy is not None and last_time is not None:
-            delta_kwh = current_energy - last_energy
-            delta_seconds = (now - last_time).total_seconds()
-            if delta_kwh != 0 and delta_seconds > 0:
-                # kWh / s -> W: (kWh * 3_600_000 J/kWh) / s = J/s = W
-                power_w = (delta_kwh * 3_600_000) / delta_seconds
-                prev_power = max(0.0, round(power_w, 1))
-                _LOGGER.debug(
-                    "Calculated %s: %.1f W (delta=%.6f kWh over %.1f s)",
-                    power_key,
-                    prev_power,
-                    delta_kwh,
-                    delta_seconds,
-                )
-
-        values[power_key] = prev_power
-
-        if current_energy != last_energy:
-            setattr(self, last_time_attr, now)
-        setattr(self, last_energy_attr, current_energy)
-
-    def _calculate_heating_power(self, values: dict) -> None:
-        """Derive heatingpower (W) from the heatingenergy (kWh) delta between polls."""
-        self._calculate_mode_power(
-            values,
-            energy_key="heatingenergy",
-            power_key="heatingpower",
-            is_active=lambda v: v.get("hp_status") == HP_STATUS_HEATING,
-            last_energy_attr="_last_heatingenergy",
-            last_time_attr="_last_heatingenergy_time",
-            mode_label="heating",
-        )
-
-    def _calculate_dhw_power(self, values: dict) -> None:
-        """Derive dhwpower (W) from the dhwenergy (kWh) delta between polls."""
-        self._calculate_mode_power(
-            values,
-            energy_key="dhwenergy",
-            power_key="dhwpower",
-            # DHW activity is determined by BF1 flow rate rather than hp_status,
-            # because active tap water production is most reliably indicated by
-            # water flow through the DHW circuit.
-            is_active=lambda v: v.get("bf1_l_min", 0) > 0,
-            last_energy_attr="_last_dhwenergy",
-            last_time_attr="_last_dhwenergy_time",
-            mode_label="dhw",
-        )
-
     async def async_update_data(self):
         """Fetch data from API endpoint."""
         try:
@@ -475,6 +391,7 @@ class QvantumDataUpdateCoordinator(DataUpdateCoordinator):
             if self.modbus_enabled:
                 self._calculate_heating_power(values)
                 self._calculate_dhw_power(values)
+                self._calculate_tap_water_cap(values)
 
             _LOGGER.debug("Final values: %s", values)
 

--- a/custom_components/qvantum/sensor.py
+++ b/custom_components/qvantum/sensor.py
@@ -181,7 +181,6 @@ class QvantumBaseSensorEntity(QvantumEntity, SensorEntity):
             self._attr_device_class = SensorDeviceClass.DURATION
             self._attr_suggested_display_precision = 0
         elif "tap_water_cap" == metric_key:
-            self._attr_native_unit_of_measurement = "showers"
             self._attr_suggested_display_precision = 1
         elif "bf1_l_min" == metric_key:
             self._attr_native_unit_of_measurement = "l/m"

--- a/custom_components/qvantum/sensor.py
+++ b/custom_components/qvantum/sensor.py
@@ -181,7 +181,8 @@ class QvantumBaseSensorEntity(QvantumEntity, SensorEntity):
             self._attr_device_class = SensorDeviceClass.DURATION
             self._attr_suggested_display_precision = 0
         elif "tap_water_cap" == metric_key:
-            self._attr_suggested_display_precision = 2
+            self._attr_native_unit_of_measurement = "showers"
+            self._attr_suggested_display_precision = 1
         elif "bf1_l_min" == metric_key:
             self._attr_native_unit_of_measurement = "l/m"
         elif "degree_minute" == metric_key:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1178,37 +1178,32 @@ class TestCalculateTapWaterCap:
         assert values["tap_water_cap"] == pytest.approx(5.8, abs=0.1)
 
     def test_updates_baseline_on_flow(self):
-        """When bf1_l_min > 0.1, cold and hot snapshots are EMA-smoothed from their priors."""
+        """When bf1_l_min > 0.1, cold and flow snapshots are EMA-smoothed from their priors."""
         coordinator = self._make_coordinator()
-        values = {"bt30": 60.0, "bf1_l_min": 6.5, "bt33": 12.0, "bt34": 48.0}
+        values = {"bt30": 60.0, "bf1_l_min": 6.5, "bt33": 12.0}
         coordinator._calculate_tap_water_cap(values)
         # cold: 0.2 * 12.0 + 0.8 * 8.0 = 8.8 (EMA from DHW_DEFAULT_COLD_TEMP_C prior)
         assert coordinator._last_shower_cold_temp == pytest.approx(8.8)
-        # hot: 0.2 * 48.0 + 0.8 * 60.0 = 57.6 (EMA from bt30 prior, avoids cold pipe transient)
-        assert coordinator._last_shower_hot_temp == pytest.approx(57.6)
         # flow: 0.2 * 6.5 + 0.8 * 7.0 = 6.9 (EMA from DHW_DEFAULT_FLOW_LPM prior)
         assert coordinator._last_shower_flow_lpm == pytest.approx(6.9)
 
-    def test_uses_bt34_when_available(self):
-        """When bt34 is observed during flow, it is EMA-blended from bt30 prior and used as effective hot temp."""
-        coordinator = self._make_coordinator()
-        # First poll: showering — hot_out=48 EMA-seeded from bt30=60: 0.2*48 + 0.8*60 = 57.6
-        coordinator._calculate_tap_water_cap(
-            {"bt30": 60.0, "bf1_l_min": 7.0, "bt33": 10.0, "bt34": 48.0}
-        )
-        assert coordinator._last_shower_hot_temp == pytest.approx(57.6)
-        # Second poll: no flow — effective_hot=57.6 (lower than bt30=60, showing bt34 influence)
-        values = {"bt30": 60.0, "bf1_l_min": 0.0}
-        coordinator._calculate_tap_water_cap(values)
-        # effective_hot=57.6, cold=8.4 (0.2*10+0.8*8), flow=7.0 (EMA of 7.0 from 7.0 default = 7.0)
-        # hot_fraction = (38 - 8.4) / (57.6 - 8.4) = 29.6/49.2 ≈ 0.602
-        # hot_per_min = 7.0 * 0.602 ≈ 4.211
-        # minutes = (235 * 0.8 / 4.211) * 0.75 ≈ 33.5
-        # showers = 33.5 / 6 ≈ 5.58 -> rounded to 5.6
-        result_with_bt34 = values["tap_water_cap"]
-        assert result_with_bt34 == pytest.approx(5.6, abs=0.1)
-        # Verify bt34 lowered the estimate vs using bt30 alone (bt30 alone ≈ 5.9)
-        assert result_with_bt34 < 5.9
+    def test_capacity_decreases_as_tank_drains(self):
+        """Capacity decreases as tank_temp drops, reflecting actual hot water consumption."""
+        # Full tank: bt30=60°C
+        coordinator_full = self._make_coordinator()
+        values_full = {"bt30": 60.0, "bf1_l_min": 0.0}
+        coordinator_full._calculate_tap_water_cap(values_full)
+        cap_full = values_full["tap_water_cap"]
+
+        # Partially drained tank: bt30=45°C
+        coordinator_half = self._make_coordinator()
+        values_half = {"bt30": 45.0, "bf1_l_min": 0.0}
+        coordinator_half._calculate_tap_water_cap(values_half)
+        cap_half = values_half["tap_water_cap"]
+
+        # Capacity must decrease as tank drains — this was the key bug: bt34 rising
+        # during a shower caused capacity to appear to increase instead of decrease.
+        assert cap_full > cap_half
 
     def test_uses_stored_cold_temp_when_no_flow(self):
         """After flow has stopped, EMA-smoothed cold/flow values are used for the calculation."""
@@ -1219,7 +1214,7 @@ class TestCalculateTapWaterCap:
         coordinator._calculate_tap_water_cap({"bt30": 60.0, "bf1_l_min": 6.0, "bt33": 10.0})
         assert coordinator._last_shower_cold_temp == pytest.approx(8.4)
         assert coordinator._last_shower_flow_lpm == pytest.approx(6.8)
-        # Second poll: no flow — uses cold=8.4, flow=6.8, effective_hot=bt30=60 (no bt34 snapshot)
+        # Second poll: no flow — uses cold=8.4, flow=6.8, effective_hot=bt30=60 (tank_temp)
         values = {"bt30": 60.0, "bf1_l_min": 0.0}
         coordinator._calculate_tap_water_cap(values)
         # hot_fraction = (38 - 8.4) / (60 - 8.4) = 29.6/51.6 ≈ 0.574

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1170,12 +1170,12 @@ class TestCalculateTapWaterCap:
         coordinator = self._make_coordinator()
         values = {"bt30": 60.0, "bf1_l_min": 0.0}
         coordinator._calculate_tap_water_cap(values)
-        # hot_fraction = (38 - 8) / (60 - 8) = 30/52 ≈ 0.5769
-        # hot_per_min = 7 * 0.5769 ≈ 4.038
-        # minutes = (235 * 0.8 / 4.038) * 0.75 ≈ 34.9
-        # showers = 34.9 / 6 ≈ 5.82 -> rounded to 5.8
+        # hot_fraction = (36 - 8) / (60 - 8) = 28/52 ≈ 0.5385
+        # hot_per_min = 7 * 0.5385 ≈ 3.769
+        # minutes = (175 * 0.8 / 3.769) * 0.75 ≈ 27.9
+        # showers = 27.9 / 6 ≈ 4.64 -> rounded to 4.6
         assert "tap_water_cap" in values
-        assert values["tap_water_cap"] == pytest.approx(5.8, abs=0.1)
+        assert values["tap_water_cap"] == pytest.approx(4.6, abs=0.1)
 
     def test_updates_baseline_on_flow(self):
         """When bf1_l_min > 0.1, cold and flow snapshots are EMA-smoothed from their priors."""
@@ -1217,11 +1217,11 @@ class TestCalculateTapWaterCap:
         # Second poll: no flow — uses cold=8.4, flow=6.8, effective_hot=bt30=60 (tank_temp)
         values = {"bt30": 60.0, "bf1_l_min": 0.0}
         coordinator._calculate_tap_water_cap(values)
-        # hot_fraction = (38 - 8.4) / (60 - 8.4) = 29.6/51.6 ≈ 0.574
-        # hot_per_min = 6.8 * 0.574 ≈ 3.901
-        # minutes = (235 * 0.8 / 3.901) * 0.75 ≈ 36.1
-        # showers = 36.1 / 6 ≈ 6.02 -> rounded to 6.0
-        assert values["tap_water_cap"] == pytest.approx(6.0, abs=0.1)
+        # hot_fraction = (36 - 8.4) / (60 - 8.4) = 27.6/51.6 ≈ 0.535
+        # hot_per_min = 6.8 * 0.535 ≈ 3.637
+        # minutes = (175 * 0.8 / 3.637) * 0.75 ≈ 28.9
+        # showers = 28.9 / 6 ≈ 4.81 -> rounded to 4.8
+        assert values["tap_water_cap"] == pytest.approx(4.8, abs=0.1)
 
     def test_low_tank_temp_returns_zero(self):
         """When tank_temp - cold_temp < 5, tap_water_cap is set to 0.0."""
@@ -1239,11 +1239,11 @@ class TestCalculateTapWaterCap:
         coordinator._calculate_tap_water_cap(values1)
         first = values1["tap_water_cap"]
 
-        # Second poll: slightly lower tank temp
-        values2 = {"bt30": 55.0, "bf1_l_min": 0.0}
+        # Second poll: lower tank temp
+        values2 = {"bt30": 50.0, "bf1_l_min": 0.0}
         coordinator._calculate_tap_water_cap(values2)
         second = values2["tap_water_cap"]
-        # raw_second is about 5.1 with bt30=55, cold=8, flow=7
+        # raw_second ≈ 3.75 with bt30=50, cold=8, flow=7
         # EMA should stay between the new raw value and the previous reading
         assert second < first  # moved in the right direction
-        assert second > 5.57  # did not jump all the way to the raw value
+        assert second > 3.9  # did not jump all the way to the raw value

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1138,3 +1138,117 @@ class TestCalculateDhwPower:
             coordinator._calculate_dhw_power(values)
 
         assert values["dhwpower"] == 240.0
+
+
+class TestCalculateTapWaterCap:
+    """Tests for _calculate_tap_water_cap."""
+
+    def _make_coordinator(self):
+        with patch(
+            "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__",
+            return_value=None,
+        ):
+            mock_hass = MagicMock()
+            mock_hass.data = {DOMAIN: MagicMock()}
+            mock_config_entry = MagicMock()
+            mock_config_entry.options.get.side_effect = lambda key, default=None: default
+            mock_config_entry.data = {}
+            mock_config_entry.unique_id = "test_device_123"
+            coordinator = QvantumDataUpdateCoordinator(mock_hass, mock_config_entry)
+            coordinator.data = None
+        return coordinator
+
+    def test_missing_tank_temp_skips(self):
+        """When bt30 is absent, tap_water_cap is not written."""
+        coordinator = self._make_coordinator()
+        values = {"bt33": 8.0, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(values)
+        assert "tap_water_cap" not in values
+
+    def test_first_poll_uses_defaults(self):
+        """With no prior shower snapshot, defaults are used: bt30=60, cold=8, flow=7."""
+        coordinator = self._make_coordinator()
+        values = {"bt30": 60.0, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(values)
+        # hot_fraction = (38 - 8) / (60 - 8) = 30/52 ≈ 0.5769
+        # hot_per_min = 7 * 0.5769 ≈ 4.038
+        # minutes = (235 * 0.8 / 4.038) * 0.75 ≈ 34.9
+        # showers = 34.9 / 6 ≈ 5.82 -> rounded to 5.8
+        assert "tap_water_cap" in values
+        assert values["tap_water_cap"] == pytest.approx(5.8, abs=0.1)
+
+    def test_updates_baseline_on_flow(self):
+        """When bf1_l_min > 0.1, cold and hot snapshots are EMA-smoothed from their priors."""
+        coordinator = self._make_coordinator()
+        values = {"bt30": 60.0, "bf1_l_min": 6.5, "bt33": 12.0, "bt34": 48.0}
+        coordinator._calculate_tap_water_cap(values)
+        # cold: 0.2 * 12.0 + 0.8 * 8.0 = 8.8 (EMA from DHW_DEFAULT_COLD_TEMP_C prior)
+        assert coordinator._last_shower_cold_temp == pytest.approx(8.8)
+        # hot: 0.2 * 48.0 + 0.8 * 60.0 = 57.6 (EMA from bt30 prior, avoids cold pipe transient)
+        assert coordinator._last_shower_hot_temp == pytest.approx(57.6)
+        # flow: 0.2 * 6.5 + 0.8 * 7.0 = 6.9 (EMA from DHW_DEFAULT_FLOW_LPM prior)
+        assert coordinator._last_shower_flow_lpm == pytest.approx(6.9)
+
+    def test_uses_bt34_when_available(self):
+        """When bt34 is observed during flow, it is EMA-blended from bt30 prior and used as effective hot temp."""
+        coordinator = self._make_coordinator()
+        # First poll: showering — hot_out=48 EMA-seeded from bt30=60: 0.2*48 + 0.8*60 = 57.6
+        coordinator._calculate_tap_water_cap(
+            {"bt30": 60.0, "bf1_l_min": 7.0, "bt33": 10.0, "bt34": 48.0}
+        )
+        assert coordinator._last_shower_hot_temp == pytest.approx(57.6)
+        # Second poll: no flow — effective_hot=57.6 (lower than bt30=60, showing bt34 influence)
+        values = {"bt30": 60.0, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(values)
+        # effective_hot=57.6, cold=8.4 (0.2*10+0.8*8), flow=7.0 (EMA of 7.0 from 7.0 default = 7.0)
+        # hot_fraction = (38 - 8.4) / (57.6 - 8.4) = 29.6/49.2 ≈ 0.602
+        # hot_per_min = 7.0 * 0.602 ≈ 4.211
+        # minutes = (235 * 0.8 / 4.211) * 0.75 ≈ 33.5
+        # showers = 33.5 / 6 ≈ 5.58 -> rounded to 5.6
+        result_with_bt34 = values["tap_water_cap"]
+        assert result_with_bt34 == pytest.approx(5.6, abs=0.1)
+        # Verify bt34 lowered the estimate vs using bt30 alone (bt30 alone ≈ 5.9)
+        assert result_with_bt34 < 5.9
+
+    def test_uses_stored_cold_temp_when_no_flow(self):
+        """After flow has stopped, EMA-smoothed cold/flow values are used for the calculation."""
+        coordinator = self._make_coordinator()
+        # First poll: showering
+        # cold: 0.2*10 + 0.8*8 = 8.4 (EMA from DHW_DEFAULT_COLD_TEMP_C)
+        # flow: 0.2*6.0 + 0.8*7.0 = 6.8 (EMA from DHW_DEFAULT_FLOW_LPM)
+        coordinator._calculate_tap_water_cap({"bt30": 60.0, "bf1_l_min": 6.0, "bt33": 10.0})
+        assert coordinator._last_shower_cold_temp == pytest.approx(8.4)
+        assert coordinator._last_shower_flow_lpm == pytest.approx(6.8)
+        # Second poll: no flow — uses cold=8.4, flow=6.8, effective_hot=bt30=60 (no bt34 snapshot)
+        values = {"bt30": 60.0, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(values)
+        # hot_fraction = (38 - 8.4) / (60 - 8.4) = 29.6/51.6 ≈ 0.574
+        # hot_per_min = 6.8 * 0.574 ≈ 3.901
+        # minutes = (235 * 0.8 / 3.901) * 0.75 ≈ 36.1
+        # showers = 36.1 / 6 ≈ 6.02 -> rounded to 6.0
+        assert values["tap_water_cap"] == pytest.approx(6.0, abs=0.1)
+
+    def test_low_tank_temp_returns_zero(self):
+        """When tank_temp - cold_temp < 5, tap_water_cap is set to 0.0."""
+        coordinator = self._make_coordinator()
+        # default cold = 8, so tank = 12 gives delta = 4 < 5
+        values = {"bt30": 12.0, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(values)
+        assert values["tap_water_cap"] == 0.0
+
+    def test_ema_smooths_output(self):
+        """Second poll blends toward new value rather than jumping immediately."""
+        coordinator = self._make_coordinator()
+        # First poll: no prior EMA state → raw value used as-is
+        values1 = {"bt30": 60.0, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(values1)
+        first = values1["tap_water_cap"]  # ≈ 6.23
+
+        # Second poll: slightly lower tank temp
+        values2 = {"bt30": 55.0, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(values2)
+        second = values2["tap_water_cap"]
+        # raw_second ≈ 5.57 (bt30=55, cold=8, flow=7)
+        # EMA: 0.2 * 5.57 + 0.8 * 6.23 ≈ 6.10
+        assert second < first  # moved in the right direction
+        assert second > 5.57  # did not jump all the way to the raw value

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1239,16 +1239,16 @@ class TestCalculateTapWaterCap:
     def test_ema_smooths_output(self):
         """Second poll blends toward new value rather than jumping immediately."""
         coordinator = self._make_coordinator()
-        # First poll: no prior EMA state → raw value used as-is
+        # First poll: no prior EMA state → raw value used as-is (about 5.8 with defaults)
         values1 = {"bt30": 60.0, "bf1_l_min": 0.0}
         coordinator._calculate_tap_water_cap(values1)
-        first = values1["tap_water_cap"]  # ≈ 6.23
+        first = values1["tap_water_cap"]
 
         # Second poll: slightly lower tank temp
         values2 = {"bt30": 55.0, "bf1_l_min": 0.0}
         coordinator._calculate_tap_water_cap(values2)
         second = values2["tap_water_cap"]
-        # raw_second ≈ 5.57 (bt30=55, cold=8, flow=7)
-        # EMA: 0.2 * 5.57 + 0.8 * 6.23 ≈ 6.10
+        # raw_second is about 5.1 with bt30=55, cold=8, flow=7
+        # EMA should stay between the new raw value and the previous reading
         assert second < first  # moved in the right direction
         assert second > 5.57  # did not jump all the way to the raw value

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -886,7 +886,7 @@ class TestCalculateHeatingPower:
         coordinator = self._make_coordinator()
         values = {"heatingenergy": 100.0, "hp_status": 3}
 
-        with patch("custom_components.qvantum.coordinator.dt_util.utcnow") as mock_now:
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as mock_now:
             mock_now.return_value = datetime(2026, 4, 6, 12, 0, 0, tzinfo=timezone.utc)
             coordinator._calculate_heating_power(values)
 
@@ -899,7 +899,7 @@ class TestCalculateHeatingPower:
         t0 = datetime(2026, 4, 6, 12, 0, 0, tzinfo=timezone.utc)
         t1 = datetime(2026, 4, 6, 12, 0, 15, tzinfo=timezone.utc)  # 15 s later
 
-        with patch("custom_components.qvantum.coordinator.dt_util.utcnow") as mock_now:
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as mock_now:
             mock_now.return_value = t0
             coordinator._calculate_heating_power({"heatingenergy": 100.0, "hp_status": 3})
 
@@ -916,7 +916,7 @@ class TestCalculateHeatingPower:
         t0 = datetime(2026, 4, 6, 12, 0, 0, tzinfo=timezone.utc)
         t1 = datetime(2026, 4, 6, 12, 0, 15, tzinfo=timezone.utc)
 
-        with patch("custom_components.qvantum.coordinator.dt_util.utcnow") as mock_now:
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as mock_now:
             mock_now.return_value = t0
             coordinator._calculate_heating_power({"heatingenergy": 100.0, "hp_status": 3})
 
@@ -932,7 +932,7 @@ class TestCalculateHeatingPower:
         t0 = datetime(2026, 4, 6, 12, 0, 0, tzinfo=timezone.utc)
         t1 = datetime(2026, 4, 6, 12, 0, 15, tzinfo=timezone.utc)
 
-        with patch("custom_components.qvantum.coordinator.dt_util.utcnow") as mock_now:
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as mock_now:
             # Establish a prior computed power
             mock_now.return_value = t0
             coordinator._calculate_heating_power({"heatingenergy": 100.0, "hp_status": 3})
@@ -964,7 +964,7 @@ class TestCalculateHeatingPower:
         t1 = datetime(2026, 4, 6, 12, 0, 15, tzinfo=timezone.utc)
         t2 = datetime(2026, 4, 6, 12, 0, 30, tzinfo=timezone.utc)
 
-        with patch("custom_components.qvantum.coordinator.dt_util.utcnow") as mock_now:
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as mock_now:
             mock_now.return_value = t0
             coordinator._calculate_heating_power({"heatingenergy": 100.0, "hp_status": 3})
 
@@ -989,7 +989,7 @@ class TestCalculateHeatingPower:
         t0 = datetime(2026, 4, 6, 12, 0, 0, tzinfo=timezone.utc)
         t1 = datetime(2026, 4, 6, 12, 0, 15, tzinfo=timezone.utc)
 
-        with patch("custom_components.qvantum.coordinator.dt_util.utcnow") as mock_now:
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as mock_now:
             mock_now.return_value = t0
             coordinator._calculate_heating_power({"heatingenergy": 50.0, "hp_status": 3})
             assert coordinator._last_heatingenergy == 50.0
@@ -1010,7 +1010,7 @@ class TestCalculateHeatingPower:
         coordinator = self._make_coordinator()
         t0 = datetime(2026, 4, 6, 12, 0, 0, tzinfo=timezone.utc)
 
-        with patch("custom_components.qvantum.coordinator.dt_util.utcnow") as mock_now:
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as mock_now:
             # Poll 1: establish baseline
             mock_now.return_value = t0
             coordinator._calculate_heating_power({"heatingenergy": 100.0, "hp_status": 3})
@@ -1062,7 +1062,7 @@ class TestCalculateDhwPower:
         coordinator = self._make_coordinator()
         values = {"dhwenergy": 100.0, "bf1_l_min": 5.0}
 
-        with patch("custom_components.qvantum.coordinator.dt_util.utcnow") as mock_now:
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as mock_now:
             mock_now.return_value = datetime(2026, 4, 6, 12, 0, 0, tzinfo=timezone.utc)
             coordinator._calculate_dhw_power(values)
 
@@ -1075,7 +1075,7 @@ class TestCalculateDhwPower:
         t0 = datetime(2026, 4, 6, 12, 0, 0, tzinfo=timezone.utc)
         t1 = datetime(2026, 4, 6, 12, 0, 15, tzinfo=timezone.utc)
 
-        with patch("custom_components.qvantum.coordinator.dt_util.utcnow") as mock_now:
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as mock_now:
             mock_now.return_value = t0
             coordinator._calculate_dhw_power({"dhwenergy": 100.0, "bf1_l_min": 5.0})
 
@@ -1092,7 +1092,7 @@ class TestCalculateDhwPower:
         t1 = datetime(2026, 4, 6, 12, 0, 15, tzinfo=timezone.utc)
         t1_same = t1  # intentionally same timestamp: this assertion is mode-switch, not time-delta based
 
-        with patch("custom_components.qvantum.coordinator.dt_util.utcnow") as mock_now:
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as mock_now:
             mock_now.return_value = t0
             coordinator._calculate_dhw_power({"dhwenergy": 100.0, "bf1_l_min": 5.0})
             mock_now.return_value = t1
@@ -1122,7 +1122,7 @@ class TestCalculateDhwPower:
         t1 = datetime(2026, 4, 6, 12, 0, 15, tzinfo=timezone.utc)
         t2 = datetime(2026, 4, 6, 12, 0, 30, tzinfo=timezone.utc)
 
-        with patch("custom_components.qvantum.coordinator.dt_util.utcnow") as mock_now:
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as mock_now:
             mock_now.return_value = t0
             coordinator._calculate_dhw_power({"dhwenergy": 100.0, "bf1_l_min": 5.0})
 


### PR DESCRIPTION
This pull request introduces a new derived metric, `tap_water_cap`, which estimates the number of showers remaining based on hot water tank and flow sensor data. The calculation logic is extracted into a new mixin, improving code organization and testability. Several constants and sensor keys are added to support the new metric, and extensive unit tests are included to verify correct behavior and edge cases.

**Key changes:**

**Feature: Tap Water Capacity Calculation**
* Added `QvantumCalculationsMixin` with `_calculate_tap_water_cap` method to compute `tap_water_cap` (showers remaining) using tank temperature, cold water inlet, and flow rate, including EMA smoothing for realistic estimates. This logic replaces previous calculations and ensures capacity decreases as hot water is consumed. (`custom_components/qvantum/calculations.py`, `custom_components/qvantum/coordinator.py`) [[1]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3R1-R219) [[2]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fR18) [[3]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fL72-R73) [[4]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fR99-R101) [[5]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fL306-L394) [[6]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fR393)

**Configuration and Constants**
* Introduced new constants for the tap water capacity calculation (e.g., shower temperature, tank volume, EMA alpha) and added relevant sensor keys (`bt30`, `bt33`, `bf1_l_min`) to the Modbus metric list. (`custom_components/qvantum/const.py`) [[1]](diffhunk://#diff-07fd7ac76e58c80e95bb6c9ca3ff34f8c124f4a881a23cd946cfefaa5719e953R77) [[2]](diffhunk://#diff-07fd7ac76e58c80e95bb6c9ca3ff34f8c124f4a881a23cd946cfefaa5719e953R204-R207) [[3]](diffhunk://#diff-07fd7ac76e58c80e95bb6c9ca3ff34f8c124f4a881a23cd946cfefaa5719e953R225-R236)

**Sensor Display**
* Adjusted the display precision for the `tap_water_cap` sensor to 1 decimal place for a more user-friendly UI. (`custom_components/qvantum/sensor.py`)

**Testing**
* Added comprehensive unit tests for the tap water capacity calculation, covering default behavior, EMA smoothing, tank depletion, and edge cases. (`tests/test_coordinator.py`)

Fixes #124 