### PR TITLE
fix: update translation for "time to defrost" in multiple languages

### DIFF
--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -131,7 +131,7 @@
         "name": "Zusatzbedarf DHW"
       },
       "time_to_defrost": {
-        "name": "Zeit bis zum Abtauen"
+        "name": "Zeit zum Abtauen"
       }
     },
     "sensor": {

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -131,7 +131,7 @@
         "name": "Demanda adicional ACS"
       },
       "time_to_defrost": {
-        "name": "Tiempo hasta descongelación"
+        "name": "Tiempo de descongelación"
       }
     },
     "sensor": {

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -131,7 +131,7 @@
         "name": "Demande d'appoint eau chaude"
       },
       "time_to_defrost": {
-        "name": "Temps jusqu'au dégivrage"
+        "name": "Temps de dégivrage"
       }
     },
     "sensor": {

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -131,7 +131,7 @@
         "name": "Rásegítési használati melegvíz igény"
       },
       "time_to_defrost": {
-        "name": "Idő a leolvasztásig"
+        "name": "Leolvasztás ideje"
       }
     },
     "sensor": {

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -131,7 +131,7 @@
         "name": "Extra DHW vraag"
       },
       "time_to_defrost": {
-        "name": "Tijd tot ontdooien"
+        "name": "Tijd om te ontdooien"
       }
     },
     "sensor": {

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -131,7 +131,7 @@
         "name": "Zapotrzebowanie na dogrzewanie ciepłej wody"
       },
       "time_to_defrost": {
-        "name": "Czas do odszraniania"
+        "name": "Czas rozmrażania"
       }
     },
     "sensor": {

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -134,7 +134,7 @@
         "name": "Tillsatsbehov Varmvatten"
       },
       "time_to_defrost": {
-        "name": "Tid till avfrostning"
+        "name": "Tid för avfrostning"
       }
     },
     "sensor": {


### PR DESCRIPTION
This pull request updates the translation for the "time_to_defrost" label in several language files to use a more accurate or natural phrasing. The changes ensure consistency and better readability across different languages.

Translation updates for "time_to_defrost":

* Changed the label to a more natural phrasing in the following translation files:
  - German (`de.json`): from "Zeit bis zum Abtauen" to "Zeit zum Abtauen"
  - Spanish (`es.json`): from "Tiempo hasta descongelación" to "Tiempo de descongelación"
  - French (`fr.json`): from "Temps jusqu'au dégivrage" to "Temps de dégivrage"
  - Hungarian (`hu.json`): from "Idő a leolvasztásig" to "Leolvasztás ideje"
  - Dutch (`nl.json`): from "Tijd tot ontdooien" to "Tijd om te ontdooien"
  - Polish (`pl.json`): from "Czas do odszraniania" to "Czas rozmrażania"
  - Swedish (`sv.json`): from "Tid till avfrostning" to "Tid för avfrostning"