### PR TITLE
fix: improve energy derivation logic and add validation for metrics

### DIFF
--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -334,16 +334,27 @@ class QvantumAPI:
         )
 
         # Compute energy from mwh/kwh components (preferred modbus format: kwh entry scaled x10).
+        # Only derive an energy counter when both components are present and numeric.
+        # This avoids synthesizing misleading 0 values during transient partial reads.
         for prefix in ["compressor", "additional", "heating", "cooling", "dhw"]:
             mwh = metrics.get(f"{prefix}_mwh")
             kwh = metrics.get(f"{prefix}_kwh")
-            mwh = float(mwh) if mwh is not None else 0.0
-            kwh = float(kwh) if kwh is not None else 0.0
-
-            # NOTE: kwh values in `metrics` are already normalized by the Modbus register map
-            # (e.g. raw x10 register values have been de-scaled), so we can add them directly
-            # to mwh * 1000.0 here without applying any additional scaling factor.
-            metrics[f"{prefix}energy"] = round(mwh * 1000.0 + kwh, 2)
+            if mwh is not None and kwh is not None:
+                try:
+                    mwh_val = float(mwh)
+                    kwh_val = float(kwh)
+                except (TypeError, ValueError):
+                    _LOGGER.debug(
+                        "Skipping energy derivation for %s due to non-numeric components: mwh=%s, kwh=%s",
+                        prefix,
+                        mwh,
+                        kwh,
+                    )
+                else:
+                    # NOTE: kwh values in `metrics` are already normalized by the Modbus register map
+                    # (e.g. raw x10 register values have been de-scaled), so we can add them directly
+                    # to mwh * 1000.0 here without applying any additional scaling factor.
+                    metrics[f"{prefix}energy"] = round(mwh_val * 1000.0 + kwh_val, 2)
             metrics.pop(f"{prefix}_mwh", None)
             metrics.pop(f"{prefix}_kwh", None)
 

--- a/custom_components/qvantum/sensor.py
+++ b/custom_components/qvantum/sensor.py
@@ -294,22 +294,35 @@ class QvantumTotalEnergyEntity(QvantumEnergyEntity):
     ) -> None:
         super().__init__(coordinator, metric_key, device, enabled_by_default)
 
+    def _is_data_valid(
+        self, compressor: float | int | None, additional: float | int | None
+    ) -> bool:
+        """Validate total-energy source values.
+
+        Values are considered invalid when either source is missing, or when both
+        are exactly zero (treated as a transient communication anomaly).
+        """
+        if compressor is None or additional is None:
+            return False
+        if compressor == 0 and additional == 0:
+            return False
+        return True
+
     @property
     def state(self):
         """Get metric from API data."""
         compressor = self._values.get("compressorenergy")
         additional = self._values.get("additionalenergy")
-        if compressor is None or additional is None:
+        if not self._is_data_valid(compressor, additional):
             return None
         return compressor + additional
 
     @property
     def available(self):
         """Check if data is available."""
-        return (
-            self._values.get("compressorenergy") is not None
-            and self._values.get("additionalenergy") is not None
-        )
+        compressor = self._values.get("compressorenergy")
+        additional = self._values.get("additionalenergy")
+        return self._is_data_valid(compressor, additional)
 
 
 class QvantumDiagnosticEntity(QvantumBaseSensorEntity):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -162,6 +162,58 @@ class TestQvantumAPI:
         assert metrics["compressorenergy"] == 4801.0
 
     @pytest.mark.asyncio
+    async def test_read_modbus_metrics_skips_energy_if_component_missing(
+        self, mock_session
+    ):
+        """Do not derive energy when mwh/kwh pair is incomplete."""
+        api = QvantumAPI(
+            "test@example.com", "password", "test-agent", session=mock_session
+        )
+
+        with patch.object(
+            QvantumAPI,
+            "_read_modbus_registers",
+            AsyncMock(
+                return_value={
+                    "compressor_mwh": 4,
+                    # compressor_kwh intentionally missing to simulate transient partial read
+                }
+            ),
+        ):
+            result = await api._read_modbus_metrics(
+                "test_device_123", ["compressor_mwh", "compressor_kwh"]
+            )
+
+        metrics = result["metrics"]
+        assert "compressorenergy" not in metrics
+
+    @pytest.mark.asyncio
+    async def test_read_modbus_metrics_skips_energy_if_component_non_numeric(
+        self, mock_session
+    ):
+        """Do not derive energy when mwh/kwh values are malformed."""
+        api = QvantumAPI(
+            "test@example.com", "password", "test-agent", session=mock_session
+        )
+
+        with patch.object(
+            QvantumAPI,
+            "_read_modbus_registers",
+            AsyncMock(
+                return_value={
+                    "compressor_mwh": "not-a-number",
+                    "compressor_kwh": 1,
+                }
+            ),
+        ):
+            result = await api._read_modbus_metrics(
+                "test_device_123", ["compressor_mwh", "compressor_kwh"]
+            )
+
+        metrics = result["metrics"]
+        assert "compressorenergy" not in metrics
+
+    @pytest.mark.asyncio
     async def test_read_modbus_metrics_rounds_to_two_decimals(self, mock_session):
         """Test numeric outputs from modbus are rounded to two decimals."""
         api = QvantumAPI(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -277,6 +277,25 @@ class TestQvantumTotalEnergyEntity:
         )
         assert entity.available is False
 
+    def test_state_is_none_when_component_missing(self, mock_coordinator, mock_device):
+        """Total energy state should be unknown when one component is missing."""
+        del mock_coordinator.data["values"]["additionalenergy"]
+        entity = QvantumTotalEnergyEntity(
+            mock_coordinator, "totalenergy", mock_device, True
+        )
+        assert entity.state is None
+        assert entity.available is False
+
+    def test_unavailable_when_both_components_zero(self, mock_coordinator, mock_device):
+        """Total energy should be unavailable when both components are zero."""
+        mock_coordinator.data["values"]["compressorenergy"] = 0
+        mock_coordinator.data["values"]["additionalenergy"] = 0
+        entity = QvantumTotalEnergyEntity(
+            mock_coordinator, "totalenergy", mock_device, True
+        )
+        assert entity.state is None
+        assert entity.available is False
+
 
 class TestQvantumDiagnosticEntity:
     """Test the QvantumDiagnosticEntity class."""

--- a/tests/test_sensor_working.py
+++ b/tests/test_sensor_working.py
@@ -316,6 +316,16 @@ class TestQvantumTotalEnergyEntity:
         )
         assert entity.available is False
 
+    def test_unavailable_when_both_components_zero(self, mock_coordinator, mock_device):
+        """Total energy should be unavailable when both components are zero."""
+        mock_coordinator.data["values"]["compressorenergy"] = 0
+        mock_coordinator.data["values"]["additionalenergy"] = 0
+        entity = QvantumTotalEnergyEntity(
+            mock_coordinator, "totalenergy", mock_device, True
+        )
+        assert entity.state is None
+        assert entity.available is False
+
 
 class TestQvantumDiagnosticEntity:
     """Test the QvantumDiagnosticEntity class."""


### PR DESCRIPTION
This pull request improves the reliability of energy metric calculations and the handling of sensor availability by ensuring that energy values are only derived when all required components are present and valid. It also adds comprehensive tests to verify correct behavior in cases of missing or invalid data.

**Energy metric calculation improvements:**

* Modified `_read_modbus_metrics` in `api.py` to only derive energy counters when both `mwh` and `kwh` components are present and numeric, preventing the creation of misleading zero values during partial or malformed reads.

**Sensor validation and availability logic:**

* Added a `_is_data_valid` method and updated `QvantumTotalEnergyEntity` in `sensor.py` to treat the total energy as unavailable if either component is missing or both are exactly zero, improving robustness against transient communication issues.

**Testing enhancements:**

* Added tests in `test_api.py` to verify that energy derivation is skipped when components are missing or non-numeric, ensuring the API does not produce invalid energy metrics.
* Added tests in `test_sensor.py` and `test_sensor_working.py` to confirm that the sensor is unavailable and its state is `None` when components are missing or both are zero. [[1]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330R280-R298) [[2]](diffhunk://#diff-20896223bd7845352544547a303e7968d1ff44fbd8d9d180bd6dc9ab79027dc7R319-R328)


Fixes #158 