### PR TITLE
feat: add gating to Modbus write support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,16 @@ The integration will automatically discover your Qvantum devices and create comp
 - **Smart Status**: Heat pump status, defrost cycles, priority modes
 - **Comprehensive Coverage**: Supports all major Qvantum heat pump parameters
 
-### Real time Modbus Support (Read-only)
+### Real time Modbus Support
 
 - **Efficient polling** of live data from the pump’s Modbus interface
 - **Highly granular metrics** for temperatures, flows, pressures, power, and energy
 - **Stable backup path** for metrics when REST data is unavailable
 - **Minimal network impact** with optimized modbus register reads
+- **Optional Modbus writes** for supported controls when explicitly enabled in the integration options
 
 > [!IMPORTANT]
-> This integration's Modbus path is **read-only**. No write operations are performed via Modbus. Any configuration/set commands still go through the existing HTTP API.
+> By default, this integration uses Modbus for **reading only**. Modbus write support is disabled unless you explicitly enable it in the integration options, and only supported controls use that path. Other configuration/set commands continue to use the existing HTTP API.
 
 ### Services
 

--- a/custom_components/qvantum/config_flow.py
+++ b/custom_components/qvantum/config_flow.py
@@ -31,6 +31,7 @@ from .const import (
     VERSION,
     CONFIG_VERSION,
     CONF_MODBUS_TCP,
+    CONF_MODBUS_WRITE,
     CONF_MODBUS_HOST,
     DEFAULT_MODBUS_HOST,
 )
@@ -42,6 +43,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required("username"): str,
         vol.Required("password"): str,
         vol.Optional(CONF_MODBUS_TCP, default=False): bool,
+        vol.Optional(CONF_MODBUS_WRITE, default=False): bool,
     }
 )
 
@@ -115,15 +117,18 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
                 await self.async_set_unique_id(info.get("title"))
                 self._abort_if_unique_id_configured()
                 modbus_enabled = user_input.get(CONF_MODBUS_TCP, False)
+                modbus_write_enabled = user_input.get(CONF_MODBUS_WRITE, False)
                 return self.async_create_entry(
                     title=info["title"],
                     data={
                         "username": user_input["username"],
                         "password": user_input["password"],
                         CONF_MODBUS_TCP: modbus_enabled,
+                        CONF_MODBUS_WRITE: modbus_write_enabled,
                     },
                     options={
                         CONF_MODBUS_TCP: modbus_enabled,
+                        CONF_MODBUS_WRITE: modbus_write_enabled,
                     },
                 )
 
@@ -155,15 +160,18 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
             else:
                 modbus_enabled = user_input.get(CONF_MODBUS_TCP, False)
+                modbus_write_enabled = user_input.get(CONF_MODBUS_WRITE, False)
                 updated_data = {
                     **config_entry.data,
                     "username": user_input["username"],
                     "password": user_input["password"],
                     CONF_MODBUS_TCP: modbus_enabled,
+                    CONF_MODBUS_WRITE: modbus_write_enabled,
                 }
                 updated_options = {
                     **config_entry.options,
                     CONF_MODBUS_TCP: modbus_enabled,
+                    CONF_MODBUS_WRITE: modbus_write_enabled,
                 }
                 return self.async_update_reload_and_abort(
                     config_entry,
@@ -185,6 +193,13 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
                         default=config_entry.options.get(
                             CONF_MODBUS_TCP,
                             config_entry.data.get(CONF_MODBUS_TCP, False),
+                        ),
+                    ): bool,
+                    vol.Optional(
+                        CONF_MODBUS_WRITE,
+                        default=config_entry.options.get(
+                            CONF_MODBUS_WRITE,
+                            config_entry.data.get(CONF_MODBUS_WRITE, False),
                         ),
                     ): bool,
                 }
@@ -221,6 +236,10 @@ class QvantumOptionsFlowHandler(OptionsFlow):
                     CONF_MODBUS_HOST,
                     default=self.options.get(CONF_MODBUS_HOST, DEFAULT_MODBUS_HOST),
                 ): str,
+                vol.Optional(
+                    CONF_MODBUS_WRITE,
+                    default=self.options.get(CONF_MODBUS_WRITE, False),
+                ): bool,
             }
         )
 

--- a/custom_components/qvantum/config_flow.py
+++ b/custom_components/qvantum/config_flow.py
@@ -243,7 +243,8 @@ class QvantumOptionsFlowHandler(OptionsFlow):
             normalized_input = {**user_input}
             if CONF_MODBUS_TCP in user_input:
                 normalized_input[CONF_MODBUS_TCP] = modbus_enabled
-            if CONF_MODBUS_WRITE in user_input:
+                normalized_input[CONF_MODBUS_WRITE] = modbus_write_enabled
+            elif CONF_MODBUS_WRITE in user_input:
                 normalized_input[CONF_MODBUS_WRITE] = modbus_write_enabled
 
             options = self.options | normalized_input

--- a/custom_components/qvantum/config_flow.py
+++ b/custom_components/qvantum/config_flow.py
@@ -48,6 +48,13 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 )
 
 
+def _normalize_modbus_settings(
+    modbus_enabled: bool, modbus_write_enabled: bool
+) -> tuple[bool, bool]:
+    """Ensure modbus_write cannot be enabled when modbus_tcp is disabled."""
+    return modbus_enabled, modbus_write_enabled and modbus_enabled
+
+
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect.
 
@@ -116,8 +123,10 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
                 # and create the config entry.
                 await self.async_set_unique_id(info.get("title"))
                 self._abort_if_unique_id_configured()
-                modbus_enabled = user_input.get(CONF_MODBUS_TCP, False)
-                modbus_write_enabled = user_input.get(CONF_MODBUS_WRITE, False)
+                modbus_enabled, modbus_write_enabled = _normalize_modbus_settings(
+                    user_input.get(CONF_MODBUS_TCP, False),
+                    user_input.get(CONF_MODBUS_WRITE, False),
+                )
                 return self.async_create_entry(
                     title=info["title"],
                     data={
@@ -159,8 +168,10 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                modbus_enabled = user_input.get(CONF_MODBUS_TCP, False)
-                modbus_write_enabled = user_input.get(CONF_MODBUS_WRITE, False)
+                modbus_enabled, modbus_write_enabled = _normalize_modbus_settings(
+                    user_input.get(CONF_MODBUS_TCP, False),
+                    user_input.get(CONF_MODBUS_WRITE, False),
+                )
                 updated_data = {
                     **config_entry.data,
                     "username": user_input["username"],
@@ -219,7 +230,23 @@ class QvantumOptionsFlowHandler(OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Handle options flow."""
         if user_input is not None:
-            options = self.options | user_input
+            modbus_enabled, modbus_write_enabled = _normalize_modbus_settings(
+                user_input.get(
+                    CONF_MODBUS_TCP,
+                    self.options.get(CONF_MODBUS_TCP, False),
+                ),
+                user_input.get(
+                    CONF_MODBUS_WRITE,
+                    self.options.get(CONF_MODBUS_WRITE, False),
+                ),
+            )
+            normalized_input = {**user_input}
+            if CONF_MODBUS_TCP in user_input:
+                normalized_input[CONF_MODBUS_TCP] = modbus_enabled
+            if CONF_MODBUS_WRITE in user_input:
+                normalized_input[CONF_MODBUS_WRITE] = modbus_write_enabled
+
+            options = self.options | normalized_input
             return self.async_create_entry(title="", data=options)
 
         data_schema = vol.Schema(

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -22,6 +22,7 @@ CONFIG_VERSION = 7
 
 # Modbus TCP configuration
 CONF_MODBUS_TCP = "modbus_tcp"
+CONF_MODBUS_WRITE = "modbus_write"
 CONF_MODBUS_HOST = "modbus_host"
 CONF_MODBUS_PORT = "modbus_port"
 CONF_MODBUS_UNIT_ID = "modbus_unit_id"

--- a/custom_components/qvantum/number.py
+++ b/custom_components/qvantum/number.py
@@ -118,7 +118,7 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
                 )
                 if not modbus_write_enabled:
                     raise HomeAssistantError(
-                        "Modbus writing is disabled. Enable 'Enable writing via Modbus' in the integration options."
+                        "Modbus writing is disabled. Turn on writing via Modbus in the integration options."
                     )
                 response = await self.coordinator.api.write_holding_register_for_metric(
                     self._hpid, self._metric_key, int(value)

--- a/custom_components/qvantum/number.py
+++ b/custom_components/qvantum/number.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import MyConfigEntry
 from .const import (
+    CONF_MODBUS_TCP,
     CONF_MODBUS_WRITE,
     TAP_WATER_CAPACITY_MAPPINGS,
 )
@@ -111,14 +112,9 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
 
             case "dhw_stop_extra":
                 # dhw_stop_extra has no update_setting HTTP endpoint; write via Modbus holding register
-                config_entry = self.coordinator.config_entry
-                modbus_write_enabled = config_entry.options.get(
-                    CONF_MODBUS_WRITE,
-                    config_entry.data.get(CONF_MODBUS_WRITE, False),
-                )
-                if not modbus_write_enabled:
+                if not self._is_modbus_write_allowed():
                     raise HomeAssistantError(
-                        "Modbus writing is disabled. Enable 'Enable writing via Modbus' in the integration options."
+                        "Modbus writing is disabled. Enable Modbus TCP and 'Enable writing via Modbus' in the integration options."
                     )
                 response = await self.coordinator.api.write_holding_register_for_metric(
                     self._hpid, self._metric_key, int(value)
@@ -147,13 +143,24 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
     @property
     def available(self):
         """Check if data is available."""
+        return (
+            (
+                self._metric_key not in MODBUS_WRITE_METRICS
+                or self._is_modbus_write_allowed()
+            )
+            and self._values.get(self._metric_key) is not None
+            and self._has_write_access
+        )
+
+    def _is_modbus_write_allowed(self) -> bool:
+        """Return True when Modbus write actions are explicitly enabled and available."""
         config_entry = self.coordinator.config_entry
         modbus_write_enabled = config_entry.options.get(
             CONF_MODBUS_WRITE,
             config_entry.data.get(CONF_MODBUS_WRITE, False),
         )
-        return (
-            (self._metric_key not in MODBUS_WRITE_METRICS or modbus_write_enabled)
-            and self._values.get(self._metric_key) is not None
-            and self._has_write_access
+        modbus_tcp_enabled = config_entry.options.get(
+            CONF_MODBUS_TCP,
+            config_entry.data.get(CONF_MODBUS_TCP, False),
         )
+        return modbus_write_enabled and modbus_tcp_enabled

--- a/custom_components/qvantum/number.py
+++ b/custom_components/qvantum/number.py
@@ -5,6 +5,7 @@ import logging
 from homeassistant.components.number import NumberEntity
 from homeassistant.const import UnitOfEnergy, UnitOfTemperature, EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -110,6 +111,15 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
 
             case "dhw_stop_extra":
                 # dhw_stop_extra has no update_setting HTTP endpoint; write via Modbus holding register
+                config_entry = self.coordinator.config_entry
+                modbus_write_enabled = config_entry.options.get(
+                    CONF_MODBUS_WRITE,
+                    config_entry.data.get(CONF_MODBUS_WRITE, False),
+                )
+                if not modbus_write_enabled:
+                    raise HomeAssistantError(
+                        "Modbus writing is disabled. Enable 'Enable writing via Modbus' in the integration options."
+                    )
                 response = await self.coordinator.api.write_holding_register_for_metric(
                     self._hpid, self._metric_key, int(value)
                 )

--- a/custom_components/qvantum/number.py
+++ b/custom_components/qvantum/number.py
@@ -11,12 +11,17 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import MyConfigEntry
 from .const import (
+    CONF_MODBUS_WRITE,
     TAP_WATER_CAPACITY_MAPPINGS,
 )
 from .coordinator import QvantumDataUpdateCoordinator, handle_setting_update_response
 from .entity import QvantumEntity
 
 _LOGGER = logging.getLogger(__name__)
+
+# Metrics that require writing via Modbus holding registers.
+# Entities for these metrics show as unavailable when "Enable writing via Modbus" is off.
+MODBUS_WRITE_METRICS = {"dhw_stop_extra"}
 
 
 async def async_setup_entry(
@@ -132,5 +137,13 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
     @property
     def available(self):
         """Check if data is available."""
-
-        return self._values.get(self._metric_key) is not None and self._has_write_access
+        config_entry = self.coordinator.config_entry
+        modbus_write_enabled = config_entry.options.get(
+            CONF_MODBUS_WRITE,
+            config_entry.data.get(CONF_MODBUS_WRITE, False),
+        )
+        return (
+            (self._metric_key not in MODBUS_WRITE_METRICS or modbus_write_enabled)
+            and self._values.get(self._metric_key) is not None
+            and self._has_write_access
+        )

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -534,14 +534,22 @@
         "data": {
           "password": "Passwort",
           "username": "Benutzername",
-          "modbus_tcp": "Modbus TCP statt HTTP-Abfragen verwenden"
+          "modbus_tcp": "Modbus TCP statt HTTP-Abfragen verwenden",
+          "modbus_write": "Schreiben über Modbus aktivieren"
+        },
+        "data_description": {
+          "modbus_write": "Durch die Aktivierung des Modbus-Schreibens übernehmen Sie die volle Verantwortung für alle über die Schnittstelle geschriebenen Werte. Der Hersteller haftet nicht für Probleme, die durch falsche oder außerhalb des Bereichs liegende Werte verursacht werden, und solche Maßnahmen können die Garantie und/oder die Lebensdauer und Leistung des Produkts beeinträchtigen."
         }
       },
       "reconfigure": {
         "description": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest, Schreiben/Steuerung erfolgt weiterhin über HTTP-API",
         "data": {
           "password": "Passwort",
-          "username": "Benutzername"
+          "username": "Benutzername",
+          "modbus_write": "Schreiben über Modbus aktivieren"
+        },
+        "data_description": {
+          "modbus_write": "Durch die Aktivierung des Modbus-Schreibens übernehmen Sie die volle Verantwortung für alle über die Schnittstelle geschriebenen Werte. Der Hersteller haftet nicht für Probleme, die durch falsche oder außerhalb des Bereichs liegende Werte verursacht werden, und solche Maßnahmen können die Garantie und/oder die Lebensdauer und Leistung des Produkts beeinträchtigen."
         }
       }
     }
@@ -552,7 +560,11 @@
         "data": {
           "scan_interval": "HTTP-Scan-Intervall (Sekunden)",
           "modbus_tcp": "Modbus TCP statt HTTP-Abfragen verwenden",
-          "modbus_host": "Qvantum Host/IP"
+          "modbus_host": "Qvantum Host/IP",
+          "modbus_write": "Schreiben über Modbus aktivieren"
+        },
+        "data_description": {
+          "modbus_write": "Durch die Aktivierung des Modbus-Schreibens übernehmen Sie die volle Verantwortung für alle über die Schnittstelle geschriebenen Werte. Der Hersteller haftet nicht für Probleme, die durch falsche oder außerhalb des Bereichs liegende Werte verursacht werden, und solche Maßnahmen können die Garantie und/oder die Lebensdauer und Leistung des Produkts beeinträchtigen."
         },
         "description": "Ändern Sie Ihre Optionen.",
         "title": "Optionen"

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -530,7 +530,7 @@
     },
     "step": {
       "user": {
-        "description": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest, Schreiben/Steuerung erfolgt weiterhin über HTTP-API",
+        "description": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest; Schreiben/Steuerung erfolgt weiterhin über die HTTP-API, es sei denn, Schreiben ist ebenfalls aktiviert. Bestimmte Steuerungen werden über Modbus geschrieben.",
         "data": {
           "password": "Passwort",
           "username": "Benutzername",
@@ -543,7 +543,7 @@
         }
       },
       "reconfigure": {
-        "description": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest, Schreiben/Steuerung erfolgt weiterhin über HTTP-API",
+        "description": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest; Schreiben/Steuerung erfolgt weiterhin über die HTTP-API, es sei denn, Schreiben ist ebenfalls aktiviert. Bestimmte Steuerungen werden über Modbus geschrieben.",
         "data": {
           "password": "Passwort",
           "username": "Benutzername",

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -534,10 +534,11 @@
         "data": {
           "password": "Passwort",
           "username": "Benutzername",
-          "modbus_tcp": "Modbus TCP statt HTTP-Abfragen verwenden",
+          "modbus_tcp": "Modbus-Lesen statt HTTP-Abfragen verwenden",
           "modbus_write": "Schreiben über Modbus aktivieren"
         },
         "data_description": {
+          "modbus_tcp": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest; Schreiben/Steuerung erfolgt weiterhin über die HTTP-API, es sei denn, Schreiben ist ebenfalls aktiviert. Bestimmte Steuerungen werden über Modbus geschrieben.",
           "modbus_write": "Durch die Aktivierung des Modbus-Schreibens übernehmen Sie die volle Verantwortung für alle über die Schnittstelle geschriebenen Werte. Der Hersteller haftet nicht für Probleme, die durch falsche oder außerhalb des Bereichs liegende Werte verursacht werden, und solche Maßnahmen können die Garantie und/oder die Lebensdauer und Leistung des Produkts beeinträchtigen."
         }
       },
@@ -546,9 +547,11 @@
         "data": {
           "password": "Passwort",
           "username": "Benutzername",
+          "modbus_tcp": "Modbus-Lesen statt HTTP-Abfragen verwenden",
           "modbus_write": "Schreiben über Modbus aktivieren"
         },
         "data_description": {
+          "modbus_tcp": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest; Schreiben/Steuerung erfolgt weiterhin über die HTTP-API, es sei denn, Schreiben ist ebenfalls aktiviert. Bestimmte Steuerungen werden über Modbus geschrieben.",
           "modbus_write": "Durch die Aktivierung des Modbus-Schreibens übernehmen Sie die volle Verantwortung für alle über die Schnittstelle geschriebenen Werte. Der Hersteller haftet nicht für Probleme, die durch falsche oder außerhalb des Bereichs liegende Werte verursacht werden, und solche Maßnahmen können die Garantie und/oder die Lebensdauer und Leistung des Produkts beeinträchtigen."
         }
       }
@@ -559,11 +562,12 @@
       "init": {
         "data": {
           "scan_interval": "HTTP-Scan-Intervall (Sekunden)",
-          "modbus_tcp": "Modbus TCP statt HTTP-Abfragen verwenden",
+          "modbus_tcp": "Modbus-Lesen statt HTTP-Abfragen verwenden",
           "modbus_host": "Qvantum Host/IP",
           "modbus_write": "Schreiben über Modbus aktivieren"
         },
         "data_description": {
+          "modbus_tcp": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest; Schreiben/Steuerung erfolgt weiterhin über die HTTP-API, es sei denn, Schreiben ist ebenfalls aktiviert. Bestimmte Steuerungen werden über Modbus geschrieben.",
           "modbus_write": "Durch die Aktivierung des Modbus-Schreibens übernehmen Sie die volle Verantwortung für alle über die Schnittstelle geschriebenen Werte. Der Hersteller haftet nicht für Probleme, die durch falsche oder außerhalb des Bereichs liegende Werte verursacht werden, und solche Maßnahmen können die Garantie und/oder die Lebensdauer und Leistung des Produkts beeinträchtigen."
         },
         "description": "Ändern Sie Ihre Optionen.",

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -534,14 +534,22 @@
         "data": {
           "password": "Password",
           "username": "Username",
-          "modbus_tcp": "Use Modbus TCP instead of HTTP polling"
+          "modbus_tcp": "Use Modbus TCP instead of HTTP polling",
+          "modbus_write": "Enable writing via Modbus"
+        },
+        "data_description": {
+          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
         }
       },
       "reconfigure": {
         "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus, write/controls are still via HTTP API",
         "data": {
           "password": "Password",
-          "username": "Username"
+          "username": "Username",
+          "modbus_write": "Enable writing via Modbus"
+        },
+        "data_description": {
+          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
         }
       }
     }
@@ -552,7 +560,11 @@
         "data": {
           "scan_interval": "HTTP Scan Interval (seconds)",
           "modbus_tcp": "Use Modbus TCP instead of HTTP polling",
-          "modbus_host": "Qvantum Host/IP"
+          "modbus_host": "Qvantum Host/IP",
+          "modbus_write": "Enable writing via Modbus"
+        },
+        "data_description": {
+          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
         },
         "description": "Amend your options.",
         "title": "Options"

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -538,7 +538,7 @@
           "modbus_write": "Enable writing via Modbus"
         },
         "data_description": {
-          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus, write/controls are still via HTTP API unless write is also enabled, certain controls are written via Modbus.",
+          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
           "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
         }
       },
@@ -551,7 +551,7 @@
           "modbus_write": "Enable writing via Modbus"
         },
         "data_description": {
-          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus, write/controls are still via HTTP API unless write is also enabled, certain controls are written via Modbus.",
+          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
           "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
         }
       }
@@ -567,7 +567,7 @@
           "modbus_write": "Enable writing via Modbus"
         },
         "data_description": {
-          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus, write/controls are still via HTTP API unless write is also enabled, certain controls are written via Modbus.",
+          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
           "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
         },
         "description": "Amend your options.",

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -530,7 +530,7 @@
     },
     "step": {
       "user": {
-        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus, write/controls are still via HTTP API",
+        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. By default it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
         "data": {
           "password": "Password",
           "username": "Username",
@@ -543,7 +543,7 @@
         }
       },
       "reconfigure": {
-        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus, write/controls are still via HTTP API",
+        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. By default it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
         "data": {
           "password": "Password",
           "username": "Username",

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -534,10 +534,11 @@
         "data": {
           "password": "Password",
           "username": "Username",
-          "modbus_tcp": "Use Modbus TCP instead of HTTP polling",
+          "modbus_tcp": "Use Modbus reading instead of HTTP polling",
           "modbus_write": "Enable writing via Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus, write/controls are still via HTTP API unless write is also enabled, certain controls are written via Modbus.",
           "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
         }
       },
@@ -546,9 +547,11 @@
         "data": {
           "password": "Password",
           "username": "Username",
+          "modbus_tcp": "Use Modbus reading instead of HTTP polling",
           "modbus_write": "Enable writing via Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus, write/controls are still via HTTP API unless write is also enabled, certain controls are written via Modbus.",
           "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
         }
       }
@@ -559,11 +562,12 @@
       "init": {
         "data": {
           "scan_interval": "HTTP Scan Interval (seconds)",
-          "modbus_tcp": "Use Modbus TCP instead of HTTP polling",
+          "modbus_tcp": "Use Modbus reading instead of HTTP polling",
           "modbus_host": "Qvantum Host/IP",
           "modbus_write": "Enable writing via Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus, write/controls are still via HTTP API unless write is also enabled, certain controls are written via Modbus.",
           "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
         },
         "description": "Amend your options.",

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -535,10 +535,11 @@
         "data": {
           "password": "Contraseña",
           "username": "Nombre de usuario",
-          "modbus_tcp": "Usar Modbus TCP en lugar de sondeo HTTP",
+          "modbus_tcp": "Usar lectura Modbus en lugar de sondeo HTTP",
           "modbus_write": "Activar escritura mediante Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus; la escritura/control sigue siendo vía API HTTP a menos que también se habilite la escritura. Algunos controles se escriben mediante Modbus.",
           "modbus_write": "Al activar la escritura Modbus, aceptas la plena responsabilidad de cualquier valor escrito a través de la interfaz. El fabricante no es responsable de los problemas causados por valores incorrectos o fuera de rango, y tales acciones pueden anular la garantía y/o afectar el ciclo de vida y el rendimiento del producto."
         }
       },
@@ -547,9 +548,11 @@
         "data": {
           "password": "Contraseña",
           "username": "Nombre de usuario",
+          "modbus_tcp": "Usar lectura Modbus en lugar de sondeo HTTP",
           "modbus_write": "Activar escritura mediante Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus; la escritura/control sigue siendo vía API HTTP a menos que también se habilite la escritura. Algunos controles se escriben mediante Modbus.",
           "modbus_write": "Al activar la escritura Modbus, aceptas la plena responsabilidad de cualquier valor escrito a través de la interfaz. El fabricante no es responsable de los problemas causados por valores incorrectos o fuera de rango, y tales acciones pueden anular la garantía y/o afectar el ciclo de vida y el rendimiento del producto."
         }
       }
@@ -560,11 +563,12 @@
       "init": {
         "data": {
           "scan_interval": "Intervalo de exploración HTTP (segundos)",
-          "modbus_tcp": "Usar Modbus TCP en lugar de sondeo HTTP",
+          "modbus_tcp": "Usar lectura Modbus en lugar de sondeo HTTP",
           "modbus_host": "Qvantum Host/IP",
           "modbus_write": "Activar escritura mediante Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus; la escritura/control sigue siendo vía API HTTP a menos que también se habilite la escritura. Algunos controles se escriben mediante Modbus.",
           "modbus_write": "Al activar la escritura Modbus, aceptas la plena responsabilidad de cualquier valor escrito a través de la interfaz. El fabricante no es responsable de los problemas causados por valores incorrectos o fuera de rango, y tales acciones pueden anular la garantía y/o afectar el ciclo de vida y el rendimiento del producto."
         },
         "description": "Modifique sus opciones.",

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -531,7 +531,7 @@
     },
     "step": {
       "user": {
-        "description": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus, la escritura/control sigue siendo vía API HTTP",
+        "description": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus; la escritura/control sigue siendo vía API HTTP a menos que también se habilite la escritura. Algunos controles se escriben mediante Modbus.",
         "data": {
           "password": "Contraseña",
           "username": "Nombre de usuario",
@@ -544,7 +544,7 @@
         }
       },
       "reconfigure": {
-        "description": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus, la escritura/control sigue siendo vía API HTTP",
+        "description": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus; la escritura/control sigue siendo vía API HTTP a menos que también se habilite la escritura. Algunos controles se escriben mediante Modbus.",
         "data": {
           "password": "Contraseña",
           "username": "Nombre de usuario",

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -535,14 +535,22 @@
         "data": {
           "password": "Contraseña",
           "username": "Nombre de usuario",
-          "modbus_tcp": "Usar Modbus TCP en lugar de sondeo HTTP"
+          "modbus_tcp": "Usar Modbus TCP en lugar de sondeo HTTP",
+          "modbus_write": "Activar escritura mediante Modbus"
+        },
+        "data_description": {
+          "modbus_write": "Al activar la escritura Modbus, aceptas la plena responsabilidad de cualquier valor escrito a través de la interfaz. El fabricante no es responsable de los problemas causados por valores incorrectos o fuera de rango, y tales acciones pueden anular la garantía y/o afectar el ciclo de vida y el rendimiento del producto."
         }
       },
       "reconfigure": {
         "description": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus, la escritura/control sigue siendo vía API HTTP",
         "data": {
           "password": "Contraseña",
-          "username": "Nombre de usuario"
+          "username": "Nombre de usuario",
+          "modbus_write": "Activar escritura mediante Modbus"
+        },
+        "data_description": {
+          "modbus_write": "Al activar la escritura Modbus, aceptas la plena responsabilidad de cualquier valor escrito a través de la interfaz. El fabricante no es responsable de los problemas causados por valores incorrectos o fuera de rango, y tales acciones pueden anular la garantía y/o afectar el ciclo de vida y el rendimiento del producto."
         }
       }
     }
@@ -553,7 +561,11 @@
         "data": {
           "scan_interval": "Intervalo de exploración HTTP (segundos)",
           "modbus_tcp": "Usar Modbus TCP en lugar de sondeo HTTP",
-          "modbus_host": "Qvantum Host/IP"
+          "modbus_host": "Qvantum Host/IP",
+          "modbus_write": "Activar escritura mediante Modbus"
+        },
+        "data_description": {
+          "modbus_write": "Al activar la escritura Modbus, aceptas la plena responsabilidad de cualquier valor escrito a través de la interfaz. El fabricante no es responsable de los problemas causados por valores incorrectos o fuera de rango, y tales acciones pueden anular la garantía y/o afectar el ciclo de vida y el rendimiento del producto."
         },
         "description": "Modifique sus opciones.",
         "title": "Opciones"

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -533,10 +533,11 @@
         "data": {
           "password": "Mot de passe",
           "username": "Nom d'utilisateur",
-          "modbus_tcp": "Utiliser Modbus TCP au lieu du polling HTTP",
+          "modbus_tcp": "Utiliser la lecture Modbus au lieu du polling HTTP",
           "modbus_write": "Activer l'écriture via Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il lit uniquement via Modbus ; les écritures/contrôles se font toujours via l'API HTTP sauf si l'écriture est également activée. Certains contrôles sont écrits via Modbus.",
           "modbus_write": "En activant l'écriture Modbus, vous acceptez l'entière responsabilité de toutes les valeurs écrites via l'interface. Le fabricant n'est pas responsable des problèmes causés par des valeurs incorrectes ou hors limites, et de telles actions peuvent annuler la garantie et/ou affecter le cycle de vie et les performances du produit."
         }
       },
@@ -545,9 +546,11 @@
         "data": {
           "password": "Mot de passe",
           "username": "Nom d'utilisateur",
+          "modbus_tcp": "Utiliser la lecture Modbus au lieu du polling HTTP",
           "modbus_write": "Activer l'écriture via Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il lit uniquement via Modbus ; les écritures/contrôles se font toujours via l'API HTTP sauf si l'écriture est également activée. Certains contrôles sont écrits via Modbus.",
           "modbus_write": "En activant l'écriture Modbus, vous acceptez l'entière responsabilité de toutes les valeurs écrites via l'interface. Le fabricant n'est pas responsable des problèmes causés par des valeurs incorrectes ou hors limites, et de telles actions peuvent annuler la garantie et/ou affecter le cycle de vie et les performances du produit."
         }
       }
@@ -558,11 +561,12 @@
       "init": {
         "data": {
           "scan_interval": "Intervalle de scan HTTP (secondes)",
-          "modbus_tcp": "Utiliser Modbus TCP au lieu du polling HTTP",
+          "modbus_tcp": "Utiliser la lecture Modbus au lieu du polling HTTP",
           "modbus_host": "Hôte/IP Qvantum",
           "modbus_write": "Activer l'écriture via Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il lit uniquement via Modbus ; les écritures/contrôles se font toujours via l'API HTTP sauf si l'écriture est également activée. Certains contrôles sont écrits via Modbus.",
           "modbus_write": "En activant l'écriture Modbus, vous acceptez l'entière responsabilité de toutes les valeurs écrites via l'interface. Le fabricant n'est pas responsable des problèmes causés par des valeurs incorrectes ou hors limites, et de telles actions peuvent annuler la garantie et/ou affecter le cycle de vie et les performances du produit."
         },
         "description": "Modifiez vos options.",

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -533,14 +533,22 @@
         "data": {
           "password": "Mot de passe",
           "username": "Nom d'utilisateur",
-          "modbus_tcp": "Utiliser Modbus TCP au lieu du polling HTTP"
+          "modbus_tcp": "Utiliser Modbus TCP au lieu du polling HTTP",
+          "modbus_write": "Activer l'écriture via Modbus"
+        },
+        "data_description": {
+          "modbus_write": "En activant l'écriture Modbus, vous acceptez l'entière responsabilité de toutes les valeurs écrites via l'interface. Le fabricant n'est pas responsable des problèmes causés par des valeurs incorrectes ou hors limites, et de telles actions peuvent annuler la garantie et/ou affecter le cycle de vie et les performances du produit."
         }
       },
       "reconfigure": {
         "description": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il ne fait que lire via Modbus, les écritures/contrôles se font toujours via l'API HTTP",
         "data": {
           "password": "Mot de passe",
-          "username": "Nom d'utilisateur"
+          "username": "Nom d'utilisateur",
+          "modbus_write": "Activer l'écriture via Modbus"
+        },
+        "data_description": {
+          "modbus_write": "En activant l'écriture Modbus, vous acceptez l'entière responsabilité de toutes les valeurs écrites via l'interface. Le fabricant n'est pas responsable des problèmes causés par des valeurs incorrectes ou hors limites, et de telles actions peuvent annuler la garantie et/ou affecter le cycle de vie et les performances du produit."
         }
       }
     }
@@ -551,7 +559,11 @@
         "data": {
           "scan_interval": "Intervalle de scan HTTP (secondes)",
           "modbus_tcp": "Utiliser Modbus TCP au lieu du polling HTTP",
-          "modbus_host": "Hôte/IP Qvantum"
+          "modbus_host": "Hôte/IP Qvantum",
+          "modbus_write": "Activer l'écriture via Modbus"
+        },
+        "data_description": {
+          "modbus_write": "En activant l'écriture Modbus, vous acceptez l'entière responsabilité de toutes les valeurs écrites via l'interface. Le fabricant n'est pas responsable des problèmes causés par des valeurs incorrectes ou hors limites, et de telles actions peuvent annuler la garantie et/ou affecter le cycle de vie et les performances du produit."
         },
         "description": "Modifiez vos options.",
         "title": "Options"

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -529,7 +529,7 @@
     },
     "step": {
       "user": {
-        "description": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il ne fait que lire via Modbus, les écritures/contrôles se font toujours via l'API HTTP",
+        "description": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il lit uniquement via Modbus ; les écritures/contrôles se font toujours via l'API HTTP sauf si l'écriture est également activée. Certains contrôles sont écrits via Modbus.",
         "data": {
           "password": "Mot de passe",
           "username": "Nom d'utilisateur",
@@ -542,7 +542,7 @@
         }
       },
       "reconfigure": {
-        "description": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il ne fait que lire via Modbus, les écritures/contrôles se font toujours via l'API HTTP",
+        "description": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il lit uniquement via Modbus ; les écritures/contrôles se font toujours via l'API HTTP sauf si l'écriture est également activée. Certains contrôles sont écrits via Modbus.",
         "data": {
           "password": "Mot de passe",
           "username": "Nom d'utilisateur",

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -529,7 +529,7 @@
     },
     "step": {
       "user": {
-        "description": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: a Modbus csak olvas, az írás/vezérlés továbbra is HTTP API-n keresztül történik.",
+        "description": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: itt csak Modbus-olvasás történik; az írás/vezérlés továbbra is HTTP API-n keresztül történik, kivéve, ha az írás is engedélyezve van. Bizonyos vezérlések Modbuson keresztül íródnak.",
         "data": {
           "password": "Jelszó",
           "username": "Felhasználónév",
@@ -542,7 +542,7 @@
         }
       },
       "reconfigure": {
-        "description": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: a Modbus csak olvas, az írás/vezérlés továbbra is HTTP API-n keresztül történik.",
+        "description": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: itt csak Modbus-olvasás történik; az írás/vezérlés továbbra is HTTP API-n keresztül történik, kivéve, ha az írás is engedélyezve van. Bizonyos vezérlések Modbuson keresztül íródnak.",
         "data": {
           "password": "Jelszó",
           "username": "Felhasználónév",

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -533,10 +533,11 @@
         "data": {
           "password": "Jelszó",
           "username": "Felhasználónév",
-          "modbus_tcp": "Modbus TCP használata HTTP lekérdezés helyett",
+          "modbus_tcp": "Modbus-olvasás használata HTTP lekérdezés helyett",
           "modbus_write": "Modbus alapú írás engedélyezése"
         },
         "data_description": {
+          "modbus_tcp": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: itt csak Modbus-olvasás történik; az írás/vezérlés továbbra is HTTP API-n keresztül történik, kivéve, ha az írás is engedélyezve van. Bizonyos vezérlések Modbuson keresztül íródnak.",
           "modbus_write": "A Modbus-írás aktiválásával teljes felelősséget vállal a felületen keresztül írt értékekért. A gyártó nem vállal felelősséget a helytelen vagy tartományon kívüli értékek által okozott problémákért, és az ilyen műveletek érvénytelenítheti a garanciát és/vagy befolyásolhatja a termék élettartamát és teljesítményét."
         }
       },
@@ -545,9 +546,11 @@
         "data": {
           "password": "Jelszó",
           "username": "Felhasználónév",
+          "modbus_tcp": "Modbus-olvasás használata HTTP lekérdezés helyett",
           "modbus_write": "Modbus alapú írás engedélyezése"
         },
         "data_description": {
+          "modbus_tcp": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: itt csak Modbus-olvasás történik; az írás/vezérlés továbbra is HTTP API-n keresztül történik, kivéve, ha az írás is engedélyezve van. Bizonyos vezérlések Modbuson keresztül íródnak.",
           "modbus_write": "A Modbus-írás aktiválásával teljes felelősséget vállal a felületen keresztül írt értékekért. A gyártó nem vállal felelősséget a helytelen vagy tartományon kívüli értékek által okozott problémákért, és az ilyen műveletek érvénytelenítheti a garanciát és/vagy befolyásolhatja a termék élettartamát és teljesítményét."
         }
       }
@@ -558,11 +561,12 @@
       "init": {
         "data": {
           "scan_interval": "HTTP lekérdezési időköz (másodperc)",
-          "modbus_tcp": "Modbus TCP használata HTTP lekérdezés helyett",
+          "modbus_tcp": "Modbus-olvasás használata HTTP lekérdezés helyett",
           "modbus_host": "Qvantum Hoszt/IP",
           "modbus_write": "Modbus alapú írás engedélyezése"
         },
         "data_description": {
+          "modbus_tcp": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: itt csak Modbus-olvasás történik; az írás/vezérlés továbbra is HTTP API-n keresztül történik, kivéve, ha az írás is engedélyezve van. Bizonyos vezérlések Modbuson keresztül íródnak.",
           "modbus_write": "A Modbus-írás aktiválásával teljes felelősséget vállal a felületen keresztül írt értékekért. A gyártó nem vállal felelősséget a helytelen vagy tartományon kívüli értékek által okozott problémákért, és az ilyen műveletek érvénytelenítheti a garanciát és/vagy befolyásolhatja a termék élettartamát és teljesítményét."
         },
         "description": "Módosítsa a beállításait.",

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -533,14 +533,22 @@
         "data": {
           "password": "Jelszó",
           "username": "Felhasználónév",
-          "modbus_tcp": "Modbus TCP használata HTTP lekérdezés helyett"
+          "modbus_tcp": "Modbus TCP használata HTTP lekérdezés helyett",
+          "modbus_write": "Modbus alapú írás engedélyezése"
+        },
+        "data_description": {
+          "modbus_write": "A Modbus-írás aktiválásával teljes felelősséget vállal a felületen keresztül írt értékekért. A gyártó nem vállal felelősséget a helytelen vagy tartományon kívüli értékek által okozott problémákért, és az ilyen műveletek érvénytelenítheti a garanciát és/vagy befolyásolhatja a termék élettartamát és teljesítményét."
         }
       },
       "reconfigure": {
         "description": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: a Modbus csak olvas, az írás/vezérlés továbbra is HTTP API-n keresztül történik.",
         "data": {
           "password": "Jelszó",
-          "username": "Felhasználónév"
+          "username": "Felhasználónév",
+          "modbus_write": "Modbus alapú írás engedélyezése"
+        },
+        "data_description": {
+          "modbus_write": "A Modbus-írás aktiválásával teljes felelősséget vállal a felületen keresztül írt értékekért. A gyártó nem vállal felelősséget a helytelen vagy tartományon kívüli értékek által okozott problémákért, és az ilyen műveletek érvénytelenítheti a garanciát és/vagy befolyásolhatja a termék élettartamát és teljesítményét."
         }
       }
     }
@@ -551,7 +559,11 @@
         "data": {
           "scan_interval": "HTTP lekérdezési időköz (másodperc)",
           "modbus_tcp": "Modbus TCP használata HTTP lekérdezés helyett",
-          "modbus_host": "Qvantum Hoszt/IP"
+          "modbus_host": "Qvantum Hoszt/IP",
+          "modbus_write": "Modbus alapú írás engedélyezése"
+        },
+        "data_description": {
+          "modbus_write": "A Modbus-írás aktiválásával teljes felelősséget vállal a felületen keresztül írt értékekért. A gyártó nem vállal felelősséget a helytelen vagy tartományon kívüli értékek által okozott problémákért, és az ilyen műveletek érvénytelenítheti a garanciát és/vagy befolyásolhatja a termék élettartamát és teljesítményét."
         },
         "description": "Módosítsa a beállításait.",
         "title": "Beállítások"

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -531,7 +531,7 @@
     },
     "step": {
       "user": {
-        "description": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest, schrijven/sturing gebeurt nog via de HTTP API",
+        "description": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest; schrijven/sturing gebeurt nog via de HTTP API, tenzij schrijven ook is ingeschakeld. Bepaalde besturingen worden via Modbus geschreven.",
         "data": {
           "password": "Wachtwoord",
           "username": "Gebruikersnaam",
@@ -544,7 +544,7 @@
         }
       },
       "reconfigure": {
-        "description": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest, schrijven/sturing gebeurt nog via de HTTP API",
+        "description": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest; schrijven/sturing gebeurt nog via de HTTP API, tenzij schrijven ook is ingeschakeld. Bepaalde besturingen worden via Modbus geschreven.",
         "data": {
           "password": "Wachtwoord",
           "username": "Gebruikersnaam",

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -535,14 +535,22 @@
         "data": {
           "password": "Wachtwoord",
           "username": "Gebruikersnaam",
-          "modbus_tcp": "Gebruik Modbus TCP in plaats van HTTP-polling"
+          "modbus_tcp": "Gebruik Modbus TCP in plaats van HTTP-polling",
+          "modbus_write": "Schrijven via Modbus inschakelen"
+        },
+        "data_description": {
+          "modbus_write": "Door het activeren van Modbus-schrijven aanvaardt u volledige verantwoordelijkheid voor alle waarden die via de interface worden geschreven. De fabrikant is niet aansprakelijk voor problemen veroorzaakt door onjuiste of buiten bereik vallende waarden, en dergelijke acties kunnen de garantie en/of de levensduur en prestaties van het product beïnvloeden."
         }
       },
       "reconfigure": {
         "description": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest, schrijven/sturing gebeurt nog via de HTTP API",
         "data": {
           "password": "Wachtwoord",
-          "username": "Gebruikersnaam"
+          "username": "Gebruikersnaam",
+          "modbus_write": "Schrijven via Modbus inschakelen"
+        },
+        "data_description": {
+          "modbus_write": "Door het activeren van Modbus-schrijven aanvaardt u volledige verantwoordelijkheid voor alle waarden die via de interface worden geschreven. De fabrikant is niet aansprakelijk voor problemen veroorzaakt door onjuiste of buiten bereik vallende waarden, en dergelijke acties kunnen de garantie en/of de levensduur en prestaties van het product beïnvloeden."
         }
       }
     }
@@ -553,7 +561,11 @@
         "data": {
           "scan_interval": "HTTP-scaninterval (seconden)",
           "modbus_tcp": "Gebruik Modbus TCP in plaats van HTTP-polling",
-          "modbus_host": "Qvantum Host/IP"
+          "modbus_host": "Qvantum Host/IP",
+          "modbus_write": "Schrijven via Modbus inschakelen"
+        },
+        "data_description": {
+          "modbus_write": "Door het activeren van Modbus-schrijven aanvaardt u volledige verantwoordelijkheid voor alle waarden die via de interface worden geschreven. De fabrikant is niet aansprakelijk voor problemen veroorzaakt door onjuiste of buiten bereik vallende waarden, en dergelijke acties kunnen de garantie en/of de levensduur en prestaties van het product beïnvloeden."
         },
         "description": "Wijzig uw opties.",
         "title": "Opties"

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -535,10 +535,11 @@
         "data": {
           "password": "Wachtwoord",
           "username": "Gebruikersnaam",
-          "modbus_tcp": "Gebruik Modbus TCP in plaats van HTTP-polling",
+          "modbus_tcp": "Gebruik Modbus-uitlezing in plaats van HTTP-polling",
           "modbus_write": "Schrijven via Modbus inschakelen"
         },
         "data_description": {
+          "modbus_tcp": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest; schrijven/sturing gebeurt nog via de HTTP API, tenzij schrijven ook is ingeschakeld. Bepaalde besturingen worden via Modbus geschreven.",
           "modbus_write": "Door het activeren van Modbus-schrijven aanvaardt u volledige verantwoordelijkheid voor alle waarden die via de interface worden geschreven. De fabrikant is niet aansprakelijk voor problemen veroorzaakt door onjuiste of buiten bereik vallende waarden, en dergelijke acties kunnen de garantie en/of de levensduur en prestaties van het product beïnvloeden."
         }
       },
@@ -547,9 +548,11 @@
         "data": {
           "password": "Wachtwoord",
           "username": "Gebruikersnaam",
+          "modbus_tcp": "Gebruik Modbus-uitlezing in plaats van HTTP-polling",
           "modbus_write": "Schrijven via Modbus inschakelen"
         },
         "data_description": {
+          "modbus_tcp": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest; schrijven/sturing gebeurt nog via de HTTP API, tenzij schrijven ook is ingeschakeld. Bepaalde besturingen worden via Modbus geschreven.",
           "modbus_write": "Door het activeren van Modbus-schrijven aanvaardt u volledige verantwoordelijkheid voor alle waarden die via de interface worden geschreven. De fabrikant is niet aansprakelijk voor problemen veroorzaakt door onjuiste of buiten bereik vallende waarden, en dergelijke acties kunnen de garantie en/of de levensduur en prestaties van het product beïnvloeden."
         }
       }
@@ -560,11 +563,12 @@
       "init": {
         "data": {
           "scan_interval": "HTTP-scaninterval (seconden)",
-          "modbus_tcp": "Gebruik Modbus TCP in plaats van HTTP-polling",
+          "modbus_tcp": "Gebruik Modbus-uitlezing in plaats van HTTP-polling",
           "modbus_host": "Qvantum Host/IP",
           "modbus_write": "Schrijven via Modbus inschakelen"
         },
         "data_description": {
+          "modbus_tcp": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest; schrijven/sturing gebeurt nog via de HTTP API, tenzij schrijven ook is ingeschakeld. Bepaalde besturingen worden via Modbus geschreven.",
           "modbus_write": "Door het activeren van Modbus-schrijven aanvaardt u volledige verantwoordelijkheid voor alle waarden die via de interface worden geschreven. De fabrikant is niet aansprakelijk voor problemen veroorzaakt door onjuiste of buiten bereik vallende waarden, en dergelijke acties kunnen de garantie en/of de levensduur en prestaties van het product beïnvloeden."
         },
         "description": "Wijzig uw opties.",

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -533,14 +533,22 @@
         "data": {
           "password": "Hasło",
           "username": "Nazwa użytkownika",
-          "modbus_tcp": "Użyj Modbus TCP zamiast odpytywania HTTP"
+          "modbus_tcp": "Użyj Modbus TCP zamiast odpytywania HTTP",
+          "modbus_write": "Włącz zapis przez Modbus"
+        },
+        "data_description": {
+          "modbus_write": "Aktywując zapis przez Modbus, bierzesz pełną odpowiedzialność za wszelkie wartości zapisane przez interfejs. Producent nie ponosi odpowiedzialności za problemy spowodowane przez nieprawidłowe lub wykraczające poza zakres wartości, a takie działania mogą unieważnić gwarancję i/lub wpłynąć na żywotność i wydajność produktu."
         }
       },
       "reconfigure": {
         "description": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: odczytuje tylko przez Modbus, zapis/sterowanie nadal odbywa się przez HTTP API",
         "data": {
           "password": "Hasło",
-          "username": "Nazwa użytkownika"
+          "username": "Nazwa użytkownika",
+          "modbus_write": "Włącz zapis przez Modbus"
+        },
+        "data_description": {
+          "modbus_write": "Aktywując zapis przez Modbus, bierzesz pełną odpowiedzialność za wszelkie wartości zapisane przez interfejs. Producent nie ponosi odpowiedzialności za problemy spowodowane przez nieprawidłowe lub wykraczające poza zakres wartości, a takie działania mogą unieważnić gwarancję i/lub wpłynąć na żywotność i wydajność produktu."
         }
       }
     }
@@ -551,7 +559,11 @@
         "data": {
           "scan_interval": "Interwał skanowania HTTP (sekundy)",
           "modbus_tcp": "Użyj Modbus TCP zamiast odpytywania HTTP",
-          "modbus_host": "Host/IP Qvantum"
+          "modbus_host": "Host/IP Qvantum",
+          "modbus_write": "Włącz zapis przez Modbus"
+        },
+        "data_description": {
+          "modbus_write": "Aktywując zapis przez Modbus, bierzesz pełną odpowiedzialność za wszelkie wartości zapisane przez interfejs. Producent nie ponosi odpowiedzialności za problemy spowodowane przez nieprawidłowe lub wykraczające poza zakres wartości, a takie działania mogą unieważnić gwarancję i/lub wpłynąć na żywotność i wydajność produktu."
         },
         "description": "Zmień swoje opcje.",
         "title": "Opcje"

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -533,10 +533,11 @@
         "data": {
           "password": "Hasło",
           "username": "Nazwa użytkownika",
-          "modbus_tcp": "Użyj Modbus TCP zamiast odpytywania HTTP",
+          "modbus_tcp": "Użyj odczytu Modbus zamiast odpytywania HTTP",
           "modbus_write": "Włącz zapis przez Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: tutaj działa tylko odczyt przez Modbus; zapis/sterowanie nadal odbywa się przez HTTP API, chyba że zapis również jest włączony. Niektóre funkcje sterowania są zapisywane przez Modbus.",
           "modbus_write": "Aktywując zapis przez Modbus, bierzesz pełną odpowiedzialność za wszelkie wartości zapisane przez interfejs. Producent nie ponosi odpowiedzialności za problemy spowodowane przez nieprawidłowe lub wykraczające poza zakres wartości, a takie działania mogą unieważnić gwarancję i/lub wpłynąć na żywotność i wydajność produktu."
         }
       },
@@ -545,9 +546,11 @@
         "data": {
           "password": "Hasło",
           "username": "Nazwa użytkownika",
+          "modbus_tcp": "Użyj odczytu Modbus zamiast odpytywania HTTP",
           "modbus_write": "Włącz zapis przez Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: tutaj działa tylko odczyt przez Modbus; zapis/sterowanie nadal odbywa się przez HTTP API, chyba że zapis również jest włączony. Niektóre funkcje sterowania są zapisywane przez Modbus.",
           "modbus_write": "Aktywując zapis przez Modbus, bierzesz pełną odpowiedzialność za wszelkie wartości zapisane przez interfejs. Producent nie ponosi odpowiedzialności za problemy spowodowane przez nieprawidłowe lub wykraczające poza zakres wartości, a takie działania mogą unieważnić gwarancję i/lub wpłynąć na żywotność i wydajność produktu."
         }
       }
@@ -558,11 +561,12 @@
       "init": {
         "data": {
           "scan_interval": "Interwał skanowania HTTP (sekundy)",
-          "modbus_tcp": "Użyj Modbus TCP zamiast odpytywania HTTP",
+          "modbus_tcp": "Użyj odczytu Modbus zamiast odpytywania HTTP",
           "modbus_host": "Host/IP Qvantum",
           "modbus_write": "Włącz zapis przez Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: tutaj działa tylko odczyt przez Modbus; zapis/sterowanie nadal odbywa się przez HTTP API, chyba że zapis również jest włączony. Niektóre funkcje sterowania są zapisywane przez Modbus.",
           "modbus_write": "Aktywując zapis przez Modbus, bierzesz pełną odpowiedzialność za wszelkie wartości zapisane przez interfejs. Producent nie ponosi odpowiedzialności za problemy spowodowane przez nieprawidłowe lub wykraczające poza zakres wartości, a takie działania mogą unieważnić gwarancję i/lub wpłynąć na żywotność i wydajność produktu."
         },
         "description": "Zmień swoje opcje.",

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -529,7 +529,7 @@
     },
     "step": {
       "user": {
-        "description": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: odczytuje tylko przez Modbus, zapis/sterowanie nadal odbywa się przez HTTP API",
+        "description": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: tutaj działa tylko odczyt przez Modbus; zapis/sterowanie nadal odbywa się przez HTTP API, chyba że zapis również jest włączony. Niektóre funkcje sterowania są zapisywane przez Modbus.",
         "data": {
           "password": "Hasło",
           "username": "Nazwa użytkownika",
@@ -542,7 +542,7 @@
         }
       },
       "reconfigure": {
-        "description": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: odczytuje tylko przez Modbus, zapis/sterowanie nadal odbywa się przez HTTP API",
+        "description": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: tutaj działa tylko odczyt przez Modbus; zapis/sterowanie nadal odbywa się przez HTTP API, chyba że zapis również jest włączony. Niektóre funkcje sterowania są zapisywane przez Modbus.",
         "data": {
           "password": "Hasło",
           "username": "Nazwa użytkownika",

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -533,7 +533,7 @@
     },
     "step": {
       "user": {
-        "description": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus, skrivning/kontroller sker fortfarande via HTTP API",
+        "description": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus; skrivning/kontroller sker fortfarande via HTTP API om inte skrivning också är aktiverad. Vissa kontroller skrivs via Modbus.",
         "data": {
           "password": "Lösenord",
           "username": "Användarnamn",
@@ -546,7 +546,7 @@
         }
       },
       "reconfigure": {
-        "description": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus, skrivning/kontroller sker fortfarande via HTTP API",
+        "description": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus; skrivning/kontroller sker fortfarande via HTTP API om inte skrivning också är aktiverad. Vissa kontroller skrivs via Modbus.",
         "data": {
           "password": "Lösenord",
           "username": "Användarnamn",

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -537,14 +537,22 @@
         "data": {
           "password": "Lösenord",
           "username": "Användarnamn",
-          "modbus_tcp": "Använd Modbus TCP istället för HTTP-förfrågning"
+          "modbus_tcp": "Använd Modbus TCP istället för HTTP-förfrågning",
+          "modbus_write": "Aktivera skrivning via Modbus"
+        },
+        "data_description": {
+          "modbus_write": "Genom att aktivera Modbus-skrivning tar du fullt ansvar för alla värden som skrivs via gränssnittet. Tillverkaren ansvarar inte för problem orsakade av felaktiga eller utanför intervallet liggande värden, och sådana åtgärder kan ogiltigförklara garantin och/eller påverka produktens livslängd och prestanda."
         }
       },
       "reconfigure": {
         "description": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus, skrivning/kontroller sker fortfarande via HTTP API",
         "data": {
           "password": "Lösenord",
-          "username": "Användarnamn"
+          "username": "Användarnamn",
+          "modbus_write": "Aktivera skrivning via Modbus"
+        },
+        "data_description": {
+          "modbus_write": "Genom att aktivera Modbus-skrivning tar du fullt ansvar för alla värden som skrivs via gränssnittet. Tillverkaren ansvarar inte för problem orsakade av felaktiga eller utanför intervallet liggande värden, och sådana åtgärder kan ogiltigförklara garantin och/eller påverka produktens livslängd och prestanda."
         }
       }
     }
@@ -555,7 +563,11 @@
         "data": {
           "scan_interval": "HTTP-skanningsintervall (sekunder)",
           "modbus_tcp": "Använd Modbus TCP istället för HTTP-förfrågning",
-          "modbus_host": "Qvantum Host/IP"
+          "modbus_host": "Qvantum Host/IP",
+          "modbus_write": "Aktivera skrivning via Modbus"
+        },
+        "data_description": {
+          "modbus_write": "Genom att aktivera Modbus-skrivning tar du fullt ansvar för alla värden som skrivs via gränssnittet. Tillverkaren ansvarar inte för problem orsakade av felaktiga eller utanför intervallet liggande värden, och sådana åtgärder kan ogiltigförklara garantin och/eller påverka produktens livslängd och prestanda."
         },
         "description": "Ändra alternativ.",
         "title": "Alternativ"

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -537,10 +537,11 @@
         "data": {
           "password": "Lösenord",
           "username": "Användarnamn",
-          "modbus_tcp": "Använd Modbus TCP istället för HTTP-förfrågning",
+          "modbus_tcp": "Använd Modbus-avläsning istället för HTTP-förfrågning",
           "modbus_write": "Aktivera skrivning via Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus; skrivning/kontroller sker fortfarande via HTTP API om inte skrivning också är aktiverad. Vissa kontroller skrivs via Modbus.",
           "modbus_write": "Genom att aktivera Modbus-skrivning tar du fullt ansvar för alla värden som skrivs via gränssnittet. Tillverkaren ansvarar inte för problem orsakade av felaktiga eller utanför intervallet liggande värden, och sådana åtgärder kan ogiltigförklara garantin och/eller påverka produktens livslängd och prestanda."
         }
       },
@@ -549,9 +550,11 @@
         "data": {
           "password": "Lösenord",
           "username": "Användarnamn",
+          "modbus_tcp": "Använd Modbus-avläsning istället för HTTP-förfrågning",
           "modbus_write": "Aktivera skrivning via Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus; skrivning/kontroller sker fortfarande via HTTP API om inte skrivning också är aktiverad. Vissa kontroller skrivs via Modbus.",
           "modbus_write": "Genom att aktivera Modbus-skrivning tar du fullt ansvar för alla värden som skrivs via gränssnittet. Tillverkaren ansvarar inte för problem orsakade av felaktiga eller utanför intervallet liggande värden, och sådana åtgärder kan ogiltigförklara garantin och/eller påverka produktens livslängd och prestanda."
         }
       }
@@ -562,11 +565,12 @@
       "init": {
         "data": {
           "scan_interval": "HTTP-skanningsintervall (sekunder)",
-          "modbus_tcp": "Använd Modbus TCP istället för HTTP-förfrågning",
+          "modbus_tcp": "Använd Modbus-avläsning istället för HTTP-förfrågning",
           "modbus_host": "Qvantum Host/IP",
           "modbus_write": "Aktivera skrivning via Modbus"
         },
         "data_description": {
+          "modbus_tcp": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus; skrivning/kontroller sker fortfarande via HTTP API om inte skrivning också är aktiverad. Vissa kontroller skrivs via Modbus.",
           "modbus_write": "Genom att aktivera Modbus-skrivning tar du fullt ansvar för alla värden som skrivs via gränssnittet. Tillverkaren ansvarar inte för problem orsakade av felaktiga eller utanför intervallet liggande värden, och sådana åtgärder kan ogiltigförklara garantin och/eller påverka produktens livslängd och prestanda."
         },
         "description": "Ändra alternativ.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,6 +86,7 @@ def mock_config_entry():
         "username": "test@example.com",
         "password": "test_password",
     }
+    entry.options = {}
     entry.title = "Test Qvantum"
     return entry
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -182,9 +182,11 @@ class TestQvantumConfigFlow:
                     "username": "test@example.com",
                     "password": "testpass",
                     "modbus_tcp": True,
+                    "modbus_write": False,
                 },
                 options={
                     "modbus_tcp": True,
+                    "modbus_write": False,
                 },
             )
 
@@ -262,8 +264,9 @@ class TestQvantumConfigFlow:
                     "username": "new@example.com",
                     "password": "newpass",
                     "modbus_tcp": False,
+                    "modbus_write": False,
                 },
-                options={"modbus_tcp": False},
+                options={"modbus_tcp": False, "modbus_write": False},
                 reason="reconfigure_successful",
             )
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -191,6 +191,52 @@ class TestQvantumConfigFlow:
             )
 
     @pytest.mark.asyncio
+    async def test_user_step_normalizes_modbus_write_without_tcp(
+        self, hass, config_flow
+    ):
+        """Test user step coerces modbus_write to false when modbus_tcp is disabled."""
+        hass.config_entries = MagicMock()
+        hass.config_entries.flow = MagicMock()
+        hass.config_entries.flow.async_progress_by_handler = AsyncMock(return_value=[])
+
+        with (
+            patch(
+                "custom_components.qvantum.config_flow.validate_input"
+            ) as mock_validate,
+            patch.object(config_flow, "async_set_unique_id") as mock_set_unique_id,
+            patch.object(config_flow, "_abort_if_unique_id_configured") as mock_abort,
+            patch.object(config_flow, "async_create_entry") as mock_create_entry,
+        ):
+            mock_validate.return_value = {"title": "Test Device"}
+            mock_create_entry.return_value = {"type": "create_entry"}
+
+            result = await config_flow.async_step_user(
+                {
+                    "username": "test@example.com",
+                    "password": "testpass",
+                    "modbus_tcp": False,
+                    "modbus_write": True,
+                }
+            )
+
+            assert result == {"type": "create_entry"}
+            mock_set_unique_id.assert_called_once_with("Test Device")
+            mock_abort.assert_called_once()
+            mock_create_entry.assert_called_once_with(
+                title="Test Device",
+                data={
+                    "username": "test@example.com",
+                    "password": "testpass",
+                    "modbus_tcp": False,
+                    "modbus_write": False,
+                },
+                options={
+                    "modbus_tcp": False,
+                    "modbus_write": False,
+                },
+            )
+
+    @pytest.mark.asyncio
     async def test_user_step_unknown_error(self, hass, config_flow):
         """Test user step with unknown error."""
         # Mock the hass.config_entries.flow property
@@ -348,6 +394,50 @@ class TestQvantumConfigFlow:
             assert mock_update_reload.call_args.kwargs["options"]["modbus_tcp"] is True
 
     @pytest.mark.asyncio
+    async def test_step_reconfigure_normalizes_modbus_write_without_tcp(
+        self, hass, config_flow
+    ):
+        """Test reconfigure coerces modbus_write to false when modbus_tcp is disabled."""
+        config_entry = MagicMock()
+        config_entry.data = {"username": "old@example.com", "password": "oldpass"}
+        config_entry.options = {"modbus_tcp": True, "modbus_write": True}
+        config_entry.unique_id = "test_unique_id"
+
+        hass.config_entries = MagicMock()
+        hass.config_entries.async_get_entry.return_value = config_entry
+
+        config_flow.context = {"entry_id": "test_entry_id"}
+
+        with (
+            patch(
+                "custom_components.qvantum.config_flow.validate_input"
+            ) as mock_validate,
+            patch.object(
+                config_flow, "async_update_reload_and_abort"
+            ) as mock_update_reload,
+        ):
+            mock_validate.return_value = None
+            mock_update_reload.return_value = {"type": "abort"}
+
+            result = await config_flow.async_step_reconfigure(
+                {
+                    "username": "new@example.com",
+                    "password": "newpass",
+                    "modbus_tcp": False,
+                    "modbus_write": True,
+                }
+            )
+
+            assert result == {"type": "abort"}
+            mock_update_reload.assert_called_once()
+            assert mock_update_reload.call_args.kwargs["data"]["modbus_tcp"] is False
+            assert mock_update_reload.call_args.kwargs["data"]["modbus_write"] is False
+            assert mock_update_reload.call_args.kwargs["options"]["modbus_tcp"] is False
+            assert (
+                mock_update_reload.call_args.kwargs["options"]["modbus_write"] is False
+            )
+
+    @pytest.mark.asyncio
     async def test_options_flow_init_success(self, hass):
         """Test options flow init step with successful update."""
         from custom_components.qvantum.config_flow import QvantumOptionsFlowHandler
@@ -405,3 +495,45 @@ class TestQvantumConfigFlow:
         assert result["type"] == "form"
         assert result["step_id"] == "init"
         assert "data_schema" in result
+
+    @pytest.mark.asyncio
+    async def test_options_flow_init_normalizes_modbus_write_without_tcp(self, hass):
+        """Test options flow coerces modbus_write to false when modbus_tcp is disabled."""
+        from custom_components.qvantum.config_flow import QvantumOptionsFlowHandler
+        from homeassistant.config_entries import ConfigEntry
+
+        config_entry = ConfigEntry(
+            version=1,
+            minor_version=1,
+            domain="qvantum",
+            title="Test",
+            data={},
+            options={"scan_interval": 120},
+            source="user",
+            unique_id="test_unique_id",
+            discovery_keys={},
+            subentries_data={},
+        )
+
+        flow = QvantumOptionsFlowHandler(config_entry)
+
+        with patch.object(flow, "async_create_entry") as mock_create_entry:
+            mock_create_entry.return_value = {"type": "create_entry"}
+
+            result = await flow.async_step_init(
+                {
+                    "scan_interval": 300,
+                    "modbus_tcp": False,
+                    "modbus_write": True,
+                }
+            )
+
+            assert result == {"type": "create_entry"}
+            mock_create_entry.assert_called_once_with(
+                title="",
+                data={
+                    "scan_interval": 300,
+                    "modbus_tcp": False,
+                    "modbus_write": False,
+                },
+            )

--- a/tests/test_number_working.py
+++ b/tests/test_number_working.py
@@ -440,7 +440,10 @@ class TestQvantumNumberEntity:
     ):
         """Test setting dhw_stop_extra writes via Modbus holding register, not update_setting."""
         mock_coordinator.data["values"]["dhw_stop_extra"] = 65
-        mock_coordinator.config_entry.options = {"modbus_write": True}
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": True,
+        }
         entity = QvantumNumberEntity(
             mock_coordinator, "dhw_stop_extra", 60, 85, 5, mock_device
         )
@@ -482,6 +485,29 @@ class TestQvantumNumberEntity:
 
         mock_coordinator.api.write_holding_register_for_metric.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_async_set_native_value_dhw_stop_extra_raises_when_modbus_tcp_disabled(
+        self, mock_coordinator, mock_device
+    ):
+        """Test that async_set_native_value raises when modbus_tcp is disabled."""
+        from homeassistant.exceptions import HomeAssistantError
+
+        mock_coordinator.data["values"]["dhw_stop_extra"] = 65
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": False,
+        }
+        mock_coordinator.config_entry.data = {}
+        entity = QvantumNumberEntity(
+            mock_coordinator, "dhw_stop_extra", 60, 85, 5, mock_device
+        )
+        mock_coordinator.api.write_holding_register_for_metric = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="Modbus writing is disabled"):
+            await entity.async_set_native_value(75.0)
+
+        mock_coordinator.api.write_holding_register_for_metric.assert_not_called()
+
     def test_available_dhw_stop_extra_modbus_write_disabled(
         self, mock_coordinator, mock_device
     ):
@@ -499,11 +525,28 @@ class TestQvantumNumberEntity:
     ):
         """Test dhw_stop_extra entity is available when modbus_write is enabled."""
         mock_coordinator.data["values"]["dhw_stop_extra"] = 65
-        mock_coordinator.config_entry.options = {"modbus_write": True}
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": True,
+        }
         entity = QvantumNumberEntity(
             mock_coordinator, "dhw_stop_extra", 60, 85, 5, mock_device
         )
         assert entity.available is True
+
+    def test_available_dhw_stop_extra_modbus_tcp_disabled(
+        self, mock_coordinator, mock_device
+    ):
+        """Test dhw_stop_extra entity is unavailable when modbus_tcp is disabled."""
+        mock_coordinator.data["values"]["dhw_stop_extra"] = 65
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": False,
+        }
+        entity = QvantumNumberEntity(
+            mock_coordinator, "dhw_stop_extra", 60, 85, 5, mock_device
+        )
+        assert entity.available is False
 
 
 class TestNumberSetup:

--- a/tests/test_number_working.py
+++ b/tests/test_number_working.py
@@ -440,6 +440,7 @@ class TestQvantumNumberEntity:
     ):
         """Test setting dhw_stop_extra writes via Modbus holding register, not update_setting."""
         mock_coordinator.data["values"]["dhw_stop_extra"] = 65
+        mock_coordinator.config_entry.options = {"modbus_write": True}
         entity = QvantumNumberEntity(
             mock_coordinator, "dhw_stop_extra", 60, 85, 5, mock_device
         )
@@ -460,6 +461,26 @@ class TestQvantumNumberEntity:
         mock_coordinator.api.update_setting.assert_not_called()
         # Coordinator cache should be updated with the new value
         assert mock_coordinator.data["values"]["dhw_stop_extra"] == 75
+
+    @pytest.mark.asyncio
+    async def test_async_set_native_value_dhw_stop_extra_raises_when_write_disabled(
+        self, mock_coordinator, mock_device
+    ):
+        """Test that async_set_native_value raises HomeAssistantError when modbus_write is disabled."""
+        from homeassistant.exceptions import HomeAssistantError
+
+        mock_coordinator.data["values"]["dhw_stop_extra"] = 65
+        mock_coordinator.config_entry.options = {}
+        mock_coordinator.config_entry.data = {}
+        entity = QvantumNumberEntity(
+            mock_coordinator, "dhw_stop_extra", 60, 85, 5, mock_device
+        )
+        mock_coordinator.api.write_holding_register_for_metric = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="Modbus writing is disabled"):
+            await entity.async_set_native_value(75.0)
+
+        mock_coordinator.api.write_holding_register_for_metric.assert_not_called()
 
     def test_available_dhw_stop_extra_modbus_write_disabled(
         self, mock_coordinator, mock_device

--- a/tests/test_number_working.py
+++ b/tests/test_number_working.py
@@ -461,6 +461,29 @@ class TestQvantumNumberEntity:
         # Coordinator cache should be updated with the new value
         assert mock_coordinator.data["values"]["dhw_stop_extra"] == 75
 
+    def test_available_dhw_stop_extra_modbus_write_disabled(
+        self, mock_coordinator, mock_device
+    ):
+        """Test dhw_stop_extra entity is unavailable when modbus_write is disabled."""
+        mock_coordinator.data["values"]["dhw_stop_extra"] = 65
+        mock_coordinator.config_entry.options = {}
+        mock_coordinator.config_entry.data = {}
+        entity = QvantumNumberEntity(
+            mock_coordinator, "dhw_stop_extra", 60, 85, 5, mock_device
+        )
+        assert entity.available is False
+
+    def test_available_dhw_stop_extra_modbus_write_enabled(
+        self, mock_coordinator, mock_device
+    ):
+        """Test dhw_stop_extra entity is available when modbus_write is enabled."""
+        mock_coordinator.data["values"]["dhw_stop_extra"] = 65
+        mock_coordinator.config_entry.options = {"modbus_write": True}
+        entity = QvantumNumberEntity(
+            mock_coordinator, "dhw_stop_extra", 60, 85, 5, mock_device
+        )
+        assert entity.available is True
+
 
 class TestNumberSetup:
     """Test number platform setup."""


### PR DESCRIPTION
This pull request adds support for enabling and controlling "writing via Modbus" in the Qvantum integration, alongside existing Modbus reading functionality. It introduces a new configuration option to allow writing certain metrics via Modbus, updates the configuration and options flows accordingly, and ensures that entities requiring Modbus write access are only available when this option is enabled. Additionally, user-facing translations are updated to reflect the new option and provide clear warnings about the responsibility and risks of enabling Modbus writing.

**Modbus Write Option Support**

* Added a new configuration option `CONF_MODBUS_WRITE` to enable or disable writing via Modbus, including updates to `const.py`, configuration flows (`config_flow.py`), and options handling. This ensures that both initial setup and reconfiguration support toggling Modbus write capability. [[1]](diffhunk://#diff-c36f474429a06935f46ca95ee34bae1ae7442db3e8e8a8a57940023c87c5a29fR34) [[2]](diffhunk://#diff-c36f474429a06935f46ca95ee34bae1ae7442db3e8e8a8a57940023c87c5a29fR46) [[3]](diffhunk://#diff-c36f474429a06935f46ca95ee34bae1ae7442db3e8e8a8a57940023c87c5a29fR120-R131) [[4]](diffhunk://#diff-c36f474429a06935f46ca95ee34bae1ae7442db3e8e8a8a57940023c87c5a29fR163-R174) [[5]](diffhunk://#diff-c36f474429a06935f46ca95ee34bae1ae7442db3e8e8a8a57940023c87c5a29fR198-R204) [[6]](diffhunk://#diff-c36f474429a06935f46ca95ee34bae1ae7442db3e8e8a8a57940023c87c5a29fR239-R242) [[7]](diffhunk://#diff-07fd7ac76e58c80e95bb6c9ca3ff34f8c124f4a881a23cd946cfefaa5719e953R25)

**Entity Behavior Updates**

* Updated `number.py` to:
  - Restrict availability of entities that require Modbus write access (e.g., `dhw_stop_extra`) to when both Modbus TCP and Modbus write are enabled.
  - Raise a clear error if a user attempts to write to a Modbus-only metric when writing is not enabled, with a helpful message. [[1]](diffhunk://#diff-37b24c15c007d2fd3db3f36096acf939aeea60cf05d5843ece90555692105addR8-R27) [[2]](diffhunk://#diff-37b24c15c007d2fd3db3f36096acf939aeea60cf05d5843ece90555692105addR115-R118) [[3]](diffhunk://#diff-37b24c15c007d2fd3db3f36096acf939aeea60cf05d5843ece90555692105addR146-R166)

**User Interface and Translations**

* Updated English, German, French, and Spanish translations to:
  - Add labels and descriptions for the new Modbus write option in all relevant configuration and reconfiguration dialogs.
  - Provide clear warnings about the risks and responsibilities associated with enabling Modbus writing. [[1]](diffhunk://#diff-acfc3b0627ed2bb0327c528addfe1335670f607c305117c84c6eaf8b8c31e780L537-R555) [[2]](diffhunk://#diff-acfc3b0627ed2bb0327c528addfe1335670f607c305117c84c6eaf8b8c31e780L554-R571) [[3]](diffhunk://#diff-c38b12eee4843bd1f813526f2a1d519a00e26c744de32799eae5b19f0e992a4fL537-R555) [[4]](diffhunk://#diff-c38b12eee4843bd1f813526f2a1d519a00e26c744de32799eae5b19f0e992a4fL554-R571) [[5]](diffhunk://#diff-a2a9672f511a16ec3c1617867055a659f0a84e7689dc79a1eacdb83079fbff37L538-R556) [[6]](diffhunk://#diff-a2a9672f511a16ec3c1617867055a659f0a84e7689dc79a1eacdb83079fbff37L555-R572) [[7]](diffhunk://#diff-c5fb2d6ea185048b324440f4f45e1ba73623382c7ba888322ba0949fcabb1b9fL536-R554)

These changes collectively improve safety and clarity for users who wish to enable advanced Modbus write features, and ensure the integration only exposes controls when it is safe and explicitly allowed.