### PR TITLE
fix: update active flow duration handling to improve shower session tracking and EMA calculations

### DIFF
--- a/custom_components/qvantum/calculations.py
+++ b/custom_components/qvantum/calculations.py
@@ -139,13 +139,24 @@ class QvantumCalculationsMixin:
             self, "_session_started_with_reheating", False
         )
         active_flow_duration_sec = getattr(
-            self, "_session_active_flow_duration_sec", 0.0
+            self, "_session_active_flow_duration_sec", None
         )
 
         duration_min = (
             self._shower_pause_time - self._shower_start_time
         ).total_seconds() / 60.0
-        if duration_min >= DHW_MIN_SHOWER_DURATION_MIN:
+        # Use active-flow time (excludes mid-session pauses) so a short rinse
+        # followed by a long pause does not inflate the qualifying duration.
+        # None means the attribute was never set via polling (test state with manually
+        # seeded session fields); fall back to wall-clock only in that case.
+        # An explicit 0.0 means polling ran but no active-flow time accumulated,
+        # which correctly yields 0 min and fails the minimum duration check.
+        active_flow_min = (
+            active_flow_duration_sec / 60.0
+            if active_flow_duration_sec is not None
+            else duration_min
+        )
+        if active_flow_min >= DHW_MIN_SHOWER_DURATION_MIN:
             # Compute avg_flow early so it can gate all EMA learning below.
             if self._shower_event_samples:
                 avg_flow = sum(s[1] for s in self._shower_event_samples) / len(
@@ -213,10 +224,13 @@ class QvantumCalculationsMixin:
                     if outlet_samples
                     else None
                 )
-                active_flow_duration_min = active_flow_duration_sec / 60.0
-                if active_flow_duration_min <= 0:
-                    # Defensive fallback for manually seeded test state.
+                if active_flow_duration_sec is None or active_flow_duration_sec <= 0:
+                    # None = not tracked via polling (test state); 0 = no flow time
+                    # accumulated. Fall back to wall-clock duration in both cases so
+                    # water_used_l is at least a reasonable estimate.
                     active_flow_duration_min = duration_min
+                else:
+                    active_flow_duration_min = active_flow_duration_sec / 60.0
                 water_used_l = avg_flow * active_flow_duration_min
                 # Update the shower flow EMA once per completed session
                 # (same pattern as shower duration EMA) so that unrelated
@@ -317,7 +331,7 @@ class QvantumCalculationsMixin:
         self._shower_pause_time = None
         self._session_dhw_reheating = False
         self._session_started_with_reheating = False
-        self._session_active_flow_duration_sec = 0.0
+        self._session_active_flow_duration_sec = None
         self._last_active_flow_sample_time = None
         self._flow_rolling_buffer.clear()
         self._shower_event_samples.clear()

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -115,8 +115,8 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         self._session_started_with_reheating: bool = (
             False  # True if DHW reheating was already active when this session started
         )
-        self._session_active_flow_duration_sec: float = (
-            0.0  # cumulative active-flow time within current session
+        self._session_active_flow_duration_sec: float | None = (
+            None  # cumulative active-flow time within current session; None until first session starts
         )
         self._last_active_flow_sample_time: datetime | None = None
         self._flow_rolling_buffer: list = []  # [(timestamp, flow, cold)] within 60-second window

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2911,7 +2911,7 @@ class TestCalculateTapWaterCap:
     # ------------------------------------------------------------------
 
     def test_short_qualifying_shower_creates_history_entry(self):
-        """A 75-second rinse at 4 L/min (> DHW_MIN_SHOWER_DURATION_MIN=1.0 min)
+        """A 75-second active-flow rinse at 4 L/min (> DHW_MIN_SHOWER_DURATION_MIN=1.0 min)
         must finalize and add exactly one entry to the history."""
         coordinator = self._make_coordinator()
         t0 = datetime(2026, 4, 17, 8, 0, 0, tzinfo=timezone.utc)
@@ -2931,7 +2931,7 @@ class TestCalculateTapWaterCap:
             m.return_value = t_stop + timedelta(seconds=DHW_SESSION_GAP_SEC + 1)
             coordinator._calculate_tap_water_cap({"bt30": 60.0, "bf1_l_min": 0.0})
 
-        # 75 s = 1.25 min ≥ DHW_MIN_SHOWER_DURATION_MIN → must be learned.
+        # 75 s active flow = 1.25 min ≥ DHW_MIN_SHOWER_DURATION_MIN → must be learned.
         assert coordinator._last_shower_duration_min is not None
         assert coordinator._last_shower_flow_lpm is not None
         assert len(coordinator._shower_event_history) == 1
@@ -2940,7 +2940,7 @@ class TestCalculateTapWaterCap:
         )
 
     def test_burst_just_below_min_duration_ignored(self):
-        """A 45-second burst (0.75 min < DHW_MIN_SHOWER_DURATION_MIN) at qualifying
+        """A 45-second active-flow burst (0.75 min < DHW_MIN_SHOWER_DURATION_MIN) at qualifying
         flow must not create a history entry or update duration/flow EMAs."""
         coordinator = self._make_coordinator()
         t0 = datetime(2026, 4, 17, 8, 0, 0, tzinfo=timezone.utc)
@@ -2960,5 +2960,53 @@ class TestCalculateTapWaterCap:
             coordinator._calculate_tap_water_cap({"bt30": 60.0, "bf1_l_min": 0.0})
 
         assert coordinator._last_shower_duration_min is None
+        assert coordinator._last_shower_flow_lpm is None
+        assert coordinator._shower_event_history == []
+
+    def test_short_burst_with_long_mid_session_pause_not_learned(self):
+        """A ~30 s rinse followed by a ~79 s pause (within gap) must NOT be learned.
+
+        Wall-clock duration (start → final flow-stop) can exceed the threshold
+        because of the pause, but active-flow duration is only ~30 s (0.5 min),
+        which is below DHW_MIN_SHOWER_DURATION_MIN=1.0 min.  This matches the
+        real-world scenario where someone turns the tap on briefly, waits, then
+        taps again — the session should not corrupt shower EMAs.
+        """
+        coordinator = self._make_coordinator()
+        t0 = datetime(2026, 4, 18, 7, 0, 0, tzinfo=timezone.utc)
+
+        # First burst: ~30 s of active flow (2 polls × 15 s).
+        for i in range(2):
+            with patch("custom_components.qvantum.calculations.dt_util.utcnow") as m:
+                m.return_value = t0 + timedelta(seconds=i * 15)
+                coordinator._calculate_tap_water_cap(
+                    {"bt30": 59.0, "bf1_l_min": 5.2, "bt33": 11.0, "bt34": 43.0}
+                )
+        t_pause = t0 + timedelta(seconds=30)
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as m:
+            m.return_value = t_pause
+            coordinator._calculate_tap_water_cap({"bt30": 59.0, "bf1_l_min": 0.0})
+
+        # 79 s pause — still within 90 s gap, session continues.
+        t_resume = t_pause + timedelta(seconds=79)
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as m:
+            m.return_value = t_resume
+            coordinator._calculate_tap_water_cap(
+                {"bt30": 59.0, "bf1_l_min": 5.2, "bt33": 11.0, "bt34": 43.0}
+            )
+        t_stop = t_resume + timedelta(seconds=15)
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as m:
+            m.return_value = t_stop
+            coordinator._calculate_tap_water_cap({"bt30": 59.0, "bf1_l_min": 0.0})
+
+        # Expire gap to trigger finalization.
+        with patch("custom_components.qvantum.calculations.dt_util.utcnow") as m:
+            m.return_value = t_stop + timedelta(seconds=DHW_SESSION_GAP_SEC + 1)
+            coordinator._calculate_tap_water_cap({"bt30": 59.0, "bf1_l_min": 0.0})
+
+        # Wall-clock duration > 1 min, but active-flow duration = 0.75 min < threshold.
+        assert coordinator._last_shower_duration_min is None, (
+            "Short active-flow session with long pause must not update duration EMA"
+        )
         assert coordinator._last_shower_flow_lpm is None
         assert coordinator._shower_event_history == []

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2964,13 +2964,13 @@ class TestCalculateTapWaterCap:
         assert coordinator._shower_event_history == []
 
     def test_short_burst_with_long_mid_session_pause_not_learned(self):
-        """A ~30 s rinse followed by a ~79 s pause (within gap) must NOT be learned.
+        """A ~30 s rinse, ~79 s pause (within gap), then ~15 s more flow must NOT be learned.
 
         Wall-clock duration (start → final flow-stop) can exceed the threshold
-        because of the pause, but active-flow duration is only ~30 s (0.5 min),
-        which is below DHW_MIN_SHOWER_DURATION_MIN=1.0 min.  This matches the
-        real-world scenario where someone turns the tap on briefly, waits, then
-        taps again — the session should not corrupt shower EMAs.
+        because of the pause, but total active-flow duration is only ~45 s
+        (0.75 min), which is below DHW_MIN_SHOWER_DURATION_MIN=1.0 min. This
+        matches the real-world scenario where someone turns the tap on briefly,
+        waits, then taps again — the session should not corrupt shower EMAs.
         """
         coordinator = self._make_coordinator()
         t0 = datetime(2026, 4, 18, 7, 0, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
This pull request improves the logic for determining whether a tap water session (such as a shower) qualifies as a "learnable" event, focusing on using active-flow duration instead of total wall-clock duration. This change ensures that short bursts of water usage separated by long pauses do not incorrectly count as significant events, which could otherwise skew statistical calculations. The update also enhances test coverage to verify this behavior.

**Session qualification logic improvements:**

* The minimum duration check for qualifying a session now uses "active-flow" time (actual water running) instead of total elapsed time, preventing long pauses from inflating the session duration. If active-flow time is unavailable (e.g., in test scenarios), it falls back to wall-clock duration.
* When calculating water usage, if active-flow duration is missing or zero, the logic falls back to using wall-clock duration to ensure reasonable estimates in all cases.
* Session state is now initialized with `None` for `_session_active_flow_duration_sec` instead of `0.0`, clarifying the difference between "not started" and "zero flow." [[1]](diffhunk://#diff-fd906701ad3e09bcf1d242bc9dd0c2f0f6c144b00b81757be084494d1f575fc3L320-R334) [[2]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fL118-R119)

**Test improvements:**

* Test docstrings and comments now clarify that the minimum duration checks are based on active-flow time, not wall-clock time. [[1]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L2914-R2914) [[2]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L2934-R2934) [[3]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L2943-R2943)
* Added a new test (`test_short_burst_with_long_mid_session_pause_not_learned`) to ensure that a short burst of water usage followed by a long pause does not incorrectly qualify as a learnable session, even if the total elapsed time exceeds the threshold.