### PR TITLE
feat: add tap water minutes calculation and update translations

### DIFF
--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -195,7 +195,7 @@ class QvantumCalculationsMixin:
         hot_per_min = flow_lpm * hot_fraction
         if hot_per_min <= 0:
             values["tap_water_cap"] = 0.0
-            values["tap_water_minutes"] = 0.0
+            values["tap_water_minutes"] = 0
             return
 
         minutes = (

--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -181,11 +181,13 @@ class QvantumCalculationsMixin:
             or cold_temp >= DHW_SHOWER_TEMP_C
         ):
             values["tap_water_cap"] = 0.0
+            values["tap_water_minutes"] = 0.0
             return
 
         delta_available = effective_hot_temp - cold_temp
         if delta_available < DHW_MIN_TEMPERATURE_DELTA_C:
             values["tap_water_cap"] = 0.0
+            values["tap_water_minutes"] = 0.0
             return
 
         hot_fraction = (DHW_SHOWER_TEMP_C - cold_temp) / delta_available
@@ -193,6 +195,7 @@ class QvantumCalculationsMixin:
         hot_per_min = flow_lpm * hot_fraction
         if hot_per_min <= 0:
             values["tap_water_cap"] = 0.0
+            values["tap_water_minutes"] = 0.0
             return
 
         minutes = (
@@ -207,13 +210,15 @@ class QvantumCalculationsMixin:
         else:
             smoothed = raw_showers
         self._last_tap_water_cap = smoothed
-        # Publish the derived value rounded to the sensor's display precision
+        # Publish the derived values rounded to the sensor's display precision
         # so small fluctuations do not cause UI flicker between updates. Keep
         # the EMA state in full precision for subsequent calculations.
         values["tap_water_cap"] = round(smoothed, 1)
+        values["tap_water_minutes"] = round(minutes)
         _LOGGER.debug(
-            "Calculated tap_water_cap=%.2f showers (raw=%.2f, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min)",
+            "Calculated tap_water_cap=%.2f showers (%d min, raw=%.2f, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min)",
             smoothed,
+            round(minutes),
             raw_showers,
             tank_temp,
             cold_temp,

--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -181,13 +181,13 @@ class QvantumCalculationsMixin:
             or cold_temp >= DHW_SHOWER_TEMP_C
         ):
             values["tap_water_cap"] = 0.0
-            values["tap_water_minutes"] = 0.0
+            values["tap_water_minutes"] = 0
             return
 
         delta_available = effective_hot_temp - cold_temp
         if delta_available < DHW_MIN_TEMPERATURE_DELTA_C:
             values["tap_water_cap"] = 0.0
-            values["tap_water_minutes"] = 0.0
+            values["tap_water_minutes"] = 0
             return
 
         hot_fraction = (DHW_SHOWER_TEMP_C - cold_temp) / delta_available
@@ -210,15 +210,16 @@ class QvantumCalculationsMixin:
         else:
             smoothed = raw_showers
         self._last_tap_water_cap = smoothed
+        smoothed_minutes = smoothed * DHW_SHOWER_DURATION_MIN
         # Publish the derived values rounded to the sensor's display precision
         # so small fluctuations do not cause UI flicker between updates. Keep
         # the EMA state in full precision for subsequent calculations.
         values["tap_water_cap"] = round(smoothed, 1)
-        values["tap_water_minutes"] = round(minutes)
+        values["tap_water_minutes"] = round(smoothed_minutes)
         _LOGGER.debug(
             "Calculated tap_water_cap=%.2f showers (%d min, raw=%.2f, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min)",
             smoothed,
-            round(minutes),
+            round(smoothed_minutes),
             raw_showers,
             tank_temp,
             cold_temp,

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -75,6 +75,7 @@ DEFAULT_ENABLED_MODBUS_ONLY_METRICS = [
     "heatingpower",  # Derived from heatingenergy delta; only meaningful with fast Modbus polling
     "dhwpower",  # Derived from dhwenergy delta; only meaningful with fast Modbus polling
     "tap_water_cap",  # Derived from bt30/bt33/bf1_l_min; only computed in Modbus mode
+    "tap_water_minutes",  # Minutes of hot water remaining; companion to tap_water_cap
     "smart_dhw_control_status",
     "compressor_state",
     "picpin_relay_pump",

--- a/custom_components/qvantum/sensor.py
+++ b/custom_components/qvantum/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfTemperature,
     UnitOfPower,
+    UnitOfTime,
     EntityCategory,
     UnitOfPressure,
     UnitOfElectricCurrent,
@@ -182,6 +183,10 @@ class QvantumBaseSensorEntity(QvantumEntity, SensorEntity):
             self._attr_suggested_display_precision = 0
         elif "tap_water_cap" == metric_key:
             self._attr_suggested_display_precision = 1
+        elif "tap_water_minutes" == metric_key:
+            self._attr_native_unit_of_measurement = UnitOfTime.MINUTES
+            self._attr_device_class = SensorDeviceClass.DURATION
+            self._attr_suggested_display_precision = 0
         elif "bf1_l_min" == metric_key:
             self._attr_native_unit_of_measurement = "l/m"
         elif "degree_minute" == metric_key:

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -348,6 +348,9 @@
       "tap_water_cap": {
         "name": "Brauchwasserkapazität"
       },
+      "tap_water_minutes": {
+        "name": "Verbleibende Brauchwasserzeit"
+      },
       "additionalenergy": {
         "name": "Zusätzliche Energie"
       },

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -348,6 +348,9 @@
       "tap_water_cap": {
         "name": "Hot water capacity"
       },
+      "tap_water_minutes": {
+        "name": "Hot water remaining"
+      },
       "additionalenergy": {
         "name": "Additional energy"
       },

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -348,6 +348,9 @@
       "tap_water_cap": {
         "name": "Capacidad agua caliente"
       },
+      "tap_water_minutes": {
+        "name": "Agua caliente restante"
+      },
       "additionalenergy": {
         "name": "Energía adicional"
       },

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -347,6 +347,9 @@
       "tap_water_cap": {
         "name": "Capacité eau chaude"
       },
+      "tap_water_minutes": {
+        "name": "Eau chaude restante"
+      },
       "additionalenergy": {
         "name": "Énergie d'appoint"
       },

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -347,6 +347,9 @@
       "tap_water_cap": {
         "name": "Melegvíz kapacitás"
       },
+      "tap_water_minutes": {
+        "name": "Melegvíz hátralévő"
+      },
       "additionalenergy": {
         "name": "Rásegítési energia"
       },

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -348,6 +348,9 @@
       "tap_water_cap": {
         "name": "Warmwater capaciteit"
       },
+      "tap_water_minutes": {
+        "name": "Warmwater resterend"
+      },
       "additionalenergy": {
         "name": "Extra energie"
       },

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -347,6 +347,9 @@
       "tap_water_cap": {
         "name": "Pojemność ciepłej wody"
       },
+      "tap_water_minutes": {
+        "name": "Pozostała ciepła woda"
+      },
       "additionalenergy": {
         "name": "Energia dogrzewania"
       },

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -359,6 +359,9 @@
       "tap_water_cap": {
         "name": "Varmvattenkapacitet"
       },
+      "tap_water_minutes": {
+        "name": "Återstående varmvatten"
+      },
       "additionalenergy": {
         "name": "Tillsatsenergi"
       },

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1164,6 +1164,7 @@ class TestCalculateTapWaterCap:
         values = {"bt33": 8.0, "bf1_l_min": 0.0}
         coordinator._calculate_tap_water_cap(values)
         assert "tap_water_cap" not in values
+        assert "tap_water_minutes" not in values
 
     def test_first_poll_uses_defaults(self):
         """With no prior shower snapshot, defaults are used: bt30=60, cold=8, flow=7."""
@@ -1176,6 +1177,7 @@ class TestCalculateTapWaterCap:
         # showers = 26.0 / 6 ≈ 4.33 -> rounded to 4.3
         assert "tap_water_cap" in values
         assert values["tap_water_cap"] == pytest.approx(4.3, abs=0.1)
+        assert values["tap_water_minutes"] == 26
 
     def test_updates_baseline_on_flow(self):
         """When bf1_l_min > 0.1, cold and flow snapshots are EMA-smoothed from their priors."""
@@ -1222,6 +1224,7 @@ class TestCalculateTapWaterCap:
         # minutes = (175 * 0.8 / 3.904) * 0.75 ≈ 26.9
         # showers = 26.9 / 6 ≈ 4.48 -> rounded to 4.5
         assert values["tap_water_cap"] == pytest.approx(4.5, abs=0.1)
+        assert values["tap_water_minutes"] == 27
 
     def test_low_tank_temp_returns_zero(self):
         """When tank_temp - cold_temp < 5, tap_water_cap is set to 0.0."""
@@ -1230,6 +1233,7 @@ class TestCalculateTapWaterCap:
         values = {"bt30": 12.0, "bf1_l_min": 0.0}
         coordinator._calculate_tap_water_cap(values)
         assert values["tap_water_cap"] == 0.0
+        assert values["tap_water_minutes"] == 0
 
     def test_ema_smooths_output(self):
         """Second poll blends toward new value rather than jumping immediately."""

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -13,6 +13,7 @@ from custom_components.qvantum.const import (
     DEFAULT_ENABLED_HTTP_METRICS,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    DHW_SHOWER_DURATION_MIN,
     REQUIRED_METRICS,
 )
 from homeassistant.const import CONF_SCAN_INTERVAL
@@ -1225,6 +1226,18 @@ class TestCalculateTapWaterCap:
         # showers = 26.9 / 6 ≈ 4.48 -> rounded to 4.5
         assert values["tap_water_cap"] == pytest.approx(4.5, abs=0.1)
         assert values["tap_water_minutes"] == 27
+        assert values["tap_water_minutes"] == round(
+            values["tap_water_cap"] * DHW_SHOWER_DURATION_MIN
+        )
+
+    def test_tap_water_minutes_matches_smoothed_capacity(self):
+        """tap_water_minutes is derived from the same smoothed tap_water_cap estimate."""
+        coordinator = self._make_coordinator()
+        values = {"bt30": 60.0, "bf1_l_min": 6.0, "bt33": 10.0}
+        coordinator._calculate_tap_water_cap(values)
+        assert values["tap_water_minutes"] == round(
+            values["tap_water_cap"] * DHW_SHOWER_DURATION_MIN
+        )
 
     def test_low_tank_temp_returns_zero(self):
         """When tank_temp - cold_temp < 5, tap_water_cap is set to 0.0."""


### PR DESCRIPTION
This pull request adds a new metric, `tap_water_minutes`, which represents the estimated minutes of hot water remaining, as a companion to the existing `tap_water_cap` (showers) metric. The implementation includes calculation logic, sensor unit configuration, localization, and test coverage for the new metric.

Key changes:

**Feature Addition: Hot Water Minutes Metric**
* Added calculation and assignment of `tap_water_minutes` in the `_calculate_tap_water_cap` method, ensuring it is set alongside `tap_water_cap` and properly rounded for display. [[1]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3R184-R198) [[2]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3L210-R221)
* Registered `tap_water_minutes` as a metric in `const.py`.

**Sensor Configuration**
* Configured `tap_water_minutes` with appropriate unit (`minutes`), device class (`duration`), and display precision in the sensor setup. [[1]](diffhunk://#diff-af82684eb729ea8867a212d272993cdb20328a4a110bbe9fac584d00de299299R16) [[2]](diffhunk://#diff-af82684eb729ea8867a212d272993cdb20328a4a110bbe9fac584d00de299299R186-R189)

**Localization**
* Added translations for `tap_water_minutes` in all supported languages (de, en, es, fr, hu, nl, pl, sv). [[1]](diffhunk://#diff-c38b12eee4843bd1f813526f2a1d519a00e26c744de32799eae5b19f0e992a4fR351-R353) [[2]](diffhunk://#diff-acfc3b0627ed2bb0327c528addfe1335670f607c305117c84c6eaf8b8c31e780R351-R353) [[3]](diffhunk://#diff-a2a9672f511a16ec3c1617867055a659f0a84e7689dc79a1eacdb83079fbff37R351-R353) [[4]](diffhunk://#diff-c5fb2d6ea185048b324440f4f45e1ba73623382c7ba888322ba0949fcabb1b9fR350-R352) [[5]](diffhunk://#diff-7a6c968b2fd371d0cc18051be96d7ed737a1d5b731a3c3d9788623a7ef61d91cR350-R352) [[6]](diffhunk://#diff-109634c5949fae269ebe22ad819b8beeaeec637b0fe83e1fcda3b18fb3ba1c0dR351-R353) [[7]](diffhunk://#diff-dbadd40b4bfdf9f26a70958e8813234128be91d97acb995f648fa34b5ca7e3a3R350-R352) [[8]](diffhunk://#diff-17731185892f92368a0a463c8d218030c11e775fab898134846ab991a29440f0R362-R364)

**Testing**
* Updated and added tests to verify correct calculation and handling of `tap_water_minutes` in various scenarios, including missing data, default values, and edge cases. [[1]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R1167) [[2]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R1180) [[3]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R1227) [[4]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R1236)