### PR TITLE
feat: enhance tap water capacity calculations with detailed logging

### DIFF
--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -213,9 +213,10 @@ class QvantumCalculationsMixin:
                         DHW_EMA_ALPHA * duration_min + (1 - DHW_EMA_ALPHA) * prior_dur
                     )
                     _LOGGER.debug(
-                        "Shower ended: duration=%.1f min; EMA shower duration → %.1f min",
+                        "Shower ended: duration=%.1f min; EMA shower duration → %.1f min (tank=%.1f°C)",
                         duration_min,
                         self._last_shower_duration_min,
+                        tank_temp if tank_temp is not None else -1.0,
                     )
 
                     # Phase 2: record completed shower event to history.
@@ -343,12 +344,30 @@ class QvantumCalculationsMixin:
         if effective_hot_temp <= calc_shower_temp or calc_cold >= calc_shower_temp:
             values["tap_water_cap"] = 0.0
             values["tap_water_minutes"] = 0
+            _LOGGER.debug(
+                "Calculated tap_water_cap=0.00 showers (0 min, reason=insufficient_hot_temp, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min, shower_temp=%.1f°C, shower_dur=%.1f min)",
+                effective_hot_temp,
+                calc_cold,
+                calc_flow,
+                calc_shower_temp,
+                calc_shower_duration,
+            )
             return
 
         delta_available = effective_hot_temp - calc_cold
         if delta_available < DHW_MIN_TEMPERATURE_DELTA_C:
             values["tap_water_cap"] = 0.0
             values["tap_water_minutes"] = 0
+            _LOGGER.debug(
+                "Calculated tap_water_cap=0.00 showers (0 min, reason=delta_below_min, tank=%.1f°C, cold=%.1f°C, delta=%.1f°C, min_delta=%.1f°C, flow=%.1f L/min, shower_temp=%.1f°C, shower_dur=%.1f min)",
+                effective_hot_temp,
+                calc_cold,
+                delta_available,
+                DHW_MIN_TEMPERATURE_DELTA_C,
+                calc_flow,
+                calc_shower_temp,
+                calc_shower_duration,
+            )
             return
 
         hot_fraction = (calc_shower_temp - calc_cold) / delta_available
@@ -357,6 +376,14 @@ class QvantumCalculationsMixin:
         if hot_per_min <= 0:
             values["tap_water_cap"] = 0.0
             values["tap_water_minutes"] = 0
+            _LOGGER.debug(
+                "Calculated tap_water_cap=0.00 showers (0 min, reason=non_positive_hot_per_min, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min, shower_temp=%.1f°C, hot_fraction=%.3f)",
+                effective_hot_temp,
+                calc_cold,
+                calc_flow,
+                calc_shower_temp,
+                hot_fraction,
+            )
             return
 
         minutes = (
@@ -391,6 +418,16 @@ class QvantumCalculationsMixin:
         published_minutes = round(smoothed_minutes)
 
         if is_warmup:
+            published_warmup_cap = (
+                self._last_published_tap_water_cap
+                if self._last_published_tap_water_cap is not None
+                else published_cap
+            )
+            published_warmup_minutes = (
+                self._last_published_tap_water_minutes
+                if self._last_published_tap_water_minutes is not None
+                else published_minutes
+            )
             if self._last_published_tap_water_cap is not None:
                 values["tap_water_cap"] = self._last_published_tap_water_cap
                 values["tap_water_minutes"] = (
@@ -403,6 +440,17 @@ class QvantumCalculationsMixin:
             else:
                 values["tap_water_cap"] = published_cap
                 values["tap_water_minutes"] = published_minutes
+            _LOGGER.debug(
+                "Calculated tap_water_cap=%.2f showers (%d min, raw=%.2f, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min, shower_temp=%.1f°C, shower_dur=%.1f min, warmup=true)",
+                published_warmup_cap,
+                published_warmup_minutes,
+                raw_showers,
+                tank_temp,
+                calc_cold,
+                calc_flow,
+                calc_shower_temp,
+                calc_shower_duration,
+            )
             return
 
         # Publish the derived values rounded to the sensor's display precision

--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 from homeassistant.util import dt as dt_util
 
 from .const import (
+    DHW_CAP_HYSTERESIS_C,
     DHW_DEFAULT_COLD_TEMP_C,
     DHW_DEFAULT_FLOW_LPM,
     DHW_EMA_ALPHA,
@@ -341,24 +342,45 @@ class QvantumCalculationsMixin:
         # pipes warm up and would cause capacity to appear to increase.
         effective_hot_temp = tank_temp
 
-        hot_le_shower_temp = effective_hot_temp <= calc_shower_temp
         cold_ge_shower_temp = calc_cold >= calc_shower_temp
-        if hot_le_shower_temp or cold_ge_shower_temp:
+
+        # Hysteresis around the hot-vs-shower threshold prevents rapid
+        # 0/non-zero toggling when temperatures hover within sensor noise.
+        in_zero_mode = getattr(self, "_tap_water_cap_zero_mode", False)
+        if in_zero_mode:
+            should_force_zero = (
+                effective_hot_temp < calc_shower_temp + DHW_CAP_HYSTERESIS_C
+                or cold_ge_shower_temp
+            )
+        else:
+            should_force_zero = (
+                effective_hot_temp <= calc_shower_temp - DHW_CAP_HYSTERESIS_C
+                or cold_ge_shower_temp
+            )
+
+        if should_force_zero:
+            self._tap_water_cap_zero_mode = True
             values["tap_water_cap"] = 0.0
             values["tap_water_minutes"] = 0
-            reason = (
-                "hot_le_shower_temp" if hot_le_shower_temp else "cold_ge_shower_temp"
-            )
+            if cold_ge_shower_temp:
+                reason = "cold_ge_shower_temp"
+            elif in_zero_mode:
+                reason = "hot_below_hysteresis_exit"
+            else:
+                reason = "hot_below_hysteresis_entry"
             _LOGGER.debug(
-                "Calculated tap_water_cap=0.00 showers (0 min, reason=%s, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min, shower_temp=%.1f°C, shower_dur=%.1f min)",
+                "Calculated tap_water_cap=0.00 showers (0 min, reason=%s, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min, shower_temp=%.1f°C, shower_dur=%.1f min, hysteresis=%.1f°C, zero_mode=true)",
                 reason,
                 effective_hot_temp,
                 calc_cold,
                 calc_flow,
                 calc_shower_temp,
                 calc_shower_duration,
+                DHW_CAP_HYSTERESIS_C,
             )
             return
+
+        self._tap_water_cap_zero_mode = False
 
         delta_available = effective_hot_temp - calc_cold
         if delta_available < DHW_MIN_TEMPERATURE_DELTA_C:

--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -214,10 +214,10 @@ class QvantumCalculationsMixin:
                         DHW_EMA_ALPHA * duration_min + (1 - DHW_EMA_ALPHA) * prior_dur
                     )
                     _LOGGER.debug(
-                        "Shower ended: duration=%.1f min; EMA shower duration → %.1f min (tank=%.1f°C)",
+                        "Shower ended: duration=%.1f min; EMA shower duration → %.1f min (tank=%s)",
                         duration_min,
                         self._last_shower_duration_min,
-                        tank_temp if tank_temp is not None else -1.0,
+                        f"{tank_temp:.1f}°C" if tank_temp is not None else "unknown",
                     )
 
                     # Phase 2: record completed shower event to history.

--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -359,17 +359,27 @@ class QvantumCalculationsMixin:
             )
 
         if should_force_zero:
+            if not in_zero_mode:
+                # First poll entering zero mode: reset EMA so the first recovery
+                # poll seeds from raw rather than blending with the stale high value.
+                self._last_tap_water_cap = None
             self._tap_water_cap_zero_mode = True
-            values["tap_water_cap"] = 0.0
-            values["tap_water_minutes"] = 0
+            # Hold the last published value (or 0 if nothing published yet) so the
+            # sensor does not suddenly drop to 0 while the tank is borderline.
             if cold_ge_shower_temp:
                 reason = "cold_ge_shower_temp"
             elif in_zero_mode:
-                reason = "hot_below_hysteresis_exit"
+                reason = "hot_below_hysteresis_hold"
             else:
                 reason = "hot_below_hysteresis_entry"
+            held_cap = self._last_published_tap_water_cap or 0.0
+            held_minutes = self._last_published_tap_water_minutes or 0
+            values["tap_water_cap"] = held_cap
+            values["tap_water_minutes"] = held_minutes
             _LOGGER.debug(
-                "Calculated tap_water_cap=0.00 showers (0 min, reason=%s, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min, shower_temp=%.1f°C, shower_dur=%.1f min, hysteresis=%.1f°C, zero_mode=true)",
+                "Calculated tap_water_cap=%.2f showers (%d min, reason=%s, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min, shower_temp=%.1f°C, shower_dur=%.1f min, hysteresis=%.1f°C, zero_mode=true)",
+                held_cap,
+                held_minutes,
                 reason,
                 effective_hot_temp,
                 calc_cold,

--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -341,11 +341,17 @@ class QvantumCalculationsMixin:
         # pipes warm up and would cause capacity to appear to increase.
         effective_hot_temp = tank_temp
 
-        if effective_hot_temp <= calc_shower_temp or calc_cold >= calc_shower_temp:
+        hot_le_shower_temp = effective_hot_temp <= calc_shower_temp
+        cold_ge_shower_temp = calc_cold >= calc_shower_temp
+        if hot_le_shower_temp or cold_ge_shower_temp:
             values["tap_water_cap"] = 0.0
             values["tap_water_minutes"] = 0
+            reason = (
+                "hot_le_shower_temp" if hot_le_shower_temp else "cold_ge_shower_temp"
+            )
             _LOGGER.debug(
-                "Calculated tap_water_cap=0.00 showers (0 min, reason=insufficient_hot_temp, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min, shower_temp=%.1f°C, shower_dur=%.1f min)",
+                "Calculated tap_water_cap=0.00 showers (0 min, reason=%s, tank=%.1f°C, cold=%.1f°C, flow=%.1f L/min, shower_temp=%.1f°C, shower_dur=%.1f min)",
+                reason,
                 effective_hot_temp,
                 calc_cold,
                 calc_flow,

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -235,6 +235,9 @@ DHW_OUTLET_TEMP_THRESHOLD_DELTA_C = (
     5.0  # Minimum warm-water temperature rise above cold inlet before using outlet temp
 )
 DHW_MIN_TEMPERATURE_DELTA_C = 5.0  # Minimum spread between tank and cold water before a tap-water capacity estimate is valid
+DHW_CAP_HYSTERESIS_C = (
+    0.3  # Deadband around tank-vs-shower temperature threshold to avoid rapid 0/non-zero toggling
+)
 DHW_ROLLING_BUFFER_WINDOW_SEC = (
     60.0  # Rolling buffer window for cold/flow readings during active flow
 )

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -114,6 +114,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         self._last_tap_water_cap: float | None = None
         self._last_published_tap_water_cap: float | None = None
         self._last_published_tap_water_minutes: int | None = None
+        self._tap_water_cap_zero_mode: bool = False
         self._tap_water_cap_start_time: datetime | None = None
         self._last_persisted_dhw_state: tuple | None = None
         self._dhw_store: Store = Store(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -13,6 +13,7 @@ from custom_components.qvantum.const import (
     DEFAULT_ENABLED_HTTP_METRICS,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    DHW_CAP_HYSTERESIS_C,
     DHW_EMA_ALPHA,
     DHW_OUTLET_TEMP_THRESHOLD_DELTA_C,
     DHW_SHOWER_DURATION_MIN,
@@ -1659,3 +1660,89 @@ class TestCalculateTapWaterCap:
 
         # Additional guard: if raw near-cold bt34 had been used, cap would be huge.
         assert values["tap_water_cap"] < 20
+
+    # ------------------------------------------------------------------
+    # Hysteresis / hold-last-value (borderline tank-vs-shower-temp zone)
+    # ------------------------------------------------------------------
+
+    def test_hysteresis_entry_holds_last_published_not_zero(self):
+        """When tank drops just below shower_temp - hysteresis, the sensor holds
+        the last published value instead of jumping to 0."""
+        coordinator = self._make_warmed_up_coordinator()
+        # Warm tank: publish a baseline capacity first.
+        warm = {"bt30": 60.0, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(warm)
+        assert warm["tap_water_cap"] > 0
+        last_published = warm["tap_water_cap"]
+        last_minutes = warm["tap_water_minutes"]
+
+        # Seed learned shower temp to a known value so we control the threshold.
+        coordinator._last_shower_temp_c = 45.0
+        # tank exactly at shower_temp - hysteresis: on the boundary *outside* the entry
+        # deadband (entry requires strictly <= shower_temp - hysteresis).
+        entry_threshold = 45.0 - DHW_CAP_HYSTERESIS_C
+        borderline = {"bt30": entry_threshold, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(borderline)
+
+        # Must hold the previous published value, not drop to 0.
+        assert borderline["tap_water_cap"] == last_published
+        assert borderline["tap_water_minutes"] == last_minutes
+        assert coordinator._tap_water_cap_zero_mode is True
+
+    def test_hysteresis_remains_in_hold_until_exit_threshold_cleared(self):
+        """While in zero_mode, the sensor continues to hold once it enters,
+        until tank clears shower_temp + hysteresis."""
+        coordinator = self._make_warmed_up_coordinator()
+        coordinator._last_shower_temp_c = 45.0
+        # Prime a published value.
+        prime = {"bt30": 60.0, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(prime)
+        held = prime["tap_water_cap"]
+
+        # Drive into hold mode.
+        coordinator._last_shower_temp_c = 45.0
+        coordinator._calculate_tap_water_cap({"bt30": 44.5, "bf1_l_min": 0.0})
+        assert coordinator._tap_water_cap_zero_mode is True
+
+        # Tank rises to shower_temp but not yet above exit threshold:
+        # still inside deadband → must keep holding.
+        still_borderline = {"bt30": 45.0, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(still_borderline)
+        assert still_borderline["tap_water_cap"] == held
+        assert coordinator._tap_water_cap_zero_mode is True
+
+        # Tank clears exit threshold (shower_temp + hysteresis):
+        # zero_mode must be cleared and a fresh raw-seeded cap produced.
+        exit_temp = 45.0 + DHW_CAP_HYSTERESIS_C + 0.1
+        cleared = {"bt30": exit_temp, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(cleared)
+        assert coordinator._tap_water_cap_zero_mode is False
+        # First recovery poll seeds EMA from raw, so output should differ from held.
+        assert cleared["tap_water_cap"] != held
+
+    def test_hysteresis_entry_resets_ema_so_recovery_starts_from_raw(self):
+        """On the first poll entering hold mode, the EMA is reset to None so
+        the first valid recovery poll seeds from raw rather than blending with
+        the stale pre-hold value."""
+        coordinator = self._make_warmed_up_coordinator()
+        coordinator._last_shower_temp_c = 45.0
+        # Prime a high EMA value.
+        coordinator._last_tap_water_cap = 8.0
+        coordinator._last_published_tap_water_cap = 8.0
+        coordinator._last_published_tap_water_minutes = 48
+
+        # Enter hold mode.
+        coordinator._calculate_tap_water_cap({"bt30": 44.0, "bf1_l_min": 0.0})
+        assert coordinator._tap_water_cap_zero_mode is True
+        # EMA must be cleared on entry.
+        assert coordinator._last_tap_water_cap is None
+
+        # Exit hold mode: calculate with tank well above exit threshold.
+        coordinator._last_shower_temp_c = 45.0
+        exit_temp = 45.0 + DHW_CAP_HYSTERESIS_C + 1.0
+        values = {"bt30": exit_temp, "bf1_l_min": 0.0}
+        coordinator._calculate_tap_water_cap(values)
+        # First recovery poll has no prior EMA → raw value used directly.
+        # With default cold=8, flow=7 and tank=exit_temp the raw is modest;
+        # it must NOT be blended with the stale 8.0.
+        assert values["tap_water_cap"] < 6.0


### PR DESCRIPTION
This pull request introduces several improvements to the tap water capacity calculation logic in the `qvantum` custom component, focusing on stability and accuracy of the reported values. The main enhancement is the addition of a hysteresis mechanism to prevent rapid toggling between zero and non-zero capacity estimates when tank temperatures hover near the threshold. Additionally, debug logging has been expanded to provide clearer insights into calculation decisions and edge cases.

**Improvements to tap water capacity estimation:**

* Added a hysteresis deadband (`DHW_CAP_HYSTERESIS_C`) to the logic determining when tap water capacity should be reported as zero, preventing rapid toggling due to sensor noise or borderline temperatures. This includes tracking a zero-mode state and holding the last published value during borderline conditions. [[1]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3L343-R408) [[2]](diffhunk://#diff-07fd7ac76e58c80e95bb6c9ca3ff34f8c124f4a881a23cd946cfefaa5719e953R238-R240) [[3]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fR117)
* Improved handling during system warmup to ensure the last published values are retained and used appropriately, avoiding abrupt changes in reported capacity.

**Logging and debugging enhancements:**

* Expanded debug log messages throughout the tap water capacity calculation flow, including reasons for zeroing capacity, hysteresis state, and relevant temperature/flow values for easier troubleshooting and monitoring. [[1]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3L216-R220) [[2]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3L343-R408) [[3]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3R417-R424) [[4]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3R481-R491)

**Constants and initialization:**

* Introduced the `DHW_CAP_HYSTERESIS_C` constant in `const.py` and ensured it is imported where needed. [[1]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3R11) [[2]](diffhunk://#diff-07fd7ac76e58c80e95bb6c9ca3ff34f8c124f4a881a23cd946cfefaa5719e953R238-R240)
* Initialized the new zero-mode state variable in the coordinator to track hysteresis state across calculations.