### PR TITLE
feat: enhance tap water capacity calculation with warmup handling and EMA smoothing

### DIFF
--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -95,6 +95,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) ->
     hass.data[DOMAIN].hass = hass
 
     coordinator = QvantumDataUpdateCoordinator(hass, config_entry)
+    await coordinator.async_restore_dhw_state()
     await coordinator.async_config_entry_first_refresh()
 
     if not coordinator.data.get("device") or not coordinator.data.get("device").get(

--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -136,7 +136,10 @@ class QvantumCalculationsMixin:
         # Snapshot realistic shower-time values while water is actually flowing.
         # EMA-smooth cold to prevent a brief transient (e.g. warm pipe water at
         # the start of a 15-second run) from dominating the estimate.
-        if flow is not None and flow > DHW_FLOW_SNAPSHOT_THRESHOLD_LPM:
+        flow_is_active = flow is not None and flow > DHW_FLOW_SNAPSHOT_THRESHOLD_LPM
+        self._tap_water_flow_was_active = flow_is_active
+
+        if flow_is_active:
             if cold is not None:
                 prior_cold = (
                     self._last_shower_cold_temp
@@ -155,17 +158,32 @@ class QvantumCalculationsMixin:
                 DHW_EMA_ALPHA * flow + (1 - DHW_EMA_ALPHA) * prior_flow
             )
 
-        # Resolve effective values: use last observed or fall back to defaults
-        cold_temp = (
-            self._last_shower_cold_temp
-            if self._last_shower_cold_temp is not None
-            else DHW_DEFAULT_COLD_TEMP_C
-        )
-        flow_lpm = (
-            self._last_shower_flow_lpm
-            if self._last_shower_flow_lpm is not None
-            else DHW_DEFAULT_FLOW_LPM
-        )
+        # Resolve values for the capacity calculation:
+        # - During active flow: use raw current readings so the estimate reflects
+        #   real-time conditions without EMA lag from the default-seeded snapshot.
+        # - No active flow: fall back to EMA snapshot (or defaults if never seen).
+        if flow_is_active:
+            calc_cold = (
+                cold
+                if cold is not None
+                else (
+                    self._last_shower_cold_temp
+                    if self._last_shower_cold_temp is not None
+                    else DHW_DEFAULT_COLD_TEMP_C
+                )
+            )
+            calc_flow = flow
+        else:
+            calc_cold = (
+                self._last_shower_cold_temp
+                if self._last_shower_cold_temp is not None
+                else DHW_DEFAULT_COLD_TEMP_C
+            )
+            calc_flow = (
+                self._last_shower_flow_lpm
+                if self._last_shower_flow_lpm is not None
+                else DHW_DEFAULT_FLOW_LPM
+            )
 
         if tank_temp is None:
             return
@@ -176,23 +194,20 @@ class QvantumCalculationsMixin:
         # pipes warm up and would cause capacity to appear to increase.
         effective_hot_temp = tank_temp
 
-        if (
-            effective_hot_temp <= DHW_SHOWER_TEMP_C
-            or cold_temp >= DHW_SHOWER_TEMP_C
-        ):
+        if effective_hot_temp <= DHW_SHOWER_TEMP_C or calc_cold >= DHW_SHOWER_TEMP_C:
             values["tap_water_cap"] = 0.0
             values["tap_water_minutes"] = 0
             return
 
-        delta_available = effective_hot_temp - cold_temp
+        delta_available = effective_hot_temp - calc_cold
         if delta_available < DHW_MIN_TEMPERATURE_DELTA_C:
             values["tap_water_cap"] = 0.0
             values["tap_water_minutes"] = 0
             return
 
-        hot_fraction = (DHW_SHOWER_TEMP_C - cold_temp) / delta_available
+        hot_fraction = (DHW_SHOWER_TEMP_C - calc_cold) / delta_available
         hot_fraction = min(1.0, max(0.0, hot_fraction))
-        hot_per_min = flow_lpm * hot_fraction
+        hot_per_min = calc_flow * hot_fraction
         if hot_per_min <= 0:
             values["tap_water_cap"] = 0.0
             values["tap_water_minutes"] = 0
@@ -211,17 +226,53 @@ class QvantumCalculationsMixin:
             smoothed = raw_showers
         self._last_tap_water_cap = smoothed
         smoothed_minutes = smoothed * DHW_SHOWER_DURATION_MIN
+
+        # When flow is active, hold off publishing new values until the flow
+        # has been running for 60 s so the EMA can stabilise on real inlet
+        # conditions. If a value was previously published, keep it available
+        # during the warmup window instead of removing the metric entirely.
+        now = dt_util.utcnow()
+        is_warmup = False
+        if flow_is_active:
+            if self._tap_water_cap_start_time is None:
+                self._tap_water_cap_start_time = now
+            if (now - self._tap_water_cap_start_time).total_seconds() < 60:
+                is_warmup = True
+        else:
+            # Reset the window so the next flow onset triggers a fresh 60 s hold.
+            self._tap_water_cap_start_time = None
+
+        published_cap = round(smoothed, 1)
+        published_minutes = round(smoothed_minutes)
+
+        if is_warmup:
+            if self._last_published_tap_water_cap is not None:
+                values["tap_water_cap"] = self._last_published_tap_water_cap
+                values["tap_water_minutes"] = (
+                    self._last_published_tap_water_minutes
+                    if self._last_published_tap_water_minutes is not None
+                    else round(
+                        self._last_published_tap_water_cap * DHW_SHOWER_DURATION_MIN
+                    )
+                )
+            else:
+                values["tap_water_cap"] = published_cap
+                values["tap_water_minutes"] = published_minutes
+            return
+
         # Publish the derived values rounded to the sensor's display precision
         # so small fluctuations do not cause UI flicker between updates. Keep
         # the EMA state in full precision for subsequent calculations.
-        values["tap_water_cap"] = round(smoothed, 1)
-        values["tap_water_minutes"] = round(smoothed_minutes)
+        values["tap_water_cap"] = published_cap
+        values["tap_water_minutes"] = published_minutes
+        self._last_published_tap_water_cap = published_cap
+        self._last_published_tap_water_minutes = published_minutes
         _LOGGER.debug(
             "Calculated tap_water_cap=%.2f showers (%d min, raw=%.2f, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min)",
             smoothed,
-            round(smoothed_minutes),
+            published_minutes,
             raw_showers,
             tank_temp,
-            cold_temp,
-            flow_lpm,
+            calc_cold,
+            calc_flow,
         )

--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -137,7 +137,6 @@ class QvantumCalculationsMixin:
         # EMA-smooth cold to prevent a brief transient (e.g. warm pipe water at
         # the start of a 15-second run) from dominating the estimate.
         flow_is_active = flow is not None and flow > DHW_FLOW_SNAPSHOT_THRESHOLD_LPM
-        self._tap_water_flow_was_active = flow_is_active
 
         if flow_is_active:
             if cold is not None:

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -161,7 +161,6 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         )
         if current_state == self._last_persisted_dhw_state:
             return
-        self._last_persisted_dhw_state = current_state
         try:
             self._dhw_store.async_delay_save(
                 lambda: {
@@ -173,6 +172,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
                 },
                 delay=30,
             )
+            self._last_persisted_dhw_state = current_state
         except Exception:
             _LOGGER.warning("Failed to schedule DHW state persistence", exc_info=True)
 

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -105,7 +105,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         self._tap_water_cap_start_time: datetime | None = None
         self._last_persisted_dhw_state: tuple | None = None
         self._dhw_store: Store = Store(
-            hass, 1, f"{DOMAIN}.dhw_ema.{config_entry.unique_id}"
+            hass, 1, f"{DOMAIN}.dhw_ema.{config_entry.entry_id}"
         )
 
         super().__init__(

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -103,7 +103,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         self._last_published_tap_water_cap: float | None = None
         self._last_published_tap_water_minutes: int | None = None
         self._tap_water_cap_start_time: datetime | None = None
-        self._tap_water_flow_was_active: bool = False
+        self._last_persisted_dhw_state: tuple | None = None
         self._dhw_store: Store = Store(
             hass, 1, f"{DOMAIN}.dhw_ema.{config_entry.unique_id}"
         )
@@ -117,8 +117,20 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         )
 
     async def async_restore_dhw_state(self) -> None:
-        """Restore DHW EMA snapshot from persistent storage after a restart."""
-        data = await self._dhw_store.async_load()
+        """Restore DHW EMA snapshot from persistent storage after a restart.
+
+        Errors (corrupted JSON, I/O failures) are caught and logged so that a
+        bad store file never prevents the integration from loading — the EMA
+        simply starts fresh from its defaults.
+        """
+        try:
+            data = await self._dhw_store.async_load()
+        except Exception:
+            _LOGGER.warning(
+                "Failed to load DHW EMA state from storage; starting with defaults",
+                exc_info=True,
+            )
+            return
         if data:
             self._last_shower_cold_temp = data.get("cold_temp")
             self._last_shower_flow_lpm = data.get("flow_lpm")
@@ -132,17 +144,37 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
                 self._last_tap_water_cap or 0.0,
             )
 
-    async def _persist_dhw_state(self) -> None:
-        """Save DHW EMA snapshot to storage so it survives a restart."""
-        await self._dhw_store.async_save(
-            {
-                "cold_temp": self._last_shower_cold_temp,
-                "flow_lpm": self._last_shower_flow_lpm,
-                "tap_water_cap": self._last_tap_water_cap,
-                "published_cap": self._last_published_tap_water_cap,
-                "published_minutes": self._last_published_tap_water_minutes,
-            }
+    def _persist_dhw_state(self) -> None:
+        """Save DHW EMA snapshot via a debounced write so it survives a restart.
+
+        Uses async_delay_save (coalesces multiple calls within the delay window
+        into a single disk write). Only schedules a write when the state has
+        actually changed since the last save, and swallows storage errors so
+        they cannot propagate into the coordinator update cycle.
+        """
+        current_state = (
+            self._last_shower_cold_temp,
+            self._last_shower_flow_lpm,
+            self._last_tap_water_cap,
+            self._last_published_tap_water_cap,
+            self._last_published_tap_water_minutes,
         )
+        if current_state == self._last_persisted_dhw_state:
+            return
+        self._last_persisted_dhw_state = current_state
+        try:
+            self._dhw_store.async_delay_save(
+                lambda: {
+                    "cold_temp": self._last_shower_cold_temp,
+                    "flow_lpm": self._last_shower_flow_lpm,
+                    "tap_water_cap": self._last_tap_water_cap,
+                    "published_cap": self._last_published_tap_water_cap,
+                    "published_minutes": self._last_published_tap_water_minutes,
+                },
+                delay=30,
+            )
+        except Exception:
+            _LOGGER.warning("Failed to schedule DHW state persistence", exc_info=True)
 
     @property
     def device_id(self) -> str | None:
@@ -427,7 +459,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
                 self._calculate_heating_power(values)
                 self._calculate_dhw_power(values)
                 self._calculate_tap_water_cap(values)
-                await self._persist_dhw_state()
+                self._persist_dhw_state()
 
             _LOGGER.debug("Final values: %s", values)
 

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -99,6 +99,10 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         self._last_shower_cold_temp: float | None = None
         self._last_shower_flow_lpm: float | None = None
         self._last_tap_water_cap: float | None = None
+        self._last_published_tap_water_cap: float | None = None
+        self._last_published_tap_water_minutes: int | None = None
+        self._tap_water_cap_start_time: datetime | None = None
+        self._tap_water_flow_was_active: bool = False
 
         super().__init__(
             hass,

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.storage import Store
 
 from .api import APIAuthError
 from .calculations import QvantumCalculationsMixin
@@ -103,6 +104,9 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         self._last_published_tap_water_minutes: int | None = None
         self._tap_water_cap_start_time: datetime | None = None
         self._tap_water_flow_was_active: bool = False
+        self._dhw_store: Store = Store(
+            hass, 1, f"{DOMAIN}.dhw_ema.{config_entry.unique_id}"
+        )
 
         super().__init__(
             hass,
@@ -110,6 +114,34 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
             name=f"{DOMAIN} ({config_entry.unique_id})",
             update_method=self.async_update_data,
             update_interval=timedelta(seconds=self.poll_interval),
+        )
+
+    async def async_restore_dhw_state(self) -> None:
+        """Restore DHW EMA snapshot from persistent storage after a restart."""
+        data = await self._dhw_store.async_load()
+        if data:
+            self._last_shower_cold_temp = data.get("cold_temp")
+            self._last_shower_flow_lpm = data.get("flow_lpm")
+            self._last_tap_water_cap = data.get("tap_water_cap")
+            self._last_published_tap_water_cap = data.get("published_cap")
+            self._last_published_tap_water_minutes = data.get("published_minutes")
+            _LOGGER.debug(
+                "Restored DHW EMA state: cold=%.1f°C, flow=%.1f L/min, cap=%.2f showers",
+                self._last_shower_cold_temp or 0.0,
+                self._last_shower_flow_lpm or 0.0,
+                self._last_tap_water_cap or 0.0,
+            )
+
+    async def _persist_dhw_state(self) -> None:
+        """Save DHW EMA snapshot to storage so it survives a restart."""
+        await self._dhw_store.async_save(
+            {
+                "cold_temp": self._last_shower_cold_temp,
+                "flow_lpm": self._last_shower_flow_lpm,
+                "tap_water_cap": self._last_tap_water_cap,
+                "published_cap": self._last_published_tap_water_cap,
+                "published_minutes": self._last_published_tap_water_minutes,
+            }
         )
 
     @property
@@ -395,6 +427,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
                 self._calculate_heating_power(values)
                 self._calculate_dhw_power(values)
                 self._calculate_tap_water_cap(values)
+                await self._persist_dhw_state()
 
             _LOGGER.debug("Final values: %s", values)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,18 @@ import pytest_asyncio
 pytest_plugins = ["pytest_homeassistant_custom_component"]
 
 
+@pytest.fixture(autouse=True)
+def mock_storage_save():
+    """Prevent Store.async_save from performing real disk I/O in unit tests."""
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "homeassistant.helpers.storage.Store.async_save",
+            AsyncMock(return_value=None),
+            raising=False,
+        )
+        yield
+
+
 @pytest.fixture
 def hass():
     """Mock Home Assistant instance."""
@@ -121,6 +133,7 @@ def mock_coordinator():
         }
     }
     coordinator.async_config_entry_first_refresh = AsyncMock()
+    coordinator.async_restore_dhw_state = AsyncMock()
 
     # Mock the maintenance coordinator for access level checking
     config_entry = Mock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,11 +17,16 @@ pytest_plugins = ["pytest_homeassistant_custom_component"]
 
 @pytest.fixture(autouse=True)
 def mock_storage_save():
-    """Prevent Store.async_save from performing real disk I/O in unit tests."""
+    """Prevent Store disk I/O in unit tests."""
     with pytest.MonkeyPatch.context() as mp:
         mp.setattr(
             "homeassistant.helpers.storage.Store.async_save",
             AsyncMock(return_value=None),
+            raising=False,
+        )
+        mp.setattr(
+            "homeassistant.helpers.storage.Store.async_delay_save",
+            Mock(return_value=None),
             raising=False,
         )
         yield

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1195,6 +1195,20 @@ class TestCalculateTapWaterCap:
         assert coordinator._last_shower_flow_lpm is None
         assert coordinator._last_tap_water_cap is None
 
+    @pytest.mark.asyncio
+    async def test_restore_dhw_state_storage_error_leaves_none(self):
+        """A storage I/O error during restore is swallowed; attributes stay None."""
+        coordinator = self._make_coordinator()
+        with patch.object(
+            coordinator._dhw_store,
+            "async_load",
+            side_effect=Exception("disk error"),
+        ):
+            await coordinator.async_restore_dhw_state()
+        assert coordinator._last_shower_cold_temp is None
+        assert coordinator._last_shower_flow_lpm is None
+        assert coordinator._last_tap_water_cap is None
+
     def test_missing_tank_temp_skips(self):
         """When bt30 is absent, tap_water_cap is not written."""
         coordinator = self._make_coordinator()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -17,6 +17,7 @@ from custom_components.qvantum.const import (
     REQUIRED_METRICS,
 )
 from homeassistant.const import CONF_SCAN_INTERVAL
+from homeassistant.util import dt as dt_util
 
 
 def _modbus_options_get(key, default=None):
@@ -1159,6 +1160,12 @@ class TestCalculateTapWaterCap:
             coordinator.data = None
         return coordinator
 
+    def _make_warmed_up_coordinator(self):
+        """Return a coordinator whose warmup window has already elapsed."""
+        coordinator = self._make_coordinator()
+        coordinator._tap_water_cap_start_time = dt_util.utcnow() - timedelta(seconds=61)
+        return coordinator
+
     def test_missing_tank_temp_skips(self):
         """When bt30 is absent, tap_water_cap is not written."""
         coordinator = self._make_coordinator()
@@ -1167,9 +1174,65 @@ class TestCalculateTapWaterCap:
         assert "tap_water_cap" not in values
         assert "tap_water_minutes" not in values
 
+    def test_warmup_suppresses_publication_during_flow(self):
+        """During active flow, publication holds the last published value."""
+        coordinator = self._make_coordinator()
+        # First call with no flow: publishes immediately
+        values_no_flow = {"bt30": 60.0, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(values_no_flow)
+        assert "tap_water_cap" in values_no_flow
+        baseline_cap = values_no_flow["tap_water_cap"]
+        baseline_minutes = values_no_flow["tap_water_minutes"]
+
+        # Flow starts: 60 s hold begins, first flow poll keeps the previous value
+        values_flow1 = {"bt30": 60.0, "bf1_l_min": 6.0, "bt33": 10.0}
+        coordinator._calculate_tap_water_cap(values_flow1)
+        assert values_flow1["tap_water_cap"] == baseline_cap
+        assert values_flow1["tap_water_minutes"] == baseline_minutes
+
+        # Subsequent flow poll within 60 s: still retains the previous value
+        values_flow2 = {"bt30": 60.0, "bf1_l_min": 6.0, "bt33": 10.0}
+        coordinator._calculate_tap_water_cap(values_flow2)
+        assert values_flow2["tap_water_cap"] == baseline_cap
+        assert values_flow2["tap_water_minutes"] == baseline_minutes
+        assert coordinator._last_tap_water_cap is not None
+
+    def test_no_flow_always_publishes(self):
+        """Without active flow, every poll publishes (no warmup suppression)."""
+        coordinator = self._make_coordinator()
+        for _ in range(3):
+            values = {"bt30": 60.0, "bf1_l_min": 0.0}
+            coordinator._calculate_tap_water_cap(values)
+            assert "tap_water_cap" in values
+
+    def test_flow_onset_resets_warmup(self):
+        """Each new flow onset starts a fresh 60 s hold before publishing."""
+        coordinator = self._make_coordinator()
+        # No-flow baseline: publishes
+        baseline = {"bt30": 60.0, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(baseline)
+        baseline_cap = baseline["tap_water_cap"]
+
+        # Flow starts: retains the previous value while warmup is active
+        values = {"bt30": 60.0, "bf1_l_min": 6.0, "bt33": 10.0}
+        coordinator._calculate_tap_water_cap(values)
+        assert values["tap_water_cap"] == baseline_cap
+        assert coordinator._tap_water_cap_start_time is not None
+
+        # Flow stops: resets window; next no-flow poll publishes again
+        values_stopped = {"bt30": 60.0, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(values_stopped)
+        assert "tap_water_cap" in values_stopped
+        assert coordinator._tap_water_cap_start_time is None
+        # Flow starts again: new 60 s hold, retaining the last published value.
+        values2 = {"bt30": 60.0, "bf1_l_min": 6.0, "bt33": 10.0}
+        coordinator._calculate_tap_water_cap(values2)
+        assert values2["tap_water_cap"] == values_stopped["tap_water_cap"]
+        assert values2["tap_water_minutes"] == values_stopped["tap_water_minutes"]
+
     def test_first_poll_uses_defaults(self):
         """With no prior shower snapshot, defaults are used: bt30=60, cold=8, flow=7."""
-        coordinator = self._make_coordinator()
+        coordinator = self._make_warmed_up_coordinator()
         values = {"bt30": 60.0, "bf1_l_min": 0.0}
         coordinator._calculate_tap_water_cap(values)
         # hot_fraction = (38 - 8) / (60 - 8) = 30/52 ≈ 0.577
@@ -1193,13 +1256,13 @@ class TestCalculateTapWaterCap:
     def test_capacity_decreases_as_tank_drains(self):
         """Capacity decreases as tank_temp drops, reflecting actual hot water consumption."""
         # Full tank: bt30=60°C
-        coordinator_full = self._make_coordinator()
+        coordinator_full = self._make_warmed_up_coordinator()
         values_full = {"bt30": 60.0, "bf1_l_min": 0.0}
         coordinator_full._calculate_tap_water_cap(values_full)
         cap_full = values_full["tap_water_cap"]
 
         # Partially drained tank: bt30=45°C
-        coordinator_half = self._make_coordinator()
+        coordinator_half = self._make_warmed_up_coordinator()
         values_half = {"bt30": 45.0, "bf1_l_min": 0.0}
         coordinator_half._calculate_tap_water_cap(values_half)
         cap_half = values_half["tap_water_cap"]
@@ -1209,30 +1272,35 @@ class TestCalculateTapWaterCap:
         assert cap_full > cap_half
 
     def test_uses_stored_cold_temp_when_no_flow(self):
-        """After flow has stopped, EMA-smoothed cold/flow values are used for the calculation."""
-        coordinator = self._make_coordinator()
-        # First poll: showering
-        # cold: 0.2*10 + 0.8*8 = 8.4 (EMA from DHW_DEFAULT_COLD_TEMP_C)
-        # flow: 0.2*6.0 + 0.8*7.0 = 6.8 (EMA from DHW_DEFAULT_FLOW_LPM)
+        """After flow stops, the no-flow poll uses EMA snapshot values; the result is
+        EMA-blended with the preceding flow-active estimate."""
+        coordinator = self._make_warmed_up_coordinator()
+        # First poll: showering with raw readings (cold=10, flow=6.0)
+        # raw: hot_fraction=(38-10)/(60-10)=0.56, hot_per_min=6*0.56=3.36
+        #      minutes=(140/3.36)*0.75=31.25, showers=31.25/6=5.21 → _last_tap_water_cap=5.21
+        # EMA snapshot stored: cold=0.2*10+0.8*8=8.4, flow=0.2*6+0.8*7=6.8
         coordinator._calculate_tap_water_cap({"bt30": 60.0, "bf1_l_min": 6.0, "bt33": 10.0})
         assert coordinator._last_shower_cold_temp == pytest.approx(8.4)
         assert coordinator._last_shower_flow_lpm == pytest.approx(6.8)
-        # Second poll: no flow — uses cold=8.4, flow=6.8, effective_hot=bt30=60 (tank_temp)
+        # Advance past the new warmup window
+        coordinator._tap_water_cap_start_time -= timedelta(seconds=61)
+        # Second poll: no flow — uses EMA snapshot (cold=8.4, flow=6.8)
+        # raw: hot_fraction=(38-8.4)/(60-8.4)=0.574, hot_per_min=6.8*0.574=3.90
+        #      minutes=(140/3.90)*0.75=26.9, showers=4.48
+        # EMA blend: 0.2*4.48 + 0.8*5.21 = 5.1
         values = {"bt30": 60.0, "bf1_l_min": 0.0}
         coordinator._calculate_tap_water_cap(values)
-        # hot_fraction = (38 - 8.4) / (60 - 8.4) = 29.6/51.6 ≈ 0.574
-        # hot_per_min = 6.8 * 0.574 ≈ 3.904
-        # minutes = (175 * 0.8 / 3.904) * 0.75 ≈ 26.9
-        # showers = 26.9 / 6 ≈ 4.48 -> rounded to 4.5
-        assert values["tap_water_cap"] == pytest.approx(4.5, abs=0.1)
-        assert values["tap_water_minutes"] == 27
-        assert values["tap_water_minutes"] == round(
-            values["tap_water_cap"] * DHW_SHOWER_DURATION_MIN
-        )
+        assert values["tap_water_cap"] == pytest.approx(5.1, abs=0.1)
+        assert values["tap_water_minutes"] == 30
 
     def test_tap_water_minutes_matches_smoothed_capacity(self):
         """tap_water_minutes is derived from the same smoothed tap_water_cap estimate."""
-        coordinator = self._make_coordinator()
+        coordinator = self._make_warmed_up_coordinator()
+        # Flow onset resets warmup; advance past it so values are published
+        coordinator._calculate_tap_water_cap(
+            {"bt30": 60.0, "bf1_l_min": 6.0, "bt33": 10.0}
+        )
+        coordinator._tap_water_cap_start_time -= timedelta(seconds=61)
         values = {"bt30": 60.0, "bf1_l_min": 6.0, "bt33": 10.0}
         coordinator._calculate_tap_water_cap(values)
         assert values["tap_water_minutes"] == round(
@@ -1250,7 +1318,7 @@ class TestCalculateTapWaterCap:
 
     def test_ema_smooths_output(self):
         """Second poll blends toward new value rather than jumping immediately."""
-        coordinator = self._make_coordinator()
+        coordinator = self._make_warmed_up_coordinator()
         # First poll: no prior EMA state → raw value used as-is (about 5.8 with defaults)
         values1 = {"bt30": 60.0, "bf1_l_min": 0.0}
         coordinator._calculate_tap_water_cap(values1)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1209,6 +1209,48 @@ class TestCalculateTapWaterCap:
         assert coordinator._last_shower_flow_lpm is None
         assert coordinator._last_tap_water_cap is None
 
+    def test_persist_dhw_state_updates_last_persisted_only_after_schedule_success(self):
+        """A successful schedule updates _last_persisted_dhw_state."""
+        coordinator = self._make_coordinator()
+        coordinator._last_shower_cold_temp = 8.4
+        coordinator._last_shower_flow_lpm = 6.8
+        coordinator._last_tap_water_cap = 5.0
+        coordinator._last_published_tap_water_cap = 5.0
+        coordinator._last_published_tap_water_minutes = 30
+
+        with patch.object(
+            coordinator._dhw_store, "async_delay_save"
+        ) as mock_delay_save:
+            coordinator._persist_dhw_state()
+
+        mock_delay_save.assert_called_once()
+        assert coordinator._last_persisted_dhw_state == (
+            8.4,
+            6.8,
+            5.0,
+            5.0,
+            30,
+        )
+
+    def test_persist_dhw_state_schedule_error_does_not_update_last_persisted(self):
+        """A scheduling failure must not poison _last_persisted_dhw_state."""
+        coordinator = self._make_coordinator()
+        coordinator._last_persisted_dhw_state = None
+        coordinator._last_shower_cold_temp = 8.4
+        coordinator._last_shower_flow_lpm = 6.8
+        coordinator._last_tap_water_cap = 5.0
+        coordinator._last_published_tap_water_cap = 5.0
+        coordinator._last_published_tap_water_minutes = 30
+
+        with patch.object(
+            coordinator._dhw_store,
+            "async_delay_save",
+            side_effect=Exception("schedule error"),
+        ):
+            coordinator._persist_dhw_state()
+
+        assert coordinator._last_persisted_dhw_state is None
+
     def test_missing_tank_temp_skips(self):
         """When bt30 is absent, tap_water_cap is not written."""
         coordinator = self._make_coordinator()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1166,6 +1166,35 @@ class TestCalculateTapWaterCap:
         coordinator._tap_water_cap_start_time = dt_util.utcnow() - timedelta(seconds=61)
         return coordinator
 
+    @pytest.mark.asyncio
+    async def test_restore_dhw_state_populates_attributes(self):
+        """async_restore_dhw_state loads persisted EMA values into coordinator state."""
+        coordinator = self._make_coordinator()
+        stored = {
+            "cold_temp": 9.5,
+            "flow_lpm": 5.8,
+            "tap_water_cap": 4.2,
+            "published_cap": 4.2,
+            "published_minutes": 25,
+        }
+        with patch.object(coordinator._dhw_store, "async_load", return_value=stored):
+            await coordinator.async_restore_dhw_state()
+        assert coordinator._last_shower_cold_temp == 9.5
+        assert coordinator._last_shower_flow_lpm == 5.8
+        assert coordinator._last_tap_water_cap == 4.2
+        assert coordinator._last_published_tap_water_cap == 4.2
+        assert coordinator._last_published_tap_water_minutes == 25
+
+    @pytest.mark.asyncio
+    async def test_restore_dhw_state_empty_storage_leaves_none(self):
+        """With no stored data, EMA attributes remain None after restore."""
+        coordinator = self._make_coordinator()
+        with patch.object(coordinator._dhw_store, "async_load", return_value=None):
+            await coordinator.async_restore_dhw_state()
+        assert coordinator._last_shower_cold_temp is None
+        assert coordinator._last_shower_flow_lpm is None
+        assert coordinator._last_tap_water_cap is None
+
     def test_missing_tank_temp_skips(self):
         """When bt30 is absent, tap_water_cap is not written."""
         coordinator = self._make_coordinator()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -190,6 +190,7 @@ class TestIntegrationSetup:
         mock_coordinator = MagicMock()
         mock_coordinator.data = {"device": {}}
         mock_coordinator.async_config_entry_first_refresh = AsyncMock(side_effect=[None, None])
+        mock_coordinator.async_restore_dhw_state = AsyncMock()
 
         with patch("custom_components.qvantum.QvantumAPI", return_value=mock_api), \
             patch("custom_components.qvantum.QvantumDataUpdateCoordinator", return_value=mock_coordinator), \


### PR DESCRIPTION
This pull request introduces a warmup suppression mechanism for publishing tap water capacity estimates during the initial 60 seconds of active flow, ensuring more stable and realistic sensor readings. It also updates the calculation logic to use real-time readings during flow and EMA-smoothed values otherwise, and enhances the test suite to cover the new behavior.

**Warmup suppression and publication logic:**
* Adds a 60-second warmup window after flow starts, during which the last published `tap_water_cap` and `tap_water_minutes` values are retained, preventing premature updates while the EMA stabilizes. State is reset when flow stops. (`custom_components/qvantum/calculations.py`, `custom_components/qvantum/coordinator.py`) [[1]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3L139-R142) [[2]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3R229-R277) [[3]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fR102-R105)
* Refines capacity calculation to use current readings during flow and fallback to EMA or defaults when no flow is detected, improving real-time accuracy. (`custom_components/qvantum/calculations.py`) [[1]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3L158-R182) [[2]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3L179-R210)

**Testing improvements:**
* Adds new tests to verify warmup suppression, publication timing, and correct reset of the warmup window on flow state changes. (`tests/test_coordinator.py`) [[1]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R1163-R1168) [[2]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R1177-R1235)
* Updates existing tests to use a warmed-up coordinator, ensuring they reflect the new warmup logic and accurately test EMA blending and value publication. (`tests/test_coordinator.py`) [[1]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L1196-R1265) [[2]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L1212-R1303) [[3]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L1253-R1321)

**General refactoring:**
* Imports `dt_util` in tests to support warmup window manipulation. (`tests/test_coordinator.py`)