### PR TITLE
feat: add write methods for Modbus integration; add dhw_stop_extra handling in number entity

### DIFF
--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -12,6 +12,7 @@ from pymodbus.client.tcp import AsyncModbusTcpClient
 from pymodbus.pdu.register_message import (
     ReadHoldingRegistersRequest,
     ReadInputRegistersRequest,
+    WriteSingleRegisterRequest,
 )
 from pymodbus.exceptions import ModbusException
 
@@ -533,6 +534,79 @@ class QvantumAPI:
         payload = {"update_settings": settings}
 
         return await self._send_command(device_id, payload)
+
+    async def write_holding_register(
+        self, device_id: str, register_address: int, value: int
+    ) -> dict:
+        """Write a single Modbus holding register and return a status dict."""
+        async with self._modbus_lock:
+            self._init_modbus_client()
+            if not self._modbus_client:
+                raise APIConnectionError(None, "Modbus client not initialized")
+
+            try:
+                if not self._modbus_client.connected:
+                    await self._modbus_client.connect()
+                    if not self._modbus_client.connected:
+                        raise APIConnectionError(
+                            None, "Modbus client connection failed"
+                        )
+
+                request = WriteSingleRegisterRequest(
+                    dev_id=self._modbus_unit_id,
+                    address=register_address,
+                    # pymodbus 3.x uses a shared ModbusPDU base class where all register
+                    # values are stored as list[int]. For WriteSingleRegisterRequest the
+                    # value to write is accessed as registers[0] internally, so a
+                    # single-element list is the correct API.
+                    registers=[value],
+                )
+                result = await self._modbus_client.execute(False, request)
+                if result is None:
+                    raise APIConnectionError(
+                        None,
+                        "Modbus write failed: no response received from device",
+                    )
+                if result.isError():
+                    raise APIConnectionError(
+                        None,
+                        f"Modbus write error on register {register_address}: {result}",
+                    )
+            except ModbusException as e:
+                _LOGGER.error(
+                    "Modbus error writing holding register %d: %s", register_address, e
+                )
+                await self._reset_modbus_client()
+                raise APIConnectionError(None, f"Modbus write failed: {e}")
+            except APIConnectionError:
+                raise
+            except Exception as e:
+                _LOGGER.error(
+                    "Unexpected error writing holding register %d: %s",
+                    register_address,
+                    e,
+                    exc_info=True,
+                )
+                await self._reset_modbus_client()
+                raise APIConnectionError(None, f"Modbus write failed: {e}")
+
+        return {"status": "APPLIED"}
+
+    async def write_holding_register_for_metric(
+        self, device_id: str, metric_key: str, value: float
+    ) -> dict:
+        """Write a Modbus holding register looked up by metric key."""
+        holding_key = next(
+            (k for k, v in MODBUS_HOLDING_TO_SETTINGS_MAP.items() if v == metric_key),
+            None,
+        )
+        if holding_key is None or holding_key not in MODBUS_HOLDING_REGISTER_MAP:
+            raise ValueError(
+                f"No Modbus holding register mapping found for metric '{metric_key}'"
+            )
+        register_address, _data_type, scale = MODBUS_HOLDING_REGISTER_MAP[holding_key]
+        raw_value = int(round(value / scale)) if scale != 1.0 else int(value)
+        return await self.write_holding_register(device_id, register_address, raw_value)
 
     async def _update_settings(self, device_id: str, payload: dict):
         """Update one or several settings."""

--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -542,14 +542,17 @@ class QvantumAPI:
         async with self._modbus_lock:
             self._init_modbus_client()
             if not self._modbus_client:
-                raise APIConnectionError(None, "Modbus client not initialized")
+                raise APIConnectionError(
+                    None, f"Modbus client not initialized for device {device_id}"
+                )
 
             try:
                 if not self._modbus_client.connected:
                     await self._modbus_client.connect()
                     if not self._modbus_client.connected:
                         raise APIConnectionError(
-                            None, "Modbus client connection failed"
+                            None,
+                            f"Modbus client connection failed for device {device_id}",
                         )
 
                 request = WriteSingleRegisterRequest(
@@ -565,16 +568,19 @@ class QvantumAPI:
                 if result is None:
                     raise APIConnectionError(
                         None,
-                        "Modbus write failed: no response received from device",
+                        f"Modbus write failed for device {device_id}: no response received from device",
                     )
                 if result.isError():
                     raise APIConnectionError(
                         None,
-                        f"Modbus write error on register {register_address}: {result}",
+                        f"Modbus write error on register {register_address} for device {device_id}: {result}",
                     )
             except ModbusException as e:
                 _LOGGER.error(
-                    "Modbus error writing holding register %d: %s", register_address, e
+                    "Modbus error writing holding register %d for device %s: %s",
+                    register_address,
+                    device_id,
+                    e,
                 )
                 await self._reset_modbus_client()
                 raise APIConnectionError(None, f"Modbus write failed: {e}")
@@ -582,8 +588,9 @@ class QvantumAPI:
                 raise
             except Exception as e:
                 _LOGGER.error(
-                    "Unexpected error writing holding register %d: %s",
+                    "Unexpected error writing holding register %d for device %s: %s",
                     register_address,
+                    device_id,
                     e,
                     exc_info=True,
                 )

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -206,6 +206,7 @@ REQUIRED_MODBUS_METRICS = [
     "bt30",  # Tank temperature
     "bt33",  # Cold water inlet temperature
     "bf1_l_min",  # DHW flow rate
+    "dhw_stop_extra",
 ]
 
 # Sensor type classification
@@ -214,6 +215,7 @@ TEMPERATURE_METRICS = [
     "bt",
     "tap_water_start",
     "tap_water_stop",
+    "dhw_stop_extra",
 ]
 ENERGY_METRICS = ["energy"]
 POWER_METRICS = ["powertotal", "heatingpower", "dhwpower"]

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -206,7 +206,6 @@ REQUIRED_MODBUS_METRICS = [
     "bt30",  # Tank temperature
     "bt33",  # Cold water inlet temperature
     "bf1_l_min",  # DHW flow rate
-    "dhw_stop_extra",
 ]
 
 # Sensor type classification
@@ -215,7 +214,6 @@ TEMPERATURE_METRICS = [
     "bt",
     "tap_water_start",
     "tap_water_stop",
-    "dhw_stop_extra",
 ]
 ENERGY_METRICS = ["energy"]
 POWER_METRICS = ["powertotal", "heatingpower", "dhwpower"]

--- a/custom_components/qvantum/modbus.py
+++ b/custom_components/qvantum/modbus.py
@@ -120,13 +120,13 @@ RELAY_BIT_MAP = {
     "picpin_relay_ha12": 9,
 }
 
-# One-way map from Modbus holding register keys to the canonical settings names
-# used by the API/settings layer. This does not imply reverse lookup support.
+# Map from Modbus holding register keys to the canonical settings names used by
+# the API/settings layer. Also used in reverse (settings name -> holding key) by
+# write_holding_register_for_metric() to resolve a metric key to its register address.
 MODBUS_HOLDING_TO_SETTINGS_MAP = {
     "start_cooling_temp": "start_cooling_temp",
     "dhw_start_normal": "tap_water_start",
     "dhw_stop_normal": "tap_water_stop",
-    # "dhw_stop_extra": "dhw_stop_extra", # No update_setting found for this metric, so it's handled separately in number.py
     "dhw_mode": "extra_tap_water",
     "room_compensation": "room_comp_factor",
     "desired_indoor_temp": "indoor_temperature_target",

--- a/custom_components/qvantum/modbus.py
+++ b/custom_components/qvantum/modbus.py
@@ -139,4 +139,5 @@ MODBUS_HOLDING_TO_SETTINGS_MAP = {
     "allow_addition": "op_man_addition",
     "allow_heating": "man_mode",
     "ventilation_state": "fanspeedselector",
+    "dhw_stop_extra": "dhw_stop_extra",
 }

--- a/custom_components/qvantum/number.py
+++ b/custom_components/qvantum/number.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
         "indoor_temperature_offset": (-10, 10, 1),
         "tap_water_stop": (60, 80, 1),
         "tap_water_start": (50, 65, 1),
-        "dhw_stop_extra": (60, 80, 5),
+        "dhw_stop_extra": (60, 85, 5),
         "fan_normal": (0, 100, 5),
         "fan_speed_2": (0, 100, 5),
     }
@@ -98,8 +98,14 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
                 response = await self.coordinator.api.set_tap_water(
                     self._hpid, start=int(value)
                 )
-            case "room_comp_factor" | "fan_normal" | "fan_speed_2" | "dhw_stop_extra":
+            case "room_comp_factor" | "fan_normal" | "fan_speed_2":
                 response = await self.coordinator.api.update_setting(
+                    self._hpid, self._metric_key, int(value)
+                )
+
+            case "dhw_stop_extra":
+                # dhw_stop_extra has no update_setting HTTP endpoint; write via Modbus holding register
+                response = await self.coordinator.api.write_holding_register_for_metric(
                     self._hpid, self._metric_key, int(value)
                 )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2184,7 +2184,7 @@ class TestWriteHoldingRegister:
             "modbus_host": "192.168.1.100",
             "modbus_port": 502,
         }
-        if mock_session:
+        if mock_session is not None:
             kwargs["session"] = mock_session
         return QvantumAPI("test@example.com", "password", "test-agent", **kwargs)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2173,3 +2173,177 @@ class TestQvantumAPI:
         result = await authenticated_api.get_http_metrics("dev1", ["tap_stop"])
 
         assert result == {"metrics": {}}
+
+
+class TestWriteHoldingRegister:
+    """Tests for write_holding_register and write_holding_register_for_metric."""
+
+    def _make_api(self, mock_session=None):
+        kwargs = {
+            "modbus_tcp": True,
+            "modbus_host": "192.168.1.100",
+            "modbus_port": 502,
+        }
+        if mock_session:
+            kwargs["session"] = mock_session
+        return QvantumAPI("test@example.com", "password", "test-agent", **kwargs)
+
+    def _make_fake_client(self, execute_result=None, connected=True):
+        client = MagicMock()
+        client.connected = connected
+        client.connect = AsyncMock(
+            side_effect=lambda: setattr(client, "connected", True)
+        )
+        if execute_result is None:
+            ok_result = MagicMock()
+            ok_result.isError.return_value = False
+            execute_result = ok_result
+        client.execute = AsyncMock(return_value=execute_result)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_write_holding_register_success(self, mock_session):
+        """Successful write returns APPLIED status dict."""
+        api = self._make_api(mock_session)
+        client = self._make_fake_client()
+        api._modbus_client = client
+
+        result = await api.write_holding_register("dev1", 59, 75)
+
+        assert result == {"status": "APPLIED"}
+        client.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_write_holding_register_connects_if_disconnected(self, mock_session):
+        """Connects the client if not already connected."""
+        api = self._make_api(mock_session)
+        client = self._make_fake_client(connected=False)
+        api._modbus_client = client
+
+        result = await api.write_holding_register("dev1", 59, 75)
+
+        client.connect.assert_awaited_once()
+        assert result == {"status": "APPLIED"}
+
+    @pytest.mark.asyncio
+    async def test_write_holding_register_raises_when_no_client(self, mock_session):
+        """Raises APIConnectionError when Modbus is not enabled (no client)."""
+        from custom_components.qvantum.api import APIConnectionError
+
+        api = QvantumAPI(
+            "test@example.com", "password", "test-agent", session=mock_session
+        )
+        # modbus_tcp=False so _init_modbus_client leaves _modbus_client as None
+
+        with pytest.raises(APIConnectionError, match="Modbus client not initialized"):
+            await api.write_holding_register("dev1", 59, 75)
+
+    @pytest.mark.asyncio
+    async def test_write_holding_register_raises_on_error_result(self, mock_session):
+        """Raises APIConnectionError when device returns an error response."""
+        from custom_components.qvantum.api import APIConnectionError
+
+        api = self._make_api(mock_session)
+        error_result = MagicMock()
+        error_result.isError.return_value = True
+        client = self._make_fake_client(execute_result=error_result)
+        api._modbus_client = client
+
+        with pytest.raises(APIConnectionError):
+            await api.write_holding_register("dev1", 59, 75)
+
+    @pytest.mark.asyncio
+    async def test_write_holding_register_raises_on_none_response(self, mock_session):
+        """Raises APIConnectionError when execute returns None."""
+        from custom_components.qvantum.api import APIConnectionError
+
+        api = self._make_api(mock_session)
+        client = self._make_fake_client()
+        client.execute = AsyncMock(return_value=None)
+        api._modbus_client = client
+
+        with pytest.raises(APIConnectionError, match="no response received"):
+            await api.write_holding_register("dev1", 59, 75)
+
+    @pytest.mark.asyncio
+    async def test_write_holding_register_resets_client_on_modbus_exception(
+        self, mock_session
+    ):
+        """Resets the Modbus client and raises APIConnectionError on ModbusException."""
+        from custom_components.qvantum.api import APIConnectionError
+        from pymodbus.exceptions import ModbusException
+
+        api = self._make_api(mock_session)
+        client = self._make_fake_client()
+        client.execute = AsyncMock(side_effect=ModbusException("boom"))
+        api._modbus_client = client
+
+        with pytest.raises(APIConnectionError, match="Modbus write failed"):
+            await api.write_holding_register("dev1", 59, 75)
+
+        assert api._modbus_client is None
+
+    @pytest.mark.asyncio
+    async def test_write_holding_register_resets_client_on_generic_exception(
+        self, mock_session
+    ):
+        """Resets the Modbus client and raises APIConnectionError on unexpected errors."""
+        from custom_components.qvantum.api import APIConnectionError
+
+        api = self._make_api(mock_session)
+        client = self._make_fake_client()
+        client.execute = AsyncMock(side_effect=RuntimeError("unexpected"))
+        api._modbus_client = client
+
+        with pytest.raises(APIConnectionError, match="Modbus write failed"):
+            await api.write_holding_register("dev1", 59, 75)
+
+        assert api._modbus_client is None
+
+    @pytest.mark.asyncio
+    async def test_write_holding_register_for_metric_dhw_stop_extra(self, mock_session):
+        """write_holding_register_for_metric resolves dhw_stop_extra to register 59."""
+        api = self._make_api(mock_session)
+        client = self._make_fake_client()
+        api._modbus_client = client
+
+        result = await api.write_holding_register_for_metric(
+            "dev1", "dhw_stop_extra", 75
+        )
+
+        assert result == {"status": "APPLIED"}
+        # Verify the correct register address (59) was written
+        call_args = client.execute.call_args[0][
+            1
+        ]  # second positional arg is the request
+        assert call_args.address == 59
+        assert call_args.registers == [75]
+
+    @pytest.mark.asyncio
+    async def test_write_holding_register_for_metric_unknown_key_raises(
+        self, mock_session
+    ):
+        """write_holding_register_for_metric raises ValueError for unknown metric keys."""
+        api = self._make_api(mock_session)
+
+        with pytest.raises(
+            ValueError, match="No Modbus holding register mapping found"
+        ):
+            await api.write_holding_register_for_metric("dev1", "not_a_real_metric", 42)
+
+    @pytest.mark.asyncio
+    async def test_write_holding_register_for_metric_applies_scale(self, mock_session):
+        """write_holding_register_for_metric applies inverse scale when scale != 1.0."""
+        api = self._make_api(mock_session)
+        client = self._make_fake_client()
+        api._modbus_client = client
+
+        # room_comp_factor maps to holding key "room_compensation" (scale=0.1)
+        # value=2.5 -> raw = int(round(2.5 / 0.1)) = 25
+        result = await api.write_holding_register_for_metric(
+            "dev1", "room_comp_factor", 2.5
+        )
+
+        assert result == {"status": "APPLIED"}
+        call_args = client.execute.call_args[0][1]
+        assert call_args.registers == [25]

--- a/tests/test_number_working.py
+++ b/tests/test_number_working.py
@@ -434,6 +434,33 @@ class TestQvantumNumberEntity:
         )
         # Note: async_set_updated_data would be called if the API response status was correct
 
+    @pytest.mark.asyncio
+    async def test_async_set_native_value_dhw_stop_extra(
+        self, mock_coordinator, mock_device
+    ):
+        """Test setting dhw_stop_extra writes via Modbus holding register, not update_setting."""
+        mock_coordinator.data["values"]["dhw_stop_extra"] = 65
+        entity = QvantumNumberEntity(
+            mock_coordinator, "dhw_stop_extra", 60, 85, 5, mock_device
+        )
+
+        mock_coordinator.api.write_holding_register_for_metric = AsyncMock(
+            return_value={"status": "APPLIED"}
+        )
+        mock_coordinator.api.update_setting = AsyncMock(
+            return_value={"status": "APPLIED"}
+        )
+
+        await entity.async_set_native_value(75.0)
+
+        mock_coordinator.api.write_holding_register_for_metric.assert_called_once_with(
+            "test_device_123", "dhw_stop_extra", 75
+        )
+        # update_setting must NOT be called for dhw_stop_extra
+        mock_coordinator.api.update_setting.assert_not_called()
+        # Coordinator cache should be updated with the new value
+        assert mock_coordinator.data["values"]["dhw_stop_extra"] == 75
+
 
 class TestNumberSetup:
     """Test number platform setup."""


### PR DESCRIPTION
This pull request adds robust support for writing to Modbus holding registers, specifically enabling the `dhw_stop_extra` metric to be set via Modbus rather than the HTTP API. It introduces new methods for writing registers, updates the metric-to-register mapping, adjusts value ranges, and adds comprehensive unit tests for the new functionality.

**Modbus Holding Register Write Support**

* Added `write_holding_register` and `write_holding_register_for_metric` methods to `QvantumAPI` to support writing values directly to Modbus holding registers, with detailed error handling and connection management. (`custom_components/qvantum/api.py`, [custom_components/qvantum/api.pyR538-R617](diffhunk://#diff-88fa74f55f5a9ef6cb7bc5c395906c8fa1cb670f9d21d1d66c8e672b7c5bd8c8R538-R617))
* Updated the import to include `WriteSingleRegisterRequest` for Modbus write operations. (`custom_components/qvantum/api.py`, [custom_components/qvantum/api.pyR15](diffhunk://#diff-88fa74f55f5a9ef6cb7bc5c395906c8fa1cb670f9d21d1d66c8e672b7c5bd8c8R15))

**Metric Mapping and Value Range Adjustments**

* Extended `MODBUS_HOLDING_TO_SETTINGS_MAP` to include `"dhw_stop_extra"`, enabling reverse lookup for writing this metric. (`custom_components/qvantum/modbus.py`, [[1]](diffhunk://#diff-93c70da3b6878ca7af7b350f167eda6585822b5e506ffa2bd8a10d74d7d50e9aL123-L129) [[2]](diffhunk://#diff-93c70da3b6878ca7af7b350f167eda6585822b5e506ffa2bd8a10d74d7d50e9aR142)
* Increased the allowed range for the `dhw_stop_extra` metric from 80 to 85. (`custom_components/qvantum/number.py`, [custom_components/qvantum/number.pyL38-R38](diffhunk://#diff-37b24c15c007d2fd3db3f36096acf939aeea60cf05d5843ece90555692105addL38-R38))

**Integration and Behavior Changes**

* Updated `QvantumNumberEntity.async_set_native_value` so that setting `dhw_stop_extra` now uses the new Modbus write method, rather than the HTTP API. (`custom_components/qvantum/number.py`, [custom_components/qvantum/number.pyL101-R111](diffhunk://#diff-37b24c15c007d2fd3db3f36096acf939aeea60cf05d5843ece90555692105addL101-R111))

**Testing Enhancements**

* Added a comprehensive test suite for the new Modbus write methods, covering success, connection handling, error scenarios, and correct register mapping and scaling. (`tests/test_api.py`, [tests/test_api.pyR2176-R2349](diffhunk://#diff-3451cc474d5698222168f66a293339a6bd296ee2c56f56409866bbae99917a79R2176-R2349))
* Added a test to ensure that setting `dhw_stop_extra` uses the Modbus write method and not the HTTP API, and that the cache is updated. (`tests/test_number_working.py`, [tests/test_number_working.pyR437-R463](diffhunk://#diff-75640ab15806ac1268316d13a9f9c9ab2f12888eeddd7da6f91e017e69818f44R437-R463))