### PR TITLE
fix: enable tap_stop fetch in HTTP mode and avoid duplicate timer sensor (fixes #164)

### DIFF
--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -94,6 +94,8 @@ DEFAULT_ENABLED_HTTP_ONLY_METRICS = [
     "bp2_pressure",
     "bp2_temp",
     "fan0_10v",
+    # Epoch timestamp for when extra hot water ends; powers QvantumTimerEntity
+    "tap_stop",
 ]
 
 DEFAULT_ENABLED_MODBUS_METRICS = (

--- a/custom_components/qvantum/sensor.py
+++ b/custom_components/qvantum/sensor.py
@@ -71,8 +71,8 @@ async def async_setup_entry(
             DEFAULT_ENABLED_HTTP_METRICS + DEFAULT_DISABLED_HTTP_METRICS
         )
 
-    # Special metrics that have dedicated sensor classes
-    special_metrics = {"latency", "hpid"}
+    # Special metrics that have dedicated sensor classes (created explicitly below)
+    special_metrics = {"latency", "hpid", "tap_stop"}
 
     # Create entities using a hybrid approach:
     # - Disabled-by-default metrics: always create so they appear in the entity registry

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -250,6 +250,8 @@ class TestQvantumDataUpdateCoordinator:
         # Should return DEFAULT_ENABLED_HTTP_METRICS plus REQUIRED_METRICS
         expected_metrics = set(DEFAULT_ENABLED_HTTP_METRICS) | set(REQUIRED_METRICS)
         assert set(result) == expected_metrics
+        # Extra hot water stop timestamp must be fetched in HTTP mode
+        assert "tap_stop" in result
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     def test_get_enabled_metrics_no_matching_entities(self, mock_super_init):
@@ -386,6 +388,50 @@ class TestQvantumDataUpdateCoordinator:
         coordinator = QvantumDataUpdateCoordinator(mock_hass, config_entry)
 
         assert coordinator.poll_interval == 15
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_async_update_data_http_includes_tap_stop(self, mock_super_init):
+        """HTTP mode should request and surface tap_stop for the timer sensor."""
+        mock_super_init.return_value = None
+
+        mock_api = MagicMock()
+        mock_api.get_primary_device = AsyncMock(return_value={"id": "test_device_123"})
+        mock_api.get_metrics = AsyncMock(
+            return_value={
+                "metrics": {
+                    "hpid": "test_device_123",
+                    "tap_stop": 1712232000,
+                }
+            }
+        )
+        mock_api.get_settings = AsyncMock(return_value={"settings": []})
+
+        mock_hass = MagicMock()
+        mock_hass.data = {
+            DOMAIN: mock_api,
+            "device_registry": MagicMock(),
+            "entity_registry": MagicMock(),
+        }
+
+        mock_config_entry = MagicMock()
+        mock_config_entry.options.get.side_effect = lambda key, default=None: (
+            120 if key == CONF_SCAN_INTERVAL else default
+        )
+        mock_config_entry.data = {}
+        mock_config_entry.unique_id = "test_device_123"
+
+        coordinator = QvantumDataUpdateCoordinator(mock_hass, mock_config_entry)
+        coordinator.api = mock_api
+        coordinator.hass = mock_hass
+        coordinator.modbus_enabled = False
+
+        result = await coordinator.async_update_data()
+
+        enabled_metrics = mock_api.get_metrics.await_args.kwargs["enabled_metrics"]
+        assert "tap_stop" in enabled_metrics
+        assert result["values"]["tap_stop"] == 1712232000
+        mock_api.get_http_metrics.assert_not_called()
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -41,6 +41,7 @@ with patch(
             QvantumCurrentEntity,
             QvantumDiagnosticEntity,
             QvantumTotalEnergyEntity,
+            QvantumTimerEntity,
             _get_sensor_type,
             async_setup_entry,
         )
@@ -70,6 +71,7 @@ def mock_coordinator():
             "qn8position": 1,  # Position sensor
             "tap_water_start": 3600,
             "tap_water_stop": 7200,
+            "tap_stop": 1712232000,
         },
     }
     return coordinator
@@ -396,6 +398,31 @@ class TestSensorSetup:
             "device_registry": mock_device_registry,
         }
         return hass
+
+    @pytest.mark.asyncio
+    async def test_async_setup_entry_creates_single_tap_stop_timer(
+        self, mock_hass, mock_config_entry, mock_coordinator, mock_device
+    ):
+        """tap_stop must only be created once as QvantumTimerEntity (not also as a base sensor)."""
+        mock_entity_registry = mock_hass.data["entity_registry"]
+        mock_entity_registry.async_get.return_value = None
+        mock_entity_registry.async_update_entity = MagicMock()
+
+        def mock_async_add_entities(entities):
+            for sensor in entities:
+                sensor.entity_id = f"sensor.qvantum_{sensor._metric_key}_{sensor._hpid}"
+
+        async_add_entities = MagicMock(side_effect=mock_async_add_entities)
+
+        await async_setup_entry(mock_hass, mock_config_entry, async_add_entities)
+
+        entities = async_add_entities.call_args[0][0]
+        tap_stop_entities = [e for e in entities if e._metric_key == "tap_stop"]
+        unique_ids = [e._attr_unique_id for e in entities]
+
+        assert len(tap_stop_entities) == 1
+        assert isinstance(tap_stop_entities[0], QvantumTimerEntity)
+        assert unique_ids.count("qvantum_tap_stop_test_device_123") == 1
 
     @pytest.mark.asyncio
     async def test_async_setup_entry_disables_default_disabled_entities(


### PR DESCRIPTION
This pull request adds support for the `tap_stop` metric, which represents the epoch timestamp for when extra hot water ends, and ensures it is handled as a dedicated timer sensor (`QvantumTimerEntity`). The changes also include tests to verify that `tap_stop` is properly surfaced in HTTP mode and is not duplicated as a base sensor.

**Support for `tap_stop` metric:**

* Added `tap_stop` to the list of recognized metrics in `const.py`, with a comment explaining its purpose.
* Included `tap_stop` in the set of special metrics that are handled by dedicated sensor classes in `sensor.py`.

**Testing and validation:**

* Added tests to ensure `tap_stop` is included in enabled metrics for HTTP mode and that its value is correctly fetched and surfaced. [[1]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R253-R254) [[2]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R392-R435)
* Updated test fixtures and mocks to include `tap_stop` in the test data. [[1]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330R74) [[2]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330R44)
* Added a test to verify that only a single `QvantumTimerEntity` is created for `tap_stop` and it is not duplicated as a base sensor.