### PR TITLE
fix: correct dhw_stop_extra range to 80C

### DIFF
--- a/custom_components/qvantum/number.py
+++ b/custom_components/qvantum/number.py
@@ -42,7 +42,7 @@ async def async_setup_entry(
         "indoor_temperature_offset": (-10, 10, 1),
         "tap_water_stop": (60, 80, 1),
         "tap_water_start": (50, 65, 1),
-        "dhw_stop_extra": (60, 85, 5),
+        "dhw_stop_extra": (60, 80, 5),
         "fan_normal": (0, 100, 5),
         "fan_speed_2": (0, 100, 5),
     }


### PR DESCRIPTION
This pull request makes a small adjustment to the configuration range for the `dhw_stop_extra` parameter in the `custom_components/qvantum/number.py` file. The maximum allowable value has been reduced from 85 to 80.

- Reduced the upper limit of the `dhw_stop_extra` parameter from 85 to 80 in the configuration dictionary.