### PR TITLE
feat: enhance EMA learning logic to differentiate between recirculation pulses and real showers based on session reheating status

### DIFF
--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -159,7 +159,7 @@ class QvantumCalculationsMixin:
                 # DHW reheating was already active when flow started — this is
                 # likely a recirculation pulse, not a real shower. Skip EMA.
                 _LOGGER.debug(
-                    "Shower ended during reheating: duration=%.1f min — skipping EMA update (recirculation pulse, reheating was active at session start)",
+                    "Tap water session started with reheating active: duration=%.1f min — skipping EMA update (recirculation pulse)",
                     duration_min,
                 )
             elif not flow_qualifies:

--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -135,6 +135,9 @@ class QvantumCalculationsMixin:
             return
 
         session_dhw_reheating = getattr(self, "_session_dhw_reheating", False)
+        session_started_with_reheating = getattr(
+            self, "_session_started_with_reheating", False
+        )
         active_flow_duration_sec = getattr(
             self, "_session_active_flow_duration_sec", 0.0
         )
@@ -152,11 +155,11 @@ class QvantumCalculationsMixin:
                 avg_flow = 0.0
             flow_qualifies = avg_flow >= DHW_MIN_SHOWER_FLOW_LPM
 
-            if session_dhw_reheating:
-                # During active DHW reheating, flow events are likely
-                # recirculation pulses — skip EMA learning.
+            if session_dhw_reheating and session_started_with_reheating:
+                # DHW reheating was already active when flow started — this is
+                # likely a recirculation pulse, not a real shower. Skip EMA.
                 _LOGGER.debug(
-                    "Shower ended during reheating: duration=%.1f min — skipping EMA update (recirculation pulse)",
+                    "Shower ended during reheating: duration=%.1f min — skipping EMA update (recirculation pulse, reheating was active at session start)",
                     duration_min,
                 )
             elif not flow_qualifies:
@@ -184,8 +187,13 @@ class QvantumCalculationsMixin:
                 )
 
             # Record completed session and update shower temp/flow EMAs.
+            # Skip only if reheating was active at session start (recirculation pulse).
+            # A real shower can trigger reheating mid-session; don't skip those.
+            is_recirculation_pulse = (
+                session_dhw_reheating and session_started_with_reheating
+            )
             if (
-                not session_dhw_reheating
+                not is_recirculation_pulse
                 and flow_qualifies
                 and self._shower_event_samples
             ):
@@ -308,6 +316,7 @@ class QvantumCalculationsMixin:
         self._shower_start_time = None
         self._shower_pause_time = None
         self._session_dhw_reheating = False
+        self._session_started_with_reheating = False
         self._session_active_flow_duration_sec = 0.0
         self._last_active_flow_sample_time = None
         self._flow_rolling_buffer.clear()
@@ -364,6 +373,7 @@ class QvantumCalculationsMixin:
                     self._shower_start_time = now
                     self._shower_pause_time = None
                     self._session_dhw_reheating = False
+                    self._session_started_with_reheating = bool(dhw_reheating)
                     self._session_active_flow_duration_sec = 0.0
                     self._last_active_flow_sample_time = now
             elif self._shower_pause_time is not None:
@@ -395,6 +405,7 @@ class QvantumCalculationsMixin:
                     if flow_qualifies_for_session:
                         self._shower_start_time = now
                         self._session_dhw_reheating = False
+                        self._session_started_with_reheating = bool(dhw_reheating)
                         self._session_active_flow_duration_sec = 0.0
                         self._last_active_flow_sample_time = now
                     # _shower_pause_time is already None after finalization.

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -250,7 +250,7 @@ DHW_ROLLING_BUFFER_WINDOW_SEC = (
 DHW_MIN_SHOWER_DURATION_MIN = 1.0  # Minimum event duration to count as a shower
 DHW_SHOWER_DURATION_MIN = 6.0  # Duration of one shower in minutes
 DHW_SESSION_GAP_SEC = (
-    300.0  # Max pause between flow bursts to still treat as one shower session (5 min)
+    90.0  # Max pause between flow bursts to still treat as one shower session (90 s)
 )
 DHW_SHOWER_TEMP_STABLE_MAX_OFFSET_SEC = (
     180  # Maximum seconds since shower onset for the temperature-stability check (s)

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -264,7 +264,7 @@ DHW_MAX_SHOWER_HISTORY_SIZE = (
     10  # Maximum number of completed shower events retained in history
 )
 DHW_EMA_ALPHA = (
-    0.2  # EMA smoothing factor for tap_water_cap (0=no change, 1=no smoothing)
+    0.3  # EMA smoothing factor for tap_water_cap (0=no change, 1=no smoothing)
 )
 
 # Tap water capacity mappings (start, stop) -> capacity

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -112,6 +112,9 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
             None  # Timestamp when flow last stopped (used for session continuation gap)
         )
         self._session_dhw_reheating: bool = False
+        self._session_started_with_reheating: bool = (
+            False  # True if DHW reheating was already active when this session started
+        )
         self._session_active_flow_duration_sec: float = (
             0.0  # cumulative active-flow time within current session
         )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1466,9 +1466,9 @@ class TestCalculateTapWaterCap:
         # Three tooth-brushing bursts, each well within DHW_SESSION_GAP_SEC of
         # each other, at 0.8 L/min (below DHW_MIN_SHOWER_FLOW_LPM=3.0).
         for burst_start in [
+            t_stop + timedelta(seconds=20),
+            t_stop + timedelta(seconds=40),
             t_stop + timedelta(seconds=60),
-            t_stop + timedelta(seconds=150),
-            t_stop + timedelta(seconds=240),
         ]:
             with patch("custom_components.qvantum.calculations.dt_util.utcnow") as m:
                 m.return_value = burst_start
@@ -1518,8 +1518,8 @@ class TestCalculateTapWaterCap:
 
         # Paused low-flow bursts with very different cold/outlet temps.
         for burst_start in [
-            t_stop + timedelta(seconds=60),
-            t_stop + timedelta(seconds=150),
+            t_stop + timedelta(seconds=20),
+            t_stop + timedelta(seconds=50),
         ]:
             with patch("custom_components.qvantum.calculations.dt_util.utcnow") as m:
                 m.return_value = burst_start

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1668,9 +1668,9 @@ class TestCalculateTapWaterCap:
         assert coordinator._last_shower_flow_lpm is not None
         assert coordinator._last_shower_duration_min is not None
 
-    def test_session_reheating_flag_is_ored_across_samples(self):
-        """If any active-flow sample in a session indicates reheating, finalization must
-        treat the whole session as reheating-driven and skip EMA/history learning."""
+    def test_session_reheating_mid_session_allows_ema_learning(self):
+        """Reheating that turns on MID-session (triggered by hot water draw) must NOT
+        suppress EMA learning — the session is a real shower, not a recirculation pulse."""
         coordinator = self._make_coordinator()
         start = dt_util.utcnow()
 
@@ -1678,7 +1678,51 @@ class TestCalculateTapWaterCap:
             coordinator._calculate_tap_water_cap(
                 {"bt30": 60.0, "bf1_l_min": 6.0, "bt33": 10.0, "bt34": 39.0}
             )
-        # A later active-flow sample shows reheating; this should mark the session.
+        # Reheating kicks in mid-session as the tank depletes — still a real shower.
+        with patch(
+            "homeassistant.util.dt.utcnow", return_value=start + timedelta(seconds=90)
+        ):
+            coordinator._calculate_tap_water_cap(
+                {
+                    "bt30": 60.0,
+                    "bf1_l_min": 6.0,
+                    "bt33": 10.0,
+                    "bt34": 39.0,
+                    "compressor_state": DHW_COMPRESSOR_STATE_HOT_WATER,
+                }
+            )
+        with patch(
+            "homeassistant.util.dt.utcnow", return_value=start + timedelta(seconds=120)
+        ):
+            coordinator._calculate_tap_water_cap({"bt30": 60.0, "bf1_l_min": 0.0})
+        with patch(
+            "homeassistant.util.dt.utcnow",
+            return_value=start + timedelta(seconds=120 + DHW_SESSION_GAP_SEC + 1),
+        ):
+            coordinator._calculate_tap_water_cap({"bt30": 60.0, "bf1_l_min": 0.0})
+
+        # EMA SHOULD be updated — reheating started mid-session, not at onset.
+        assert len(coordinator._shower_event_history) == 1
+        assert coordinator._last_shower_flow_lpm is not None
+        assert coordinator._last_shower_duration_min is not None
+
+    def test_session_reheating_at_start_skips_ema_learning(self):
+        """If DHW reheating is already active when flow starts, the session is a
+        recirculation pulse — EMA/history learning must be skipped."""
+        coordinator = self._make_coordinator()
+        start = dt_util.utcnow()
+
+        # Reheating is active from the very first poll (before/at session start).
+        with patch("homeassistant.util.dt.utcnow", return_value=start):
+            coordinator._calculate_tap_water_cap(
+                {
+                    "bt30": 60.0,
+                    "bf1_l_min": 6.0,
+                    "bt33": 10.0,
+                    "bt34": 39.0,
+                    "compressor_state": DHW_COMPRESSOR_STATE_HOT_WATER,
+                }
+            )
         with patch(
             "homeassistant.util.dt.utcnow", return_value=start + timedelta(seconds=90)
         ):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1395,7 +1395,7 @@ class TestCalculateTapWaterCap:
         assert coordinator._last_shower_flow_lpm is None
 
         # Stability guard: the pulse sequence should stay smooth (no large swings).
-        assert max(pulse_caps) - min(pulse_caps) <= 0.2
+        assert max(pulse_caps) - min(pulse_caps) <= 0.3
 
     def test_low_flow_session_does_not_corrupt_shower_emas(self):
         """Flow below DHW_MIN_SHOWER_FLOW_LPM (dishwasher, hand-wash, tooth brushing)
@@ -1827,7 +1827,7 @@ class TestCalculateTapWaterCap:
           _last_tap_water_cap = 5.0  (inflated prior)
           bt30=60°C, cold/flow/shower defaults
           → raw_showers ≈ 2.27
-          → EMA candidate = 0.2*2.27 + 0.8*5.0 = 4.454  → published ≈ 4.5
+          → EMA candidate = 0.3*2.27 + 0.7*5.0 = 4.181  → published ≈ 4.2
         """
         coordinator = self._make_coordinator()
         t0 = datetime(2026, 4, 14, 12, 0, 0, tzinfo=timezone.utc)
@@ -1847,7 +1847,7 @@ class TestCalculateTapWaterCap:
         assert values["tap_water_cap"] > 2.0, (
             "EMA must not jump all the way to the raw value in one step"
         )
-        assert pytest.approx(4.5, abs=0.1) == values["tap_water_cap"]
+        assert pytest.approx(4.2, abs=0.1) == values["tap_water_cap"]
         # State must have advanced.
         assert coordinator._last_tap_water_cap < 5.0
         # Warmup window must have been cleared (no flow).
@@ -1866,9 +1866,9 @@ class TestCalculateTapWaterCap:
           _last_published_tap_water_cap = 5.0
           _last_published_tap_water_minutes = 30
           bt30=60°C, cold=10°C (in buffer), flow=7 L/min (in buffer), shower_temp=38°C
-          → raw_showers ≈ (175/7)*ln(50/28)/6 ≈ 2.82
-          → EMA candidate = 0.2*2.82 + 0.8*5.0 = 4.564  → published_cap = 4.6
-          → warmup output = round(5.0 + (4.6 - 5.0) * 0.5, 1) = round(4.8, 1) = 4.8
+          → raw_showers ≈ (175/7)*ln(50/28)/6 ≈ 2.42
+          → EMA candidate = 0.3*2.42 + 0.7*5.0 = 4.226  → published_cap = 4.2
+          → warmup output = round(5.0 + (4.2 - 5.0) * 0.5, 1) = round(4.6, 1) = 4.6
         Old broken output would have been 5.0 (no-op ramp).
         """
         coordinator = self._make_coordinator()
@@ -1889,13 +1889,13 @@ class TestCalculateTapWaterCap:
         # Arithmetic (log model):
         #   minutes = (175/7) * ln((60-10)/(38-10)) = 25 * ln(50/28) ≈ 14.49
         #   raw_showers = 14.49 / 6 ≈ 2.42
-        #   EMA candidate = 0.2*2.42 + 0.8*5.0 = 4.484  → published_cap = round(4.484,1) = 4.5
-        #   published_minutes = round(4.5 * 6) = 27
-        #   warmup output cap = round(5.0 + (4.5 - 5.0) * 0.5, 1) = round(4.75, 1) = 4.8
-        #   warmup output minutes = round(30 + (27 - 30) * 0.5) = round(28.5) = 28
+        #   EMA candidate = 0.3*2.42 + 0.7*5.0 = 4.226  → published_cap = round(4.226,1) = 4.2
+        #   published_minutes = round(4.226 * 6) = round(25.4) = 25
+        #   warmup output cap = round(5.0 + (4.2 - 5.0) * 0.5, 1) = round(4.6, 1) = 4.6
+        #   warmup output minutes = round(30 + (25 - 30) * 0.5) = round(27.5) = 28
         # Old (broken) output: smoothed = _last_tap_water_cap = 5.0
         #   → published_cap = 5.0 → interp: 5.0 + (5.0-5.0)*0.5 = 5.0  (no-op)
-        assert values["tap_water_cap"] == pytest.approx(4.8, abs=0.05), (
+        assert values["tap_water_cap"] == pytest.approx(4.6, abs=0.05), (
             "Warmup ramp must interpolate toward the EMA candidate, not the frozen prior"
         )
         assert values["tap_water_minutes"] == 28
@@ -1921,8 +1921,8 @@ class TestCalculateTapWaterCap:
         coordinator = self._make_coordinator()
         values = {"bt30": 60.0, "bf1_l_min": 6.5, "bt33": 12.0}
         coordinator._calculate_tap_water_cap(values)
-        # cold: 0.2 * 12.0 + 0.8 * 8.0 = 8.8 (EMA from DHW_DEFAULT_COLD_TEMP_C prior)
-        assert coordinator._last_shower_cold_temp == pytest.approx(8.8)
+        # cold: 0.3 * 12.0 + 0.7 * 8.0 = 9.2 (EMA from DHW_DEFAULT_COLD_TEMP_C prior)
+        assert coordinator._last_shower_cold_temp == pytest.approx(9.2)
         # flow EMA is NOT updated during an in-progress flow poll — stays None until
         # the session finalises so that non-shower flow events do not corrupt it.
         assert coordinator._last_shower_flow_lpm is None
@@ -1951,9 +1951,9 @@ class TestCalculateTapWaterCap:
         coordinator = self._make_warmed_up_coordinator()
         # First poll: showering with raw readings (cold=10, flow=6.0)
         # Log model: minutes = 175/7.0 * ln(50/28) ≈ 14.5; showers ≈ 2.42  (calc_flow=default 7.0)
-        # cold EMA stored: 0.2*10+0.8*8=8.4; flow EMA only updates at end-of-session.
+        # cold EMA stored: 0.3*10+0.7*8=8.6; flow EMA only updates at end-of-session.
         coordinator._calculate_tap_water_cap({"bt30": 60.0, "bf1_l_min": 6.0, "bt33": 10.0})
-        assert coordinator._last_shower_cold_temp == pytest.approx(8.4)
+        assert coordinator._last_shower_cold_temp == pytest.approx(8.6)
         # flow EMA remains None until a session finalises
         assert coordinator._last_shower_flow_lpm is None
         # Advance past the new warmup window


### PR DESCRIPTION
This pull request improves the accuracy of shower session detection and tap water capacity estimation by refining how DHW reheating events are handled, tightening session gap logic, and adjusting EMA smoothing. The changes ensure that only recirculation pulses (where reheating is already active at session start) are excluded from learning, while real showers that trigger reheating mid-session are correctly included. Additionally, the session gap and EMA smoothing factor are tuned for more responsive and precise behavior. Tests are updated to reflect these logic and parameter changes.

**Session Detection and Reheating Logic:**
- Added a `_session_started_with_reheating` flag to track if DHW reheating was already active at the start of a tap water session, and updated logic to skip EMA learning only for sessions that start with reheating (i.e., recirculation pulses), not for real showers that trigger reheating mid-session. [[1]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3R138-R140) [[2]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3L155-R162) [[3]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3R190-R196) [[4]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3R319) [[5]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fR115-R117) [[6]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3R376) [[7]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3R408)

**Session Gap and EMA Smoothing Adjustments:**
- Reduced `DHW_SESSION_GAP_SEC` from 300s to 90s, making session detection more sensitive to shorter pauses in flow.
- Increased `DHW_EMA_ALPHA` from 0.2 to 0.3, making the EMA smoothing for tap water capacity more responsive to recent changes.

**Test Suite Updates:**
- Updated and added tests to distinguish between sessions with reheating at start (should skip EMA) and those where reheating starts mid-session (should update EMA), and to reflect the new EMA smoothing and session gap behavior. [[1]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L1398-R1398) [[2]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R1469-L1471) [[3]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L1521-R1522) [[4]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L1671-R1725)
- Adjusted test assertions and calculations to match the new EMA smoothing factor and session gap, ensuring that expected values and tolerances are correct. [[1]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L1786-R1830) [[2]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L1806-R1850) [[3]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L1848-R1898) [[4]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L1880-R1925) [[5]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L1910-R1956)