### PR TITLE
feat: add room external temperature functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,25 @@ The integration will automatically discover your Qvantum devices and create comp
 > [!IMPORTANT]
 > By default, this integration uses Modbus for **reading only**. Modbus write support is disabled unless you explicitly enable it in the integration options, and only supported controls use that path. Other configuration/set commands continue to use the existing HTTP API.
 
+### External room sensor support
+
+When the pump is configured to use an external room sensor (`use_operation_sensor == 4`), the integration exposes a `number` entity for `room_temp_external`.
+This allows you to mirror an external temperature sensor into the pump’s control setpoint via Modbus when Modbus writes are enabled.
+
+**Example automation:**
+```yaml
+alias: "Qvantum: Update external room temperature"
+trigger:
+  - platform: state
+    entity_id: sensor.some_external_room_temperature
+action:
+  - service: number.set_value
+    target:
+      entity_id: number.qvantum_room_temp_external_<device_id>
+    data:
+      value: "{{ states('sensor.some_external_room_temperature') | float }}"
+```
+
 ### Services
 
 The integration provides the following services for advanced control and testing:

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -59,16 +59,21 @@ async def handle_setting_update_response(
     data_section: Optional[str],
     key: Optional[str],
     value: Any,
-) -> None:
+) -> bool:
     """Handle API response for setting updates and update coordinator data if successful."""
-    if api_response and (
-        api_response.get("status") == SETTING_UPDATE_APPLIED
-        or api_response.get("heatpump_status") == SETTING_UPDATE_APPLIED
-    ):
-        if data_section and key is not None:
-            coordinator.data.get(data_section)[key] = value
-            # async_set_updated_data is a synchronous method despite the name
-            coordinator.async_set_updated_data(coordinator.data)
+    success = bool(
+        api_response
+        and (
+            api_response.get("status") == SETTING_UPDATE_APPLIED
+            or api_response.get("heatpump_status") == SETTING_UPDATE_APPLIED
+        )
+    )
+    if success and data_section and key is not None:
+        coordinator.data.get(data_section)[key] = value
+        # async_set_updated_data is a synchronous method despite the name
+        coordinator.async_set_updated_data(coordinator.data)
+        return True
+    return False
 
 
 class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinator):

--- a/custom_components/qvantum/entity.py
+++ b/custom_components/qvantum/entity.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from .const import DOMAIN
+from .const import CONF_MODBUS_TCP, CONF_MODBUS_WRITE, DOMAIN
 from .coordinator import QvantumDataUpdateCoordinator
 from .maintenance_coordinator import QvantumMaintenanceCoordinator
 
@@ -94,6 +94,9 @@ _ENTITY_ICONS: dict[str, str] = {
     "enable_sc_dhw": "mdi:water-thermometer",
     # Select
     "use_adaptive": "mdi:leaf",
+    "use_operation_sensor": "mdi:motion-sensor",
+    # Number / writable temperature
+    "room_temp_external": "mdi:thermometer",
 }
 
 
@@ -130,6 +133,19 @@ class QvantumEntity(QvantumAccessMixin, CoordinatorEntity):
     def _values(self) -> dict:
         """Return current values from coordinator data, safe when data is None."""
         return (self.coordinator.data or {}).get("values", {})
+
+    def _is_modbus_write_allowed(self) -> bool:
+        """Return True when Modbus write actions are explicitly enabled and available."""
+        config_entry = self.coordinator.config_entry
+        modbus_write_enabled = config_entry.options.get(
+            CONF_MODBUS_WRITE,
+            config_entry.data.get(CONF_MODBUS_WRITE, False),
+        )
+        modbus_tcp_enabled = config_entry.options.get(
+            CONF_MODBUS_TCP,
+            config_entry.data.get(CONF_MODBUS_TCP, False),
+        )
+        return modbus_write_enabled and modbus_tcp_enabled
 
     def _resolve_device_id(self, device: DeviceInfo | dict[str, object]) -> str | None:
         """Resolve device ID from device info or coordinator data."""

--- a/custom_components/qvantum/modbus.py
+++ b/custom_components/qvantum/modbus.py
@@ -140,4 +140,5 @@ MODBUS_HOLDING_TO_SETTINGS_MAP = {
     "allow_heating": "man_mode",
     "ventilation_state": "fanspeedselector",
     "dhw_stop_extra": "dhw_stop_extra",
+    "room_temp_external": "room_temp_external",
 }

--- a/custom_components/qvantum/number.py
+++ b/custom_components/qvantum/number.py
@@ -12,8 +12,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import MyConfigEntry
 from .const import (
-    CONF_MODBUS_TCP,
-    CONF_MODBUS_WRITE,
     TAP_WATER_CAPACITY_MAPPINGS,
 )
 from .coordinator import QvantumDataUpdateCoordinator, handle_setting_update_response
@@ -23,7 +21,10 @@ _LOGGER = logging.getLogger(__name__)
 
 # Metrics that require writing via Modbus holding registers.
 # Entities for these metrics show as unavailable when "Enable writing via Modbus" is off.
-MODBUS_WRITE_METRICS = {"dhw_stop_extra"}
+MODBUS_WRITE_METRICS = {
+    "dhw_stop_extra",
+    "room_temp_external",  # Written via Modbus and only relevant when the external room sensor mode is enabled.
+}
 
 
 async def async_setup_entry(
@@ -45,6 +46,7 @@ async def async_setup_entry(
         "dhw_stop_extra": (60, 80, 5),
         "fan_normal": (0, 100, 5),
         "fan_speed_2": (0, 100, 5),
+        "room_temp_external": (-5, 40, 0.1),
     }
 
     # Only create number entities for metrics present in the coordinator's current data.
@@ -88,26 +90,32 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
         """Update the current value."""
 
         response = {}
+        coordinator_update_value: int | float = value
         match self._metric_key:
             case "tap_water_capacity_target":
+                coordinator_update_value = int(value)
                 response = await self.coordinator.api.set_tap_water_capacity_target(
-                    self._hpid, int(value)
+                    self._hpid, coordinator_update_value
                 )
             case "indoor_temperature_offset":
+                coordinator_update_value = int(value)
                 response = await self.coordinator.api.set_indoor_temperature_offset(
-                    self._hpid, int(value)
+                    self._hpid, coordinator_update_value
                 )
             case "tap_water_stop":
+                coordinator_update_value = int(value)
                 response = await self.coordinator.api.set_tap_water(
-                    self._hpid, stop=int(value)
+                    self._hpid, stop=coordinator_update_value
                 )
             case "tap_water_start":
+                coordinator_update_value = int(value)
                 response = await self.coordinator.api.set_tap_water(
-                    self._hpid, start=int(value)
+                    self._hpid, start=coordinator_update_value
                 )
             case "room_comp_factor" | "fan_normal" | "fan_speed_2":
+                coordinator_update_value = int(value)
                 response = await self.coordinator.api.update_setting(
-                    self._hpid, self._metric_key, int(value)
+                    self._hpid, self._metric_key, coordinator_update_value
                 )
 
             case "dhw_stop_extra":
@@ -116,8 +124,24 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
                     raise HomeAssistantError(
                         "Modbus writing is disabled. Turn on writing via Modbus in the integration options."
                     )
+                coordinator_update_value = int(value)
                 response = await self.coordinator.api.write_holding_register_for_metric(
-                    self._hpid, self._metric_key, int(value)
+                    self._hpid, self._metric_key, coordinator_update_value
+                )
+
+            case "room_temp_external":
+                # room_temp_external writes to Modbus holding register 14 (scale 0.1)
+                if not self._is_modbus_write_allowed():
+                    raise HomeAssistantError(
+                        "Modbus writing is disabled. Turn on writing via Modbus in the integration options."
+                    )
+                coordinator_update_value = value
+                response = await self.coordinator.api.write_holding_register_for_metric(
+                    self._hpid, self._metric_key, coordinator_update_value
+                )
+            case _:
+                raise HomeAssistantError(
+                    f"Unsupported metric key for number entity: {self._metric_key}"
                 )
 
         await handle_setting_update_response(
@@ -125,7 +149,7 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
             self.coordinator,
             "values",
             self._metric_key,
-            int(value),
+            coordinator_update_value,
         )
 
     @property
@@ -150,17 +174,13 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
             )
             and self._values.get(self._metric_key) is not None
             and self._has_write_access
+            and (
+                # `room_temp_external` is only meaningful when the heat pump is
+                # configured to use the external operation sensor; in the API,
+                # `use_operation_sensor == 4` represents the "External" sensor.
+                self._metric_key != "room_temp_external"
+                or self._values.get("use_operation_sensor") == 4
+            )
         )
 
-    def _is_modbus_write_allowed(self) -> bool:
-        """Return True when Modbus write actions are explicitly enabled and available."""
-        config_entry = self.coordinator.config_entry
-        modbus_write_enabled = config_entry.options.get(
-            CONF_MODBUS_WRITE,
-            config_entry.data.get(CONF_MODBUS_WRITE, False),
-        )
-        modbus_tcp_enabled = config_entry.options.get(
-            CONF_MODBUS_TCP,
-            config_entry.data.get(CONF_MODBUS_TCP, False),
-        )
-        return modbus_write_enabled and modbus_tcp_enabled
+

--- a/custom_components/qvantum/number.py
+++ b/custom_components/qvantum/number.py
@@ -46,7 +46,7 @@ async def async_setup_entry(
         "dhw_stop_extra": (60, 80, 5),
         "fan_normal": (0, 100, 5),
         "fan_speed_2": (0, 100, 5),
-        "room_temp_external": (-5, 40, 0.1),
+        "room_temp_external": (10, 40, 0.1),
     }
 
     # Only create number entities for metrics present in the coordinator's current data.

--- a/custom_components/qvantum/select.py
+++ b/custom_components/qvantum/select.py
@@ -29,6 +29,8 @@ async def async_setup_entry(
     entities = []
     if "use_adaptive" in coordinator.data.get("values", {}):
         entities.append(QvantumSelectEntity(coordinator, "use_adaptive", device))
+    if "use_operation_sensor" in coordinator.data.get("values", {}):
+        entities.append(QvantumSelectEntity(coordinator, "use_operation_sensor", device))
 
     async_add_entities(entities)
 
@@ -54,6 +56,8 @@ class QvantumSelectEntity(QvantumEntity, SelectEntity):
                     "1",
                     "2",
                 ]  # Translation keys that will be translated by HA
+            case "use_operation_sensor":
+                self._attr_options = ["0", "1", "2", "3", "4"]
 
     def _is_valid_mode(self, mode, valid_modes: set) -> bool:
         """Check if a mode value is valid."""
@@ -78,7 +82,16 @@ class QvantumSelectEntity(QvantumEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Update the current value."""
-        # Map option to smart control modes
+        if self._metric_key == "use_operation_sensor":
+            response = await self.coordinator.api.write_holding_register(
+                self._hpid, 9, int(option)
+            )
+            await handle_setting_update_response(
+                response, self.coordinator, "values", self._metric_key, int(option)
+            )
+            return
+
+        # Map option to smart control modes (use_adaptive)
         if option == "off":
             mode_value = -1
         else:
@@ -112,6 +125,13 @@ class QvantumSelectEntity(QvantumEntity, SelectEntity):
             return None
 
         values = self.coordinator.data.get("values", {})
+
+        if self._metric_key == "use_operation_sensor":
+            val = values.get(self._metric_key)
+            if val is None:
+                return None
+            return str(val)
+
         use_adaptive = values.get(self._metric_key)
 
         if use_adaptive is False:
@@ -181,4 +201,10 @@ class QvantumSelectEntity(QvantumEntity, SelectEntity):
             return False
 
         metrics = self.coordinator.data.get("values") or {}
+        # `use_operation_sensor` is only available when Modbus writes are
+        # currently allowed, because selecting an option for this metric
+        # depends on Modbus write capability in addition to general write
+        # access. Other select entities only require write access.
+        if self._metric_key == "use_operation_sensor":
+            return self._metric_key in metrics and self._has_write_access and self._is_modbus_write_allowed()
         return self._metric_key in metrics and self._has_write_access

--- a/custom_components/qvantum/select.py
+++ b/custom_components/qvantum/select.py
@@ -92,11 +92,14 @@ class QvantumSelectEntity(QvantumEntity, SelectEntity):
             response = await self.coordinator.api.write_holding_register(
                 self._hpid, 9, option_value
             )
-            if await handle_setting_update_response(
-                response, self.coordinator, "values", self._metric_key, option_value
+            if response and (
+                response.get("status") == SETTING_UPDATE_APPLIED
+                or response.get("heatpump_status") == SETTING_UPDATE_APPLIED
             ):
-                values = self.coordinator.data.get("values", {})
-                values["sensor_mode"] = option_value
+                self.coordinator.data.get("values", {})["sensor_mode"] = option_value
+            await handle_setting_update_response(
+                response, self.coordinator, "values", self._metric_key, option_value
+            )
             return
 
         # Map option to smart control modes (use_adaptive)

--- a/custom_components/qvantum/select.py
+++ b/custom_components/qvantum/select.py
@@ -4,6 +4,7 @@ import logging
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -83,9 +84,13 @@ class QvantumSelectEntity(QvantumEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Update the current value."""
         if self._metric_key == "use_operation_sensor":
+            if not self._is_modbus_write_allowed():
+                raise HomeAssistantError(
+                    "Modbus writing is disabled. Turn on writing via Modbus in the integration options."
+                )
             option_value = int(option)
-            response = await self.coordinator.api.write_holding_register_for_metric(
-                self._hpid, self._metric_key, option_value
+            response = await self.coordinator.api.write_holding_register(
+                self._hpid, 9, option_value
             )
             if await handle_setting_update_response(
                 response, self.coordinator, "values", self._metric_key, option_value

--- a/custom_components/qvantum/select.py
+++ b/custom_components/qvantum/select.py
@@ -83,8 +83,8 @@ class QvantumSelectEntity(QvantumEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Update the current value."""
         if self._metric_key == "use_operation_sensor":
-            response = await self.coordinator.api.write_holding_register(
-                self._hpid, 9, int(option)
+            response = await self.coordinator.api.write_holding_register_for_metric(
+                self._hpid, self._metric_key, int(option)
             )
             await handle_setting_update_response(
                 response, self.coordinator, "values", self._metric_key, int(option)

--- a/custom_components/qvantum/select.py
+++ b/custom_components/qvantum/select.py
@@ -83,12 +83,15 @@ class QvantumSelectEntity(QvantumEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Update the current value."""
         if self._metric_key == "use_operation_sensor":
+            option_value = int(option)
             response = await self.coordinator.api.write_holding_register_for_metric(
-                self._hpid, self._metric_key, int(option)
+                self._hpid, self._metric_key, option_value
             )
-            await handle_setting_update_response(
-                response, self.coordinator, "values", self._metric_key, int(option)
-            )
+            if await handle_setting_update_response(
+                response, self.coordinator, "values", self._metric_key, option_value
+            ):
+                values = self.coordinator.data.get("values", {})
+                values["sensor_mode"] = option_value
             return
 
         # Map option to smart control modes (use_adaptive)

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -55,12 +55,12 @@
         }
       },
       "use_operation_sensor": {
-        "name": "Innentemperatursensor",
+        "name": "Quelle des Innensensors",
         "state": {
-          "0": "Nein",
-          "1": "Ja: BT2",
-          "2": "Ja: BT3",
-          "3": "Ja: AUX",
+          "0": "Deaktiviert",
+          "1": "BT2",
+          "2": "BT3",
+          "3": "AUX",
           "4": "Extern"
         }
       }

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -53,6 +53,16 @@
           "1": "Ausgewogen",
           "2": "Komfort"
         }
+      },
+      "use_operation_sensor": {
+        "name": "Innentemperatursensor",
+        "state": {
+          "0": "Nein",
+          "1": "Ja: BT2",
+          "2": "Ja: BT3",
+          "3": "Ja: AUX",
+          "4": "Extern"
+        }
       }
     },
     "button": {
@@ -495,6 +505,9 @@
       },
       "dhw_stop_extra": {
         "name": "Extra Brauchwasser Stopptemperatur"
+      },
+      "room_temp_external": {
+        "name": "Externe Innentemperatur"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -57,10 +57,10 @@
       "use_operation_sensor": {
         "name": "Indoor sensor source",
         "state": {
-          "0": "No",
-          "1": "Yes: BT2",
-          "2": "Yes: BT3",
-          "3": "Yes: AUX",
+          "0": "Disabled",
+          "1": "BT2",
+          "2": "BT3",
+          "3": "AUX",
           "4": "External"
         }
       }

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -53,6 +53,16 @@
           "1": "Balanced",
           "2": "Comfort"
         }
+      },
+      "use_operation_sensor": {
+        "name": "Indoor sensor source",
+        "state": {
+          "0": "No",
+          "1": "Yes: BT2",
+          "2": "Yes: BT3",
+          "3": "Yes: AUX",
+          "4": "External"
+        }
       }
     },
     "button": {
@@ -495,6 +505,9 @@
       },
       "dhw_stop_extra": {
         "name": "Extra hot water stop temperature"
+      },
+      "room_temp_external": {
+        "name": "External indoor temperature"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -53,6 +53,16 @@
           "1": "Equilibrado",
           "2": "Confort"
         }
+      },
+      "use_operation_sensor": {
+        "name": "Sensor de interior",
+        "state": {
+          "0": "No",
+          "1": "S\u00ed: BT2",
+          "2": "S\u00ed: BT3",
+          "3": "S\u00ed: AUX",
+          "4": "Externo"
+        }
       }
     },
     "button": {
@@ -496,6 +506,9 @@
       },
       "dhw_stop_extra": {
         "name": "Temperatura de parada ACS extra"
+      },
+      "room_temp_external": {
+        "name": "Temperatura interior externa"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -55,12 +55,12 @@
         }
       },
       "use_operation_sensor": {
-        "name": "Sensor de interior",
+        "name": "Fuente del sensor interior",
         "state": {
-          "0": "No",
-          "1": "S\u00ed: BT2",
-          "2": "S\u00ed: BT3",
-          "3": "S\u00ed: AUX",
+          "0": "Desactivado",
+          "1": "BT2",
+          "2": "BT3",
+          "3": "AUX",
           "4": "Externo"
         }
       }

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -55,12 +55,12 @@
         }
       },
       "use_operation_sensor": {
-        "name": "Capteur intérieur",
+        "name": "Source du capteur intérieur",
         "state": {
-          "0": "Non",
-          "1": "Oui: BT2",
-          "2": "Oui: BT3",
-          "3": "Oui: AUX",
+          "0": "Désactivé",
+          "1": "BT2",
+          "2": "BT3",
+          "3": "AUX",
           "4": "Externe"
         }
       }

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -53,6 +53,16 @@
           "1": "Équilibré",
           "2": "Confort"
         }
+      },
+      "use_operation_sensor": {
+        "name": "Capteur intérieur",
+        "state": {
+          "0": "Non",
+          "1": "Oui: BT2",
+          "2": "Oui: BT3",
+          "3": "Oui: AUX",
+          "4": "Externe"
+        }
       }
     },
     "button": {
@@ -494,6 +504,9 @@
       },
       "dhw_stop_extra": {
         "name": "Température d'arrêt extra eau chaude"
+      },
+      "room_temp_external": {
+        "name": "Température intérieure externe"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -53,6 +53,16 @@
           "1": "Kiegyensúlyozott",
           "2": "Komfort"
         }
+      },
+      "use_operation_sensor": {
+        "name": "Bels\u0151 \u00e9rz\u00e9kel\u0151",
+        "state": {
+          "0": "Nem",
+          "1": "Igen: BT2",
+          "2": "Igen: BT3",
+          "3": "Igen: AUX",
+          "4": "K\u00fcls\u0151"
+        }
       }
     },
     "button": {
@@ -494,6 +504,9 @@
       },
       "dhw_stop_extra": {
         "name": "Extra melegvíz leállítási hőmérséklet"
+      },
+      "room_temp_external": {
+        "name": "Külső beltéri hőmérséklet"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -55,13 +55,13 @@
         }
       },
       "use_operation_sensor": {
-        "name": "Bels\u0151 \u00e9rz\u00e9kel\u0151",
+        "name": "Belső érzékelő forrása",
         "state": {
-          "0": "Nem",
-          "1": "Igen: BT2",
-          "2": "Igen: BT3",
-          "3": "Igen: AUX",
-          "4": "K\u00fcls\u0151"
+          "0": "Kikapcsolva",
+          "1": "BT2",
+          "2": "BT3",
+          "3": "AUX",
+          "4": "Külső"
         }
       }
     },

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -55,12 +55,12 @@
         }
       },
       "use_operation_sensor": {
-        "name": "Binnensensor",
+        "name": "Bron binnensensor",
         "state": {
-          "0": "Nee",
-          "1": "Ja: BT2",
-          "2": "Ja: BT3",
-          "3": "Ja: AUX",
+          "0": "Uitgeschakeld",
+          "1": "BT2",
+          "2": "BT3",
+          "3": "AUX",
           "4": "Extern"
         }
       }

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -53,6 +53,16 @@
           "1": "Gebalanceerd",
           "2": "Comfort"
         }
+      },
+      "use_operation_sensor": {
+        "name": "Binnensensor",
+        "state": {
+          "0": "Nee",
+          "1": "Ja: BT2",
+          "2": "Ja: BT3",
+          "3": "Ja: AUX",
+          "4": "Extern"
+        }
       }
     },
     "button": {
@@ -496,6 +506,9 @@
       },
       "dhw_stop_extra": {
         "name": "Extra warmwater stoptemperatuur"
+      },
+      "room_temp_external": {
+        "name": "Externe binnentemperatuur"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -55,12 +55,12 @@
         }
       },
       "use_operation_sensor": {
-        "name": "Czujnik wewn\u0119trzny",
+        "name": "Źródło czujnika wewnętrznego",
         "state": {
-          "0": "Nie",
-          "1": "Tak: BT2",
-          "2": "Tak: BT3",
-          "3": "Tak: AUX",
+          "0": "Wyłączone",
+          "1": "BT2",
+          "2": "BT3",
+          "3": "AUX",
           "4": "Zewn\u0119trzny"
         }
       }

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -53,6 +53,16 @@
           "1": "Zrównoważony",
           "2": "Komfort"
         }
+      },
+      "use_operation_sensor": {
+        "name": "Czujnik wewn\u0119trzny",
+        "state": {
+          "0": "Nie",
+          "1": "Tak: BT2",
+          "2": "Tak: BT3",
+          "3": "Tak: AUX",
+          "4": "Zewn\u0119trzny"
+        }
       }
     },
     "button": {
@@ -494,6 +504,9 @@
       },
       "dhw_stop_extra": {
         "name": "Extra temperatura zatrzymania ciepłej wody"
+      },
+      "room_temp_external": {
+        "name": "Zewnętrzna temperatura wewnętrzna"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -32,12 +32,12 @@
         }
       },
       "use_operation_sensor": {
-        "name": "Inomhusgivare",
+        "name": "Källa för inomhussensor",
         "state": {
-          "0": "Nej",
-          "1": "Ja: BT2",
-          "2": "Ja: BT3",
-          "3": "Ja: AUX",
+          "0": "Inaktiverad",
+          "1": "BT2",
+          "2": "BT3",
+          "3": "AUX",
           "4": "Extern"
         }
       }

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -30,6 +30,16 @@
           "1": "Balanserat",
           "2": "Komfort"
         }
+      },
+      "use_operation_sensor": {
+        "name": "Inomhusgivare",
+        "state": {
+          "0": "Nej",
+          "1": "Ja: BT2",
+          "2": "Ja: BT3",
+          "3": "Ja: AUX",
+          "4": "Extern"
+        }
       }
     },
     "switch": {
@@ -498,6 +508,9 @@
       },
       "dhw_stop_extra": {
         "name": "Extra varmvatten stopptemperatur"
+      },
+      "room_temp_external": {
+        "name": "Extern inomhustemperatur"
       }
     },
     "climate": {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2399,3 +2399,23 @@ class TestWriteHoldingRegister:
         assert result == {"status": "APPLIED"}
         call_args = client.execute.call_args[0][1]
         assert call_args.registers == [25]
+
+    @pytest.mark.asyncio
+    async def test_write_holding_register_for_metric_room_temp_external_scaling(
+        self, mock_session
+    ):
+        """room_temp_external writes to register 14 and applies inverse 0.1 scale."""
+        api = self._make_api(mock_session)
+        client = self._make_fake_client()
+        api._modbus_client = client
+
+        # room_temp_external maps to holding register 14 with scale=0.1
+        # value=21.5 -> raw = int(round(21.5 / 0.1)) = 215
+        result = await api.write_holding_register_for_metric(
+            "dev1", "room_temp_external", 21.5
+        )
+
+        assert result == {"status": "APPLIED"}
+        request = client.execute.call_args[0][1]
+        assert request.address == 14
+        assert request.registers == [215]

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -47,10 +47,11 @@ class TestHandleSettingUpdateResponse:
 
         api_response = {"status": "APPLIED"}
 
-        await handle_setting_update_response(
+        result = await handle_setting_update_response(
             api_response, coordinator, "values", "new_key", "new_value"
         )
 
+        assert result is True
         assert coordinator.data["values"]["new_key"] == "new_value"
         coordinator.async_set_updated_data.assert_called_once_with(coordinator.data)
         # No immediate refresh to avoid overwriting the update
@@ -60,10 +61,11 @@ class TestHandleSettingUpdateResponse:
         """Test setting update with no response."""
         coordinator = MagicMock()
 
-        await handle_setting_update_response(
+        result = await handle_setting_update_response(
             None, coordinator, "values", "key", "value"
         )
 
+        assert result is False
         # Should not update data or refresh
         coordinator.async_set_updated_data.assert_not_called()
         coordinator.async_refresh.assert_not_called()
@@ -75,10 +77,11 @@ class TestHandleSettingUpdateResponse:
 
         api_response = {"status": "FAILED"}
 
-        await handle_setting_update_response(
+        result = await handle_setting_update_response(
             api_response, coordinator, "settings", "key", "value"
         )
 
+        assert result is False
         # Should not update data or refresh
         coordinator.async_set_updated_data.assert_not_called()
         coordinator.async_refresh.assert_not_called()
@@ -91,10 +94,11 @@ class TestHandleSettingUpdateResponse:
 
         api_response = {"status": "APPLIED"}
 
-        await handle_setting_update_response(
+        result = await handle_setting_update_response(
             api_response, coordinator, None, "key", "value"
         )
 
+        assert result is False
         # Should not update data or refresh
         coordinator.async_set_updated_data.assert_not_called()
         # No refresh called
@@ -107,10 +111,11 @@ class TestHandleSettingUpdateResponse:
 
         api_response = {"status": "APPLIED"}
 
-        await handle_setting_update_response(
+        result = await handle_setting_update_response(
             api_response, coordinator, "settings", None, "value"
         )
 
+        assert result is False
         # Should not update data or refresh
         coordinator.async_set_updated_data.assert_not_called()
         # No refresh called

--- a/tests/test_number_working.py
+++ b/tests/test_number_working.py
@@ -608,7 +608,7 @@ class TestRoomTempExternal:
         )
 
         assert entity._metric_key == "room_temp_external"
-        assert entity._attr_native_min_value == -5
+        assert entity._attr_native_min_value == 10
         assert entity._attr_native_max_value == 40
         assert entity._attr_native_step == 0.1
         assert (

--- a/tests/test_number_working.py
+++ b/tests/test_number_working.py
@@ -604,7 +604,7 @@ class TestRoomTempExternal:
             "modbus_tcp": True,
         }
         entity = QvantumNumberEntity(
-            mock_coordinator, "room_temp_external", -5, 40, 0.1, mock_device
+            mock_coordinator, "room_temp_external", 10, 40, 0.1, mock_device
         )
 
         assert entity._metric_key == "room_temp_external"
@@ -627,7 +627,7 @@ class TestRoomTempExternal:
             "modbus_tcp": True,
         }
         entity = QvantumNumberEntity(
-            mock_coordinator, "room_temp_external", -5, 40, 0.1, mock_device
+            mock_coordinator, "room_temp_external", 10, 40, 0.1, mock_device
         )
         assert entity.available is True
 
@@ -641,7 +641,7 @@ class TestRoomTempExternal:
             "modbus_tcp": True,
         }
         entity = QvantumNumberEntity(
-            mock_coordinator, "room_temp_external", -5, 40, 0.1, mock_device
+            mock_coordinator, "room_temp_external", 10, 40, 0.1, mock_device
         )
         for val in [0, 1, 2, 3, None]:
             mock_coordinator.data["values"]["use_operation_sensor"] = val
@@ -656,7 +656,7 @@ class TestRoomTempExternal:
         mock_coordinator.config_entry.options = {}
         mock_coordinator.config_entry.data = {}
         entity = QvantumNumberEntity(
-            mock_coordinator, "room_temp_external", -5, 40, 0.1, mock_device
+            mock_coordinator, "room_temp_external", 10, 40, 0.1, mock_device
         )
         assert entity.available is False
 
@@ -672,7 +672,7 @@ class TestRoomTempExternal:
             "modbus_tcp": True,
         }
         entity = QvantumNumberEntity(
-            mock_coordinator, "room_temp_external", -5, 40, 0.1, mock_device
+            mock_coordinator, "room_temp_external", 10, 40, 0.1, mock_device
         )
 
         mock_coordinator.api.write_holding_register_for_metric = AsyncMock(
@@ -703,7 +703,7 @@ class TestRoomTempExternal:
         mock_coordinator.config_entry.options = {}
         mock_coordinator.config_entry.data = {}
         entity = QvantumNumberEntity(
-            mock_coordinator, "room_temp_external", -5, 40, 0.1, mock_device
+            mock_coordinator, "room_temp_external", 10, 40, 0.1, mock_device
         )
         mock_coordinator.api.write_holding_register_for_metric = AsyncMock()
 

--- a/tests/test_number_working.py
+++ b/tests/test_number_working.py
@@ -590,3 +590,124 @@ class TestNumberSetup:
             "fan_speed_2",
         ]
         assert entity_keys == expected_keys
+
+
+class TestRoomTempExternal:
+    """Tests for the room_temp_external number entity."""
+
+    def test_init_room_temp_external(self, mock_coordinator, mock_device):
+        """Test room_temp_external entity initialization."""
+        mock_coordinator.data["values"]["room_temp_external"] = 20.0
+        mock_coordinator.data["values"]["use_operation_sensor"] = 4
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": True,
+        }
+        entity = QvantumNumberEntity(
+            mock_coordinator, "room_temp_external", -5, 40, 0.1, mock_device
+        )
+
+        assert entity._metric_key == "room_temp_external"
+        assert entity._attr_native_min_value == -5
+        assert entity._attr_native_max_value == 40
+        assert entity._attr_native_step == 0.1
+        assert (
+            entity._attr_unique_id
+            == "qvantum_number_room_temp_external_test_device_123"
+        )
+
+    def test_available_when_use_operation_sensor_4(
+        self, mock_coordinator, mock_device
+    ):
+        """Test entity is available when use_operation_sensor == 4 and Modbus write on."""
+        mock_coordinator.data["values"]["room_temp_external"] = 20.0
+        mock_coordinator.data["values"]["use_operation_sensor"] = 4
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": True,
+        }
+        entity = QvantumNumberEntity(
+            mock_coordinator, "room_temp_external", -5, 40, 0.1, mock_device
+        )
+        assert entity.available is True
+
+    def test_unavailable_when_use_operation_sensor_not_4(
+        self, mock_coordinator, mock_device
+    ):
+        """Test entity is unavailable when use_operation_sensor != 4."""
+        mock_coordinator.data["values"]["room_temp_external"] = 20.0
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": True,
+        }
+        entity = QvantumNumberEntity(
+            mock_coordinator, "room_temp_external", -5, 40, 0.1, mock_device
+        )
+        for val in [0, 1, 2, 3, None]:
+            mock_coordinator.data["values"]["use_operation_sensor"] = val
+            assert entity.available is False, f"Expected unavailable for sensor={val}"
+
+    def test_unavailable_when_modbus_write_disabled(
+        self, mock_coordinator, mock_device
+    ):
+        """Test entity is unavailable when Modbus write is disabled, even if sensor == 4."""
+        mock_coordinator.data["values"]["room_temp_external"] = 20.0
+        mock_coordinator.data["values"]["use_operation_sensor"] = 4
+        mock_coordinator.config_entry.options = {}
+        mock_coordinator.config_entry.data = {}
+        entity = QvantumNumberEntity(
+            mock_coordinator, "room_temp_external", -5, 40, 0.1, mock_device
+        )
+        assert entity.available is False
+
+    @pytest.mark.asyncio
+    async def test_async_set_native_value_room_temp_external(
+        self, mock_coordinator, mock_device
+    ):
+        """Test setting room_temp_external writes via Modbus holding register with float value."""
+        mock_coordinator.data["values"]["room_temp_external"] = 20.0
+        mock_coordinator.data["values"]["use_operation_sensor"] = 4
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": True,
+        }
+        entity = QvantumNumberEntity(
+            mock_coordinator, "room_temp_external", -5, 40, 0.1, mock_device
+        )
+
+        mock_coordinator.api.write_holding_register_for_metric = AsyncMock(
+            return_value={"status": "APPLIED"}
+        )
+        mock_coordinator.api.update_setting = AsyncMock(
+            return_value={"status": "APPLIED"}
+        )
+
+        await entity.async_set_native_value(21.5)
+
+        mock_coordinator.api.write_holding_register_for_metric.assert_called_once_with(
+            "test_device_123", "room_temp_external", 21.5
+        )
+        mock_coordinator.api.update_setting.assert_not_called()
+        assert mock_coordinator.data["values"]["room_temp_external"] == 21.5
+        assert isinstance(mock_coordinator.data["values"]["room_temp_external"], float)
+
+    @pytest.mark.asyncio
+    async def test_async_set_native_value_room_temp_external_raises_when_write_disabled(
+        self, mock_coordinator, mock_device
+    ):
+        """Test that HomeAssistantError is raised when Modbus write is disabled."""
+        from homeassistant.exceptions import HomeAssistantError
+
+        mock_coordinator.data["values"]["room_temp_external"] = 20.0
+        mock_coordinator.data["values"]["use_operation_sensor"] = 4
+        mock_coordinator.config_entry.options = {}
+        mock_coordinator.config_entry.data = {}
+        entity = QvantumNumberEntity(
+            mock_coordinator, "room_temp_external", -5, 40, 0.1, mock_device
+        )
+        mock_coordinator.api.write_holding_register_for_metric = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="Modbus writing is disabled"):
+            await entity.async_set_native_value(21.5)
+
+        mock_coordinator.api.write_holding_register_for_metric.assert_not_called()

--- a/tests/test_select_working.py
+++ b/tests/test_select_working.py
@@ -357,6 +357,7 @@ class TestQvantumSelectEntityOperationSensor:
         mock_coordinator.api.write_holding_register_for_metric = AsyncMock(
             return_value={"status": "APPLIED"}
         )
+        mock_coordinator.data["values"]["sensor_mode"] = 0
 
         for opt in ["0", "1", "2", "3", "4"]:
             mock_coordinator.api.write_holding_register_for_metric.reset_mock()
@@ -364,6 +365,7 @@ class TestQvantumSelectEntityOperationSensor:
             mock_coordinator.api.write_holding_register_for_metric.assert_called_once_with(
                 "test_device_123", "use_operation_sensor", int(opt)
             )
+            assert mock_coordinator.data["values"]["sensor_mode"] == int(opt)
 
     def test_available_modbus_write_enabled(self, mock_coordinator, mock_device):
         """Test entity is available when Modbus write is enabled."""

--- a/tests/test_select_working.py
+++ b/tests/test_select_working.py
@@ -304,3 +304,85 @@ class TestQvantumSelectEntity:
         assert entity._is_valid_mode("abc", {0, 1, 2}) is False
         assert entity._is_valid_mode(None, {0, 1, 2}) is False
         assert entity._is_valid_mode([], {0, 1, 2}) is False
+
+
+class TestQvantumSelectEntityOperationSensor:
+    """Test the use_operation_sensor select entity."""
+
+    def test_init(self, mock_coordinator, mock_device):
+        """Test select entity initialization for use_operation_sensor."""
+        mock_coordinator.data["values"]["use_operation_sensor"] = 0
+        entity = QvantumSelectEntity(
+            mock_coordinator, "use_operation_sensor", mock_device
+        )
+
+        assert entity._metric_key == "use_operation_sensor"
+        assert entity._attr_unique_id == "qvantum_use_operation_sensor_test_device_123"
+        assert entity._attr_options == ["0", "1", "2", "3", "4"]
+        assert entity._attr_icon == "mdi:motion-sensor"
+        assert entity._attr_translation_key == "use_operation_sensor"
+
+    def test_current_option_all_values(self, mock_coordinator, mock_device):
+        """Test current_option returns string representation for each valid integer value."""
+        mock_coordinator.data["values"]["use_operation_sensor"] = 0
+        entity = QvantumSelectEntity(
+            mock_coordinator, "use_operation_sensor", mock_device
+        )
+
+        for val in range(5):
+            mock_coordinator.data["values"]["use_operation_sensor"] = val
+            assert entity.current_option == str(val)
+
+    def test_current_option_no_data(self, mock_coordinator, mock_device):
+        """Test current_option returns None when metric key is missing from values."""
+        mock_coordinator.data["values"]["use_operation_sensor"] = 0
+        entity = QvantumSelectEntity(
+            mock_coordinator, "use_operation_sensor", mock_device
+        )
+        del mock_coordinator.data["values"]["use_operation_sensor"]
+        assert entity.current_option is None
+
+    @pytest.mark.asyncio
+    async def test_async_select_option(self, mock_coordinator, mock_device):
+        """Test selecting an option writes directly to Modbus holding register 9."""
+        mock_coordinator.data["values"]["use_operation_sensor"] = 0
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": True,
+        }
+        entity = QvantumSelectEntity(
+            mock_coordinator, "use_operation_sensor", mock_device
+        )
+
+        mock_coordinator.api.write_holding_register = AsyncMock(
+            return_value={"status": "APPLIED"}
+        )
+
+        for opt in ["0", "1", "2", "3", "4"]:
+            mock_coordinator.api.write_holding_register.reset_mock()
+            await entity.async_select_option(opt)
+            mock_coordinator.api.write_holding_register.assert_called_once_with(
+                "test_device_123", 9, int(opt)
+            )
+
+    def test_available_modbus_write_enabled(self, mock_coordinator, mock_device):
+        """Test entity is available when Modbus write is enabled."""
+        mock_coordinator.data["values"]["use_operation_sensor"] = 0
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": True,
+        }
+        entity = QvantumSelectEntity(
+            mock_coordinator, "use_operation_sensor", mock_device
+        )
+        assert entity.available is True
+
+    def test_available_modbus_write_disabled(self, mock_coordinator, mock_device):
+        """Test entity is unavailable when Modbus write is disabled."""
+        mock_coordinator.data["values"]["use_operation_sensor"] = 0
+        mock_coordinator.config_entry.options = {}
+        mock_coordinator.config_entry.data = {}
+        entity = QvantumSelectEntity(
+            mock_coordinator, "use_operation_sensor", mock_device
+        )
+        assert entity.available is False

--- a/tests/test_select_working.py
+++ b/tests/test_select_working.py
@@ -354,15 +354,15 @@ class TestQvantumSelectEntityOperationSensor:
             mock_coordinator, "use_operation_sensor", mock_device
         )
 
-        mock_coordinator.api.write_holding_register = AsyncMock(
+        mock_coordinator.api.write_holding_register_for_metric = AsyncMock(
             return_value={"status": "APPLIED"}
         )
 
         for opt in ["0", "1", "2", "3", "4"]:
-            mock_coordinator.api.write_holding_register.reset_mock()
+            mock_coordinator.api.write_holding_register_for_metric.reset_mock()
             await entity.async_select_option(opt)
-            mock_coordinator.api.write_holding_register.assert_called_once_with(
-                "test_device_123", 9, int(opt)
+            mock_coordinator.api.write_holding_register_for_metric.assert_called_once_with(
+                "test_device_123", "use_operation_sensor", int(opt)
             )
 
     def test_available_modbus_write_enabled(self, mock_coordinator, mock_device):

--- a/tests/test_select_working.py
+++ b/tests/test_select_working.py
@@ -1,5 +1,6 @@
 """Tests for Qvantum select entities (working version that avoids metaclass issues)."""
 
+from homeassistant.exceptions import HomeAssistantError
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
@@ -354,16 +355,16 @@ class TestQvantumSelectEntityOperationSensor:
             mock_coordinator, "use_operation_sensor", mock_device
         )
 
-        mock_coordinator.api.write_holding_register_for_metric = AsyncMock(
+        mock_coordinator.api.write_holding_register = AsyncMock(
             return_value={"status": "APPLIED"}
         )
         mock_coordinator.data["values"]["sensor_mode"] = 0
 
         for opt in ["0", "1", "2", "3", "4"]:
-            mock_coordinator.api.write_holding_register_for_metric.reset_mock()
+            mock_coordinator.api.write_holding_register.reset_mock()
             await entity.async_select_option(opt)
-            mock_coordinator.api.write_holding_register_for_metric.assert_called_once_with(
-                "test_device_123", "use_operation_sensor", int(opt)
+            mock_coordinator.api.write_holding_register.assert_called_once_with(
+                "test_device_123", 9, int(opt)
             )
             assert mock_coordinator.data["values"]["sensor_mode"] == int(opt)
 
@@ -378,6 +379,39 @@ class TestQvantumSelectEntityOperationSensor:
             mock_coordinator, "use_operation_sensor", mock_device
         )
         assert entity.available is True
+
+    @pytest.mark.asyncio
+    async def test_async_select_option_raises_when_modbus_write_disabled(
+        self, mock_coordinator, mock_device
+    ):
+        """Test use_operation_sensor fails fast when Modbus writing is disabled."""
+        mock_coordinator.data["values"]["use_operation_sensor"] = 0
+        mock_coordinator.config_entry.options = {}
+        mock_coordinator.config_entry.data = {}
+        entity = QvantumSelectEntity(
+            mock_coordinator, "use_operation_sensor", mock_device
+        )
+
+        with pytest.raises(HomeAssistantError, match="Modbus writing is disabled"):
+            await entity.async_select_option("1")
+
+    @pytest.mark.asyncio
+    async def test_async_select_option_raises_when_modbus_tcp_disabled(
+        self, mock_coordinator, mock_device
+    ):
+        """Test use_operation_sensor fails fast when Modbus TCP is disabled."""
+        mock_coordinator.data["values"]["use_operation_sensor"] = 0
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": False,
+        }
+        mock_coordinator.config_entry.data = {}
+        entity = QvantumSelectEntity(
+            mock_coordinator, "use_operation_sensor", mock_device
+        )
+
+        with pytest.raises(HomeAssistantError, match="Modbus writing is disabled"):
+            await entity.async_select_option("1")
 
     def test_available_modbus_write_disabled(self, mock_coordinator, mock_device):
         """Test entity is unavailable when Modbus write is disabled."""


### PR DESCRIPTION
This pull request adds support for two new metrics—`use_operation_sensor` and `room_temp_external`—to the Qvantum Home Assistant integration. These changes enable users to select the indoor sensor source and set the external indoor temperature, with appropriate handling for Modbus write permissions, translations, and UI availability.

**Support for new metrics:**

* Added support for the `use_operation_sensor` select entity, allowing users to choose the indoor sensor source. This includes UI options, Modbus write logic, and availability checks that respect Modbus write permissions. [[1]](diffhunk://#diff-d0aee2170a1c83bc144f0c71354ba7cec131921978c8d6deede9fbe0f566b806R32-R33) [[2]](diffhunk://#diff-d0aee2170a1c83bc144f0c71354ba7cec131921978c8d6deede9fbe0f566b806R59-R60) [[3]](diffhunk://#diff-d0aee2170a1c83bc144f0c71354ba7cec131921978c8d6deede9fbe0f566b806L81-R94) [[4]](diffhunk://#diff-d0aee2170a1c83bc144f0c71354ba7cec131921978c8d6deede9fbe0f566b806R128-R134) [[5]](diffhunk://#diff-d0aee2170a1c83bc144f0c71354ba7cec131921978c8d6deede9fbe0f566b806R204-R209) [[6]](diffhunk://#diff-46476246b1f100aed1892d0fbacd6705ae0ad1d4eee38f1cb2709de7e0d78384R97-R99) [[7]](diffhunk://#diff-93c70da3b6878ca7af7b350f167eda6585822b5e506ffa2bd8a10d74d7d50e9aR143)
* Added support for the `room_temp_external` number entity, allowing users to set the external indoor temperature when the external sensor mode is enabled. This includes value ranges, Modbus write logic, and context-sensitive availability. [[1]](diffhunk://#diff-37b24c15c007d2fd3db3f36096acf939aeea60cf05d5843ece90555692105addL26-R27) [[2]](diffhunk://#diff-37b24c15c007d2fd3db3f36096acf939aeea60cf05d5843ece90555692105addR49) [[3]](diffhunk://#diff-37b24c15c007d2fd3db3f36096acf939aeea60cf05d5843ece90555692105addR93-R118) [[4]](diffhunk://#diff-37b24c15c007d2fd3db3f36096acf939aeea60cf05d5843ece90555692105addR127-R152) [[5]](diffhunk://#diff-37b24c15c007d2fd3db3f36096acf939aeea60cf05d5843ece90555692105addR177-R186) [[6]](diffhunk://#diff-93c70da3b6878ca7af7b350f167eda6585822b5e506ffa2bd8a10d74d7d50e9aR143) [[7]](diffhunk://#diff-46476246b1f100aed1892d0fbacd6705ae0ad1d4eee38f1cb2709de7e0d78384R97-R99)

**Modbus write permission handling:**

* Improved Modbus write permission checks by centralizing logic in the base entity class and ensuring both new entities respect these permissions for safe operation. [[1]](diffhunk://#diff-46476246b1f100aed1892d0fbacd6705ae0ad1d4eee38f1cb2709de7e0d78384L9-R9) [[2]](diffhunk://#diff-46476246b1f100aed1892d0fbacd6705ae0ad1d4eee38f1cb2709de7e0d78384R137-R149) [[3]](diffhunk://#diff-37b24c15c007d2fd3db3f36096acf939aeea60cf05d5843ece90555692105addR177-R186) [[4]](diffhunk://#diff-d0aee2170a1c83bc144f0c71354ba7cec131921978c8d6deede9fbe0f566b806R204-R209)

**Translations and UI enhancements:**

* Added translations for `use_operation_sensor` and `room_temp_external` in all supported languages, ensuring clear display in the Home Assistant UI. [[1]](diffhunk://#diff-c38b12eee4843bd1f813526f2a1d519a00e26c744de32799eae5b19f0e992a4fR56-R65) [[2]](diffhunk://#diff-c38b12eee4843bd1f813526f2a1d519a00e26c744de32799eae5b19f0e992a4fR508-R510) [[3]](diffhunk://#diff-acfc3b0627ed2bb0327c528addfe1335670f607c305117c84c6eaf8b8c31e780R56-R65) [[4]](diffhunk://#diff-acfc3b0627ed2bb0327c528addfe1335670f607c305117c84c6eaf8b8c31e780R508-R510) [[5]](diffhunk://#diff-a2a9672f511a16ec3c1617867055a659f0a84e7689dc79a1eacdb83079fbff37R56-R65) [[6]](diffhunk://#diff-a2a9672f511a16ec3c1617867055a659f0a84e7689dc79a1eacdb83079fbff37R509-R511) [[7]](diffhunk://#diff-c5fb2d6ea185048b324440f4f45e1ba73623382c7ba888322ba0949fcabb1b9fR56-R65) [[8]](diffhunk://#diff-c5fb2d6ea185048b324440f4f45e1ba73623382c7ba888322ba0949fcabb1b9fR507-R509) [[9]](diffhunk://#diff-7a6c968b2fd371d0cc18051be96d7ed737a1d5b731a3c3d9788623a7ef61d91cR56-R65) [[10]](diffhunk://#diff-7a6c968b2fd371d0cc18051be96d7ed737a1d5b731a3c3d9788623a7ef61d91cR507-R509) [[11]](diffhunk://#diff-109634c5949fae269ebe22ad819b8beeaeec637b0fe83e1fcda3b18fb3ba1c0dR56-R65) [[12]](diffhunk://#diff-109634c5949fae269ebe22ad819b8beeaeec637b0fe83e1fcda3b18fb3ba1c0dR509-R511) [[13]](diffhunk://#diff-dbadd40b4bfdf9f26a70958e8813234128be91d97acb995f648fa34b5ca7e3a3R56-R65) [[14]](diffhunk://#diff-dbadd40b4bfdf9f26a70958e8813234128be91d97acb995f648fa34b5ca7e3a3R507-R509) [[15]](diffhunk://#diff-17731185892f92368a0a463c8d218030c11e775fab898134846ab991a29440f0R33-R42)

**Code maintenance:**

* Removed unused imports and moved Modbus write permission logic from `number.py` to the shared entity base class for consistency and maintainability. [[1]](diffhunk://#diff-37b24c15c007d2fd3db3f36096acf939aeea60cf05d5843ece90555692105addL15-L16) [[2]](diffhunk://#diff-37b24c15c007d2fd3db3f36096acf939aeea60cf05d5843ece90555692105addR177-R186) [[3]](diffhunk://#diff-46476246b1f100aed1892d0fbacd6705ae0ad1d4eee38f1cb2709de7e0d78384L9-R9) [[4]](diffhunk://#diff-46476246b1f100aed1892d0fbacd6705ae0ad1d4eee38f1cb2709de7e0d78384R137-R149)

These enhancements provide greater flexibility and control for users with Qvantum heat pumps, especially those using external sensors and Modbus integration.