### PR TITLE
feat: add configurable Modbus scan interval.

### DIFF
--- a/custom_components/qvantum/config_flow.py
+++ b/custom_components/qvantum/config_flow.py
@@ -285,6 +285,12 @@ class QvantumOptionsFlowHandler(OptionsFlow):
                     CONF_MODBUS_WRITE,
                     default=self.options.get(CONF_MODBUS_WRITE, False),
                 ): bool,
+                vol.Optional(
+                    CONF_MODBUS_SCAN_INTERVAL,
+                    default=self.options.get(
+                        CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_MODBUS_SCAN_INTERVAL)),
             }
         )
 

--- a/custom_components/qvantum/config_flow.py
+++ b/custom_components/qvantum/config_flow.py
@@ -25,11 +25,14 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .api import QvantumAPI, APIAuthError, APIConnectionError
 from .const import (
+    DEFAULT_MODBUS_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    MIN_MODBUS_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
     VERSION,
     CONFIG_VERSION,
+    CONF_MODBUS_SCAN_INTERVAL,
     CONF_MODBUS_TCP,
     CONF_MODBUS_WRITE,
     CONF_MODBUS_HOST,
@@ -183,6 +186,12 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
                     **config_entry.options,
                     CONF_MODBUS_TCP: modbus_enabled,
                     CONF_MODBUS_WRITE: modbus_write_enabled,
+                    CONF_MODBUS_SCAN_INTERVAL: user_input.get(
+                        CONF_MODBUS_SCAN_INTERVAL,
+                        config_entry.options.get(
+                            CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL
+                        ),
+                    ),
                 }
                 return self.async_update_reload_and_abort(
                     config_entry,
@@ -213,6 +222,14 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
                             config_entry.data.get(CONF_MODBUS_WRITE, False),
                         ),
                     ): bool,
+                    vol.Optional(
+                        CONF_MODBUS_SCAN_INTERVAL,
+                        default=config_entry.options.get(
+                            CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL
+                        ),
+                    ): vol.All(
+                        vol.Coerce(int), vol.Clamp(min=MIN_MODBUS_SCAN_INTERVAL)
+                    ),
                 }
             ),
             errors=errors,

--- a/custom_components/qvantum/config_flow.py
+++ b/custom_components/qvantum/config_flow.py
@@ -58,6 +58,15 @@ def _normalize_modbus_settings(
     return modbus_enabled, modbus_write_enabled and modbus_enabled
 
 
+def _normalize_modbus_scan_interval(value: Any) -> int:
+    """Coerce Modbus scan interval to int and enforce the configured minimum."""
+    try:
+        interval = int(value)
+    except (TypeError, ValueError):
+        return DEFAULT_MODBUS_SCAN_INTERVAL
+    return max(interval, MIN_MODBUS_SCAN_INTERVAL)
+
+
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect.
 
@@ -186,11 +195,14 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
                     **config_entry.options,
                     CONF_MODBUS_TCP: modbus_enabled,
                     CONF_MODBUS_WRITE: modbus_write_enabled,
-                    CONF_MODBUS_SCAN_INTERVAL: user_input.get(
-                        CONF_MODBUS_SCAN_INTERVAL,
-                        config_entry.options.get(
-                            CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL
-                        ),
+                    CONF_MODBUS_SCAN_INTERVAL: _normalize_modbus_scan_interval(
+                        user_input.get(
+                            CONF_MODBUS_SCAN_INTERVAL,
+                            config_entry.options.get(
+                                CONF_MODBUS_SCAN_INTERVAL,
+                                DEFAULT_MODBUS_SCAN_INTERVAL,
+                            ),
+                        )
                     ),
                 }
                 return self.async_update_reload_and_abort(
@@ -224,8 +236,11 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
                     ): bool,
                     vol.Optional(
                         CONF_MODBUS_SCAN_INTERVAL,
-                        default=config_entry.options.get(
-                            CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL
+                        default=_normalize_modbus_scan_interval(
+                            config_entry.options.get(
+                                CONF_MODBUS_SCAN_INTERVAL,
+                                DEFAULT_MODBUS_SCAN_INTERVAL,
+                            )
                         ),
                     ): vol.All(
                         vol.Coerce(int), vol.Clamp(min=MIN_MODBUS_SCAN_INTERVAL)
@@ -263,6 +278,12 @@ class QvantumOptionsFlowHandler(OptionsFlow):
                 normalized_input[CONF_MODBUS_WRITE] = modbus_write_enabled
             elif CONF_MODBUS_WRITE in user_input:
                 normalized_input[CONF_MODBUS_WRITE] = modbus_write_enabled
+            if CONF_MODBUS_SCAN_INTERVAL in normalized_input:
+                normalized_input[CONF_MODBUS_SCAN_INTERVAL] = (
+                    _normalize_modbus_scan_interval(
+                        normalized_input[CONF_MODBUS_SCAN_INTERVAL]
+                    )
+                )
 
             options = self.options | normalized_input
             return self.async_create_entry(title="", data=options)
@@ -287,8 +308,10 @@ class QvantumOptionsFlowHandler(OptionsFlow):
                 ): bool,
                 vol.Optional(
                     CONF_MODBUS_SCAN_INTERVAL,
-                    default=self.options.get(
-                        CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL
+                    default=_normalize_modbus_scan_interval(
+                        self.options.get(
+                            CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL
+                        )
                     ),
                 ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_MODBUS_SCAN_INTERVAL)),
             }

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -3,7 +3,7 @@
 DOMAIN = "qvantum"
 DEFAULT_SCAN_INTERVAL = 120
 MIN_SCAN_INTERVAL = 60
-# Modbus poll interval (reconfigure-only). Default matches the previous hard cap.
+# Modbus poll interval. Default matches the previous hard cap.
 DEFAULT_MODBUS_SCAN_INTERVAL = 15
 MIN_MODBUS_SCAN_INTERVAL = 5
 SETTING_UPDATE_APPLIED = "APPLIED"

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -3,6 +3,9 @@
 DOMAIN = "qvantum"
 DEFAULT_SCAN_INTERVAL = 120
 MIN_SCAN_INTERVAL = 60
+# Modbus poll interval (reconfigure-only). Default matches the previous hard cap.
+DEFAULT_MODBUS_SCAN_INTERVAL = 15
+MIN_MODBUS_SCAN_INTERVAL = 5
 SETTING_UPDATE_APPLIED = "APPLIED"
 
 # Heat pump status values (hp_status metric)
@@ -26,6 +29,7 @@ CONF_MODBUS_WRITE = "modbus_write"
 CONF_MODBUS_HOST = "modbus_host"
 CONF_MODBUS_PORT = "modbus_port"
 CONF_MODBUS_UNIT_ID = "modbus_unit_id"
+CONF_MODBUS_SCAN_INTERVAL = "modbus_scan_interval"
 DEFAULT_MODBUS_HOST = "Qvantum-HP"
 DEFAULT_MODBUS_PORT = 502
 DEFAULT_MODBUS_UNIT_ID = 1

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -95,7 +95,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         )
 
         if self.modbus_enabled:
-            # Dedicated Modbus interval (reconfigure-only). Falls back to the
+            # Dedicated Modbus interval. Falls back to the
             # historical 15s default when unset. Enforce a sensible minimum.
             modbus_interval = config_entry.options.get(
                 CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -20,17 +20,20 @@ from .calculations import QvantumCalculationsMixin
 from .const import (
     DEFAULT_DISABLED_HTTP_METRICS,
     DEFAULT_DISABLED_MODBUS_METRICS,
+    DEFAULT_MODBUS_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     HP_STATUS_COOLING,
     HP_STATUS_DEFROSTING,
     HP_STATUS_HEATING,
     HP_STATUS_HOT_WATER,
+    MIN_MODBUS_SCAN_INTERVAL,
     SETTING_UPDATE_APPLIED,
     DEFAULT_ENABLED_HTTP_METRICS,
     DEFAULT_ENABLED_MODBUS_METRICS,
     REQUIRED_METRICS,
     REQUIRED_MODBUS_METRICS,
+    CONF_MODBUS_SCAN_INTERVAL,
     CONF_MODBUS_TCP,
     TAP_WATER_CAPACITY_MAPPINGS,
 )
@@ -92,7 +95,16 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         )
 
         if self.modbus_enabled:
-            self.poll_interval = min(self.poll_interval, 15)  # Faster for Modbus
+            # Dedicated Modbus interval (reconfigure-only). Falls back to the
+            # historical 15s default when unset. Enforce a sensible minimum.
+            modbus_interval = config_entry.options.get(
+                CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL
+            )
+            try:
+                modbus_interval = int(modbus_interval)
+            except (TypeError, ValueError):
+                modbus_interval = DEFAULT_MODBUS_SCAN_INTERVAL
+            self.poll_interval = max(modbus_interval, MIN_MODBUS_SCAN_INTERVAL)
 
         self.api = hass.data[DOMAIN]
         self._device = None

--- a/custom_components/qvantum/sensor.py
+++ b/custom_components/qvantum/sensor.py
@@ -52,6 +52,8 @@ async def async_setup_entry(
     coordinator: QvantumDataUpdateCoordinator = config_entry.runtime_data.coordinator
     device: DeviceInfo | dict = config_entry.runtime_data.device
 
+    _LOGGER.debug("Setting up platform SENSOR")
+
     sensors = []
 
     values = coordinator.data.get("values", {})

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -578,11 +578,13 @@
           "scan_interval": "HTTP-Scan-Intervall (Sekunden)",
           "modbus_tcp": "Modbus-Lesen statt HTTP-Abfragen verwenden",
           "modbus_host": "Qvantum Host/IP",
-          "modbus_write": "Schreiben über Modbus aktivieren"
+          "modbus_write": "Schreiben über Modbus aktivieren",
+          "modbus_scan_interval": "Modbus-Scan-Intervall (Sekunden)"
         },
         "data_description": {
           "modbus_tcp": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest; Schreiben/Steuerung erfolgt weiterhin über die HTTP-API, es sei denn, Schreiben ist ebenfalls aktiviert. Bestimmte Steuerungen werden über Modbus geschrieben.",
-          "modbus_write": "Durch die Aktivierung des Modbus-Schreibens übernehmen Sie die volle Verantwortung für alle über die Schnittstelle geschriebenen Werte. Der Hersteller haftet nicht für Probleme, die durch falsche oder außerhalb des Bereichs liegende Werte verursacht werden, und solche Maßnahmen können die Garantie und/oder die Lebensdauer und Leistung des Produkts beeinträchtigen."
+          "modbus_write": "Durch die Aktivierung des Modbus-Schreibens übernehmen Sie die volle Verantwortung für alle über die Schnittstelle geschriebenen Werte. Der Hersteller haftet nicht für Probleme, die durch falsche oder außerhalb des Bereichs liegende Werte verursacht werden, und solche Maßnahmen können die Garantie und/oder die Lebensdauer und Leistung des Produkts beeinträchtigen.",
+          "modbus_scan_interval": "Wie oft die Wärmepumpe über Modbus TCP abgefragt wird. Niedrigere Werte ermöglichen nahezu Echtzeit-Durchfluss- und Volumenmessung. Minimum sind 5 Sekunden. Standard sind 15 Sekunden."
         },
         "description": "Ändern Sie Ihre Optionen.",
         "title": "Optionen"

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -202,7 +202,6 @@
       "inputcurrent3": {
         "name": "Eingangsstrom L3"
       },
-
       "degree_minute": {
         "name": "Gradminute"
       },
@@ -561,11 +560,13 @@
           "password": "Passwort",
           "username": "Benutzername",
           "modbus_tcp": "Modbus-Lesen statt HTTP-Abfragen verwenden",
-          "modbus_write": "Schreiben über Modbus aktivieren"
+          "modbus_write": "Schreiben über Modbus aktivieren",
+          "modbus_scan_interval": "Modbus-Scan-Intervall (Sekunden)"
         },
         "data_description": {
           "modbus_tcp": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest; Schreiben/Steuerung erfolgt weiterhin über die HTTP-API, es sei denn, Schreiben ist ebenfalls aktiviert. Bestimmte Steuerungen werden über Modbus geschrieben.",
-          "modbus_write": "Durch die Aktivierung des Modbus-Schreibens übernehmen Sie die volle Verantwortung für alle über die Schnittstelle geschriebenen Werte. Der Hersteller haftet nicht für Probleme, die durch falsche oder außerhalb des Bereichs liegende Werte verursacht werden, und solche Maßnahmen können die Garantie und/oder die Lebensdauer und Leistung des Produkts beeinträchtigen."
+          "modbus_write": "Durch die Aktivierung des Modbus-Schreibens übernehmen Sie die volle Verantwortung für alle über die Schnittstelle geschriebenen Werte. Der Hersteller haftet nicht für Probleme, die durch falsche oder außerhalb des Bereichs liegende Werte verursacht werden, und solche Maßnahmen können die Garantie und/oder die Lebensdauer und Leistung des Produkts beeinträchtigen.",
+          "modbus_scan_interval": "Wie oft die Wärmepumpe über Modbus TCP abgefragt wird. Niedrigere Werte ermöglichen nahezu Echtzeit-Durchfluss- und Volumenmessung. Minimum sind 5 Sekunden. Standard sind 15 Sekunden."
         }
       }
     }

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -578,11 +578,13 @@
           "scan_interval": "HTTP Scan Interval (seconds)",
           "modbus_tcp": "Use Modbus reading instead of HTTP polling",
           "modbus_host": "Qvantum Host/IP",
-          "modbus_write": "Enable writing via Modbus"
+          "modbus_write": "Enable writing via Modbus",
+          "modbus_scan_interval": "Modbus scan interval (seconds)"
         },
         "data_description": {
           "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
-          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
+          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product.",
+          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Lower values give near real-time flow and volume accuracy. Minimum is 5 seconds. Default is 15 seconds."
         },
         "description": "Amend your options.",
         "title": "Options"

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -202,7 +202,6 @@
       "inputcurrent3": {
         "name": "Input current L3"
       },
-
       "degree_minute": {
         "name": "Degree Minute"
       },
@@ -561,11 +560,13 @@
           "password": "Password",
           "username": "Username",
           "modbus_tcp": "Use Modbus reading instead of HTTP polling",
-          "modbus_write": "Enable writing via Modbus"
+          "modbus_write": "Enable writing via Modbus",
+          "modbus_scan_interval": "Modbus scan interval (seconds)"
         },
         "data_description": {
           "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
-          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
+          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product.",
+          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Lower values give near real-time flow and volume accuracy. Minimum is 5 seconds. Default is 15 seconds."
         }
       }
     }

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -202,7 +202,6 @@
       "inputcurrent3": {
         "name": "Corriente de entrada L3"
       },
-
       "degree_minute": {
         "name": "Grado minuto"
       },
@@ -414,7 +413,6 @@
           "client-disconnect": "Cliente desconectado"
         }
       },
-
       "heatingreleased": {
         "name": "Calefacción liberada"
       },
@@ -562,11 +560,13 @@
           "password": "Contraseña",
           "username": "Nombre de usuario",
           "modbus_tcp": "Usar lectura Modbus en lugar de sondeo HTTP",
-          "modbus_write": "Activar escritura mediante Modbus"
+          "modbus_write": "Activar escritura mediante Modbus",
+          "modbus_scan_interval": "Intervalo de exploración Modbus (segundos)"
         },
         "data_description": {
           "modbus_tcp": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus; la escritura/control sigue siendo vía API HTTP a menos que también se habilite la escritura. Algunos controles se escriben mediante Modbus.",
-          "modbus_write": "Al activar la escritura Modbus, aceptas la plena responsabilidad de cualquier valor escrito a través de la interfaz. El fabricante no es responsable de los problemas causados por valores incorrectos o fuera de rango, y tales acciones pueden anular la garantía y/o afectar el ciclo de vida y el rendimiento del producto."
+          "modbus_write": "Al activar la escritura Modbus, aceptas la plena responsabilidad de cualquier valor escrito a través de la interfaz. El fabricante no es responsable de los problemas causados por valores incorrectos o fuera de rango, y tales acciones pueden anular la garantía y/o afectar el ciclo de vida y el rendimiento del producto.",
+          "modbus_scan_interval": "Con qué frecuencia se consulta la bomba de calor por Modbus TCP. Valores más bajos dan precisión casi en tiempo real de caudal y volumen. El mínimo es 5 segundos. El valor predeterminado es 15 segundos."
         }
       }
     }

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -578,11 +578,13 @@
           "scan_interval": "Intervalo de exploración HTTP (segundos)",
           "modbus_tcp": "Usar lectura Modbus en lugar de sondeo HTTP",
           "modbus_host": "Qvantum Host/IP",
-          "modbus_write": "Activar escritura mediante Modbus"
+          "modbus_write": "Activar escritura mediante Modbus",
+          "modbus_scan_interval": "Intervalo de exploración Modbus (segundos)"
         },
         "data_description": {
           "modbus_tcp": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus; la escritura/control sigue siendo vía API HTTP a menos que también se habilite la escritura. Algunos controles se escriben mediante Modbus.",
-          "modbus_write": "Al activar la escritura Modbus, aceptas la plena responsabilidad de cualquier valor escrito a través de la interfaz. El fabricante no es responsable de los problemas causados por valores incorrectos o fuera de rango, y tales acciones pueden anular la garantía y/o afectar el ciclo de vida y el rendimiento del producto."
+          "modbus_write": "Al activar la escritura Modbus, aceptas la plena responsabilidad de cualquier valor escrito a través de la interfaz. El fabricante no es responsable de los problemas causados por valores incorrectos o fuera de rango, y tales acciones pueden anular la garantía y/o afectar el ciclo de vida y el rendimiento del producto.",
+          "modbus_scan_interval": "Con qué frecuencia se consulta la bomba de calor por Modbus TCP. Valores más bajos dan precisión casi en tiempo real de caudal y volumen. El mínimo es 5 segundos. El valor predeterminado es 15 segundos."
         },
         "description": "Modifique sus opciones.",
         "title": "Opciones"

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -578,11 +578,13 @@
           "scan_interval": "Intervalle de scan HTTP (secondes)",
           "modbus_tcp": "Utiliser la lecture Modbus au lieu du polling HTTP",
           "modbus_host": "Hôte/IP Qvantum",
-          "modbus_write": "Activer l'écriture via Modbus"
+          "modbus_write": "Activer l'écriture via Modbus",
+          "modbus_scan_interval": "Intervalle de scan Modbus (secondes)"
         },
         "data_description": {
           "modbus_tcp": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il lit uniquement via Modbus ; les écritures/contrôles se font toujours via l'API HTTP sauf si l'écriture est également activée. Certains contrôles sont écrits via Modbus.",
-          "modbus_write": "En activant l'écriture Modbus, vous acceptez l'entière responsabilité de toutes les valeurs écrites via l'interface. Le fabricant n'est pas responsable des problèmes causés par des valeurs incorrectes ou hors limites, et de telles actions peuvent annuler la garantie et/ou affecter le cycle de vie et les performances du produit."
+          "modbus_write": "En activant l'écriture Modbus, vous acceptez l'entière responsabilité de toutes les valeurs écrites via l'interface. Le fabricant n'est pas responsable des problèmes causés par des valeurs incorrectes ou hors limites, et de telles actions peuvent annuler la garantie et/ou affecter le cycle de vie et les performances du produit.",
+          "modbus_scan_interval": "Fréquence d'interrogation de la pompe à chaleur via Modbus TCP. Des valeurs plus basses offrent une précision quasi temps réel du débit et du volume. Minimum 5 secondes. Par défaut 15 secondes."
         },
         "description": "Modifiez vos options.",
         "title": "Options"

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -560,11 +560,13 @@
           "password": "Mot de passe",
           "username": "Nom d'utilisateur",
           "modbus_tcp": "Utiliser la lecture Modbus au lieu du polling HTTP",
-          "modbus_write": "Activer l'écriture via Modbus"
+          "modbus_write": "Activer l'écriture via Modbus",
+          "modbus_scan_interval": "Intervalle de scan Modbus (secondes)"
         },
         "data_description": {
           "modbus_tcp": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il lit uniquement via Modbus ; les écritures/contrôles se font toujours via l'API HTTP sauf si l'écriture est également activée. Certains contrôles sont écrits via Modbus.",
-          "modbus_write": "En activant l'écriture Modbus, vous acceptez l'entière responsabilité de toutes les valeurs écrites via l'interface. Le fabricant n'est pas responsable des problèmes causés par des valeurs incorrectes ou hors limites, et de telles actions peuvent annuler la garantie et/ou affecter le cycle de vie et les performances du produit."
+          "modbus_write": "En activant l'écriture Modbus, vous acceptez l'entière responsabilité de toutes les valeurs écrites via l'interface. Le fabricant n'est pas responsable des problèmes causés par des valeurs incorrectes ou hors limites, et de telles actions peuvent annuler la garantie et/ou affecter le cycle de vie et les performances du produit.",
+          "modbus_scan_interval": "Fréquence d'interrogation de la pompe à chaleur via Modbus TCP. Des valeurs plus basses offrent une précision quasi temps réel du débit et du volume. Minimum 5 secondes. Par défaut 15 secondes."
         }
       }
     }

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -578,11 +578,13 @@
           "scan_interval": "HTTP lekérdezési időköz (másodperc)",
           "modbus_tcp": "Modbus-olvasás használata HTTP lekérdezés helyett",
           "modbus_host": "Qvantum Hoszt/IP",
-          "modbus_write": "Modbus alapú írás engedélyezése"
+          "modbus_write": "Modbus alapú írás engedélyezése",
+          "modbus_scan_interval": "Modbus lekérdezési időköz (másodperc)"
         },
         "data_description": {
           "modbus_tcp": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: itt csak Modbus-olvasás történik; az írás/vezérlés továbbra is HTTP API-n keresztül történik, kivéve, ha az írás is engedélyezve van. Bizonyos vezérlések Modbuson keresztül íródnak.",
-          "modbus_write": "A Modbus-írás aktiválásával teljes felelősséget vállal a felületen keresztül írt értékekért. A gyártó nem vállal felelősséget a helytelen vagy tartományon kívüli értékek által okozott problémákért, és az ilyen műveletek érvénytelenítheti a garanciát és/vagy befolyásolhatja a termék élettartamát és teljesítményét."
+          "modbus_write": "A Modbus-írás aktiválásával teljes felelősséget vállal a felületen keresztül írt értékekért. A gyártó nem vállal felelősséget a helytelen vagy tartományon kívüli értékek által okozott problémákért, és az ilyen műveletek érvénytelenítheti a garanciát és/vagy befolyásolhatja a termék élettartamát és teljesítményét.",
+          "modbus_scan_interval": "Milyen gyakran kérdezze le a hőszivattyút Modbus TCP-n. Az alacsonyabb értékek közel valós idejű áramlás- és térfogatpontosságot adnak. Minimum 5 másodperc. Alapértelmezett 15 másodperc."
         },
         "description": "Módosítsa a beállításait.",
         "title": "Beállítások"

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -560,11 +560,13 @@
           "password": "Jelszó",
           "username": "Felhasználónév",
           "modbus_tcp": "Modbus-olvasás használata HTTP lekérdezés helyett",
-          "modbus_write": "Modbus alapú írás engedélyezése"
+          "modbus_write": "Modbus alapú írás engedélyezése",
+          "modbus_scan_interval": "Modbus lekérdezési időköz (másodperc)"
         },
         "data_description": {
           "modbus_tcp": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: itt csak Modbus-olvasás történik; az írás/vezérlés továbbra is HTTP API-n keresztül történik, kivéve, ha az írás is engedélyezve van. Bizonyos vezérlések Modbuson keresztül íródnak.",
-          "modbus_write": "A Modbus-írás aktiválásával teljes felelősséget vállal a felületen keresztül írt értékekért. A gyártó nem vállal felelősséget a helytelen vagy tartományon kívüli értékek által okozott problémákért, és az ilyen műveletek érvénytelenítheti a garanciát és/vagy befolyásolhatja a termék élettartamát és teljesítményét."
+          "modbus_write": "A Modbus-írás aktiválásával teljes felelősséget vállal a felületen keresztül írt értékekért. A gyártó nem vállal felelősséget a helytelen vagy tartományon kívüli értékek által okozott problémákért, és az ilyen műveletek érvénytelenítheti a garanciát és/vagy befolyásolhatja a termék élettartamát és teljesítményét.",
+          "modbus_scan_interval": "Milyen gyakran kérdezze le a hőszivattyút Modbus TCP-n. Az alacsonyabb értékek közel valós idejű áramlás- és térfogatpontosságot adnak. Minimum 5 másodperc. Alapértelmezett 15 másodperc."
         }
       }
     }

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -578,11 +578,13 @@
           "scan_interval": "HTTP-scaninterval (seconden)",
           "modbus_tcp": "Gebruik Modbus-uitlezing in plaats van HTTP-polling",
           "modbus_host": "Qvantum Host/IP",
-          "modbus_write": "Schrijven via Modbus inschakelen"
+          "modbus_write": "Schrijven via Modbus inschakelen",
+          "modbus_scan_interval": "Modbus-scaninterval (seconden)"
         },
         "data_description": {
           "modbus_tcp": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest; schrijven/sturing gebeurt nog via de HTTP API, tenzij schrijven ook is ingeschakeld. Bepaalde besturingen worden via Modbus geschreven.",
-          "modbus_write": "Door het activeren van Modbus-schrijven aanvaardt u volledige verantwoordelijkheid voor alle waarden die via de interface worden geschreven. De fabrikant is niet aansprakelijk voor problemen veroorzaakt door onjuiste of buiten bereik vallende waarden, en dergelijke acties kunnen de garantie en/of de levensduur en prestaties van het product beïnvloeden."
+          "modbus_write": "Door het activeren van Modbus-schrijven aanvaardt u volledige verantwoordelijkheid voor alle waarden die via de interface worden geschreven. De fabrikant is niet aansprakelijk voor problemen veroorzaakt door onjuiste of buiten bereik vallende waarden, en dergelijke acties kunnen de garantie en/of de levensduur en prestaties van het product beïnvloeden.",
+          "modbus_scan_interval": "Hoe vaak de warmtepomp via Modbus TCP wordt gepolld. Lagere waarden geven bijna realtime debiet- en volumenauwkeurigheid. Minimum is 5 seconden. Standaard is 15 seconden."
         },
         "description": "Wijzig uw opties.",
         "title": "Opties"

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -202,7 +202,6 @@
       "inputcurrent3": {
         "name": "Ingangsstroom L3"
       },
-
       "degree_minute": {
         "name": "Graadminuut"
       },
@@ -414,7 +413,6 @@
           "client-disconnect": "Client verbroken"
         }
       },
-
       "heatingreleased": {
         "name": "Verwarming vrijgegeven"
       },
@@ -562,11 +560,13 @@
           "password": "Wachtwoord",
           "username": "Gebruikersnaam",
           "modbus_tcp": "Gebruik Modbus-uitlezing in plaats van HTTP-polling",
-          "modbus_write": "Schrijven via Modbus inschakelen"
+          "modbus_write": "Schrijven via Modbus inschakelen",
+          "modbus_scan_interval": "Modbus-scaninterval (seconden)"
         },
         "data_description": {
           "modbus_tcp": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest; schrijven/sturing gebeurt nog via de HTTP API, tenzij schrijven ook is ingeschakeld. Bepaalde besturingen worden via Modbus geschreven.",
-          "modbus_write": "Door het activeren van Modbus-schrijven aanvaardt u volledige verantwoordelijkheid voor alle waarden die via de interface worden geschreven. De fabrikant is niet aansprakelijk voor problemen veroorzaakt door onjuiste of buiten bereik vallende waarden, en dergelijke acties kunnen de garantie en/of de levensduur en prestaties van het product beïnvloeden."
+          "modbus_write": "Door het activeren van Modbus-schrijven aanvaardt u volledige verantwoordelijkheid voor alle waarden die via de interface worden geschreven. De fabrikant is niet aansprakelijk voor problemen veroorzaakt door onjuiste of buiten bereik vallende waarden, en dergelijke acties kunnen de garantie en/of de levensduur en prestaties van het product beïnvloeden.",
+          "modbus_scan_interval": "Hoe vaak de warmtepomp via Modbus TCP wordt gepolld. Lagere waarden geven bijna realtime debiet- en volumenauwkeurigheid. Minimum is 5 seconden. Standaard is 15 seconden."
         }
       }
     }

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -61,7 +61,7 @@
           "1": "BT2",
           "2": "BT3",
           "3": "AUX",
-          "4": "Zewn\u0119trzny"
+          "4": "Zewnętrzny"
         }
       }
     },
@@ -560,11 +560,13 @@
           "password": "Hasło",
           "username": "Nazwa użytkownika",
           "modbus_tcp": "Użyj odczytu Modbus zamiast odpytywania HTTP",
-          "modbus_write": "Włącz zapis przez Modbus"
+          "modbus_write": "Włącz zapis przez Modbus",
+          "modbus_scan_interval": "Interwał skanowania Modbus (sekundy)"
         },
         "data_description": {
           "modbus_tcp": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: tutaj działa tylko odczyt przez Modbus; zapis/sterowanie nadal odbywa się przez HTTP API, chyba że zapis również jest włączony. Niektóre funkcje sterowania są zapisywane przez Modbus.",
-          "modbus_write": "Aktywując zapis przez Modbus, bierzesz pełną odpowiedzialność za wszelkie wartości zapisane przez interfejs. Producent nie ponosi odpowiedzialności za problemy spowodowane przez nieprawidłowe lub wykraczające poza zakres wartości, a takie działania mogą unieważnić gwarancję i/lub wpłynąć na żywotność i wydajność produktu."
+          "modbus_write": "Aktywując zapis przez Modbus, bierzesz pełną odpowiedzialność za wszelkie wartości zapisane przez interfejs. Producent nie ponosi odpowiedzialności za problemy spowodowane przez nieprawidłowe lub wykraczające poza zakres wartości, a takie działania mogą unieważnić gwarancję i/lub wpłynąć na żywotność i wydajność produktu.",
+          "modbus_scan_interval": "Jak często odpytywać pompę ciepła przez Modbus TCP. Niższe wartości dają prawie rzeczywistą dokładność przepływu i objętości. Minimum to 5 sekund. Domyślnie 15 sekund."
         }
       }
     }

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -578,11 +578,13 @@
           "scan_interval": "Interwał skanowania HTTP (sekundy)",
           "modbus_tcp": "Użyj odczytu Modbus zamiast odpytywania HTTP",
           "modbus_host": "Host/IP Qvantum",
-          "modbus_write": "Włącz zapis przez Modbus"
+          "modbus_write": "Włącz zapis przez Modbus",
+          "modbus_scan_interval": "Interwał skanowania Modbus (sekundy)"
         },
         "data_description": {
           "modbus_tcp": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: tutaj działa tylko odczyt przez Modbus; zapis/sterowanie nadal odbywa się przez HTTP API, chyba że zapis również jest włączony. Niektóre funkcje sterowania są zapisywane przez Modbus.",
-          "modbus_write": "Aktywując zapis przez Modbus, bierzesz pełną odpowiedzialność za wszelkie wartości zapisane przez interfejs. Producent nie ponosi odpowiedzialności za problemy spowodowane przez nieprawidłowe lub wykraczające poza zakres wartości, a takie działania mogą unieważnić gwarancję i/lub wpłynąć na żywotność i wydajność produktu."
+          "modbus_write": "Aktywując zapis przez Modbus, bierzesz pełną odpowiedzialność za wszelkie wartości zapisane przez interfejs. Producent nie ponosi odpowiedzialności za problemy spowodowane przez nieprawidłowe lub wykraczające poza zakres wartości, a takie działania mogą unieważnić gwarancję i/lub wpłynąć na żywotność i wydajność produktu.",
+          "modbus_scan_interval": "Jak często odpytywać pompę ciepła przez Modbus TCP. Niższe wartości dają prawie rzeczywistą dokładność przepływu i objętości. Minimum to 5 sekund. Domyślnie 15 sekund."
         },
         "description": "Zmień swoje opcje.",
         "title": "Opcje"

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -205,7 +205,6 @@
       "inputcurrent3": {
         "name": "Ingångsström L3"
       },
-
       "degree_minute": {
         "name": "Gradminut"
       },
@@ -564,11 +563,13 @@
           "password": "Lösenord",
           "username": "Användarnamn",
           "modbus_tcp": "Använd Modbus-avläsning istället för HTTP-förfrågning",
-          "modbus_write": "Aktivera skrivning via Modbus"
+          "modbus_write": "Aktivera skrivning via Modbus",
+          "modbus_scan_interval": "Modbus-skanningsintervall (sekunder)"
         },
         "data_description": {
           "modbus_tcp": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus; skrivning/kontroller sker fortfarande via HTTP API om inte skrivning också är aktiverad. Vissa kontroller skrivs via Modbus.",
-          "modbus_write": "Genom att aktivera Modbus-skrivning tar du fullt ansvar för alla värden som skrivs via gränssnittet. Tillverkaren ansvarar inte för problem orsakade av felaktiga eller utanför intervallet liggande värden, och sådana åtgärder kan ogiltigförklara garantin och/eller påverka produktens livslängd och prestanda."
+          "modbus_write": "Genom att aktivera Modbus-skrivning tar du fullt ansvar för alla värden som skrivs via gränssnittet. Tillverkaren ansvarar inte för problem orsakade av felaktiga eller utanför intervallet liggande värden, och sådana åtgärder kan ogiltigförklara garantin och/eller påverka produktens livslängd och prestanda.",
+          "modbus_scan_interval": "Hur ofta värmepumpen pollas via Modbus TCP. Lägre värden ger nästan realtidsnoggrannhet för flöde och volym. Minimum är 5 sekunder. Standard är 15 sekunder."
         }
       }
     }

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -581,11 +581,13 @@
           "scan_interval": "HTTP-skanningsintervall (sekunder)",
           "modbus_tcp": "Använd Modbus-avläsning istället för HTTP-förfrågning",
           "modbus_host": "Qvantum Host/IP",
-          "modbus_write": "Aktivera skrivning via Modbus"
+          "modbus_write": "Aktivera skrivning via Modbus",
+          "modbus_scan_interval": "Modbus-skanningsintervall (sekunder)"
         },
         "data_description": {
           "modbus_tcp": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus; skrivning/kontroller sker fortfarande via HTTP API om inte skrivning också är aktiverad. Vissa kontroller skrivs via Modbus.",
-          "modbus_write": "Genom att aktivera Modbus-skrivning tar du fullt ansvar för alla värden som skrivs via gränssnittet. Tillverkaren ansvarar inte för problem orsakade av felaktiga eller utanför intervallet liggande värden, och sådana åtgärder kan ogiltigförklara garantin och/eller påverka produktens livslängd och prestanda."
+          "modbus_write": "Genom att aktivera Modbus-skrivning tar du fullt ansvar för alla värden som skrivs via gränssnittet. Tillverkaren ansvarar inte för problem orsakade av felaktiga eller utanför intervallet liggande värden, och sådana åtgärder kan ogiltigförklara garantin och/eller påverka produktens livslängd och prestanda.",
+          "modbus_scan_interval": "Hur ofta värmepumpen pollas via Modbus TCP. Lägre värden ger nästan realtidsnoggrannhet för flöde och volym. Minimum är 5 sekunder. Standard är 15 sekunder."
         },
         "description": "Ändra alternativ.",
         "title": "Alternativ"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -485,6 +485,68 @@ class TestQvantumConfigFlow:
             assert mock_update_reload.call_args.kwargs["options"]["modbus_tcp"] is True
 
     @pytest.mark.asyncio
+    async def test_step_reconfigure_normalizes_invalid_modbus_scan_interval(
+        self, hass, config_flow
+    ):
+        """Test reconfigure coerces invalid Modbus intervals to a valid int."""
+        config_entry = MagicMock()
+        config_entry.data = {"username": "old@example.com", "password": "oldpass"}
+        config_entry.options = {
+            "modbus_tcp": True,
+            "modbus_scan_interval": "not-a-number",
+        }
+        config_entry.unique_id = "test_unique_id"
+
+        hass.config_entries = MagicMock()
+        hass.config_entries.async_get_entry.return_value = config_entry
+
+        config_flow.context = {"entry_id": "test_entry_id"}
+
+        with (
+            patch(
+                "custom_components.qvantum.config_flow.validate_input"
+            ) as mock_validate,
+            patch.object(
+                config_flow, "async_update_reload_and_abort"
+            ) as mock_update_reload,
+        ):
+            mock_validate.return_value = None
+            mock_update_reload.return_value = {"type": "abort"}
+
+            # Missing field falls back to stored invalid value, then normalizes.
+            result = await config_flow.async_step_reconfigure(
+                {
+                    "username": "new@example.com",
+                    "password": "newpass",
+                    "modbus_tcp": True,
+                    "modbus_write": False,
+                }
+            )
+
+            assert result == {"type": "abort"}
+            assert (
+                mock_update_reload.call_args.kwargs["options"]["modbus_scan_interval"]
+                == 15
+            )
+
+            mock_update_reload.reset_mock()
+            result = await config_flow.async_step_reconfigure(
+                {
+                    "username": "new@example.com",
+                    "password": "newpass",
+                    "modbus_tcp": True,
+                    "modbus_write": False,
+                    "modbus_scan_interval": "3",
+                }
+            )
+
+            assert result == {"type": "abort"}
+            assert (
+                mock_update_reload.call_args.kwargs["options"]["modbus_scan_interval"]
+                == 5
+            )
+
+    @pytest.mark.asyncio
     async def test_options_flow_init_success(self, hass):
         """Test options flow init step with successful update."""
         from custom_components.qvantum.config_flow import QvantumOptionsFlowHandler
@@ -615,6 +677,50 @@ class TestQvantumConfigFlow:
                     "modbus_tcp": True,
                     "modbus_write": False,
                     "modbus_scan_interval": 5,
+                }
+            )
+
+            assert result == {"type": "create_entry"}
+            mock_create_entry.assert_called_once_with(
+                title="",
+                data={
+                    "scan_interval": 120,
+                    "modbus_tcp": True,
+                    "modbus_write": False,
+                    "modbus_scan_interval": 5,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_options_flow_normalizes_invalid_modbus_scan_interval(self, hass):
+        """Test options flow coerces invalid Modbus intervals before persisting."""
+        from custom_components.qvantum.config_flow import QvantumOptionsFlowHandler
+        from homeassistant.config_entries import ConfigEntry
+
+        config_entry = ConfigEntry(
+            version=1,
+            minor_version=1,
+            domain="qvantum",
+            title="Test",
+            data={},
+            options={"scan_interval": 120, "modbus_tcp": True},
+            source="user",
+            unique_id="test_unique_id",
+            discovery_keys={},
+            subentries_data={},
+        )
+
+        flow = QvantumOptionsFlowHandler(config_entry)
+
+        with patch.object(flow, "async_create_entry") as mock_create_entry:
+            mock_create_entry.return_value = {"type": "create_entry"}
+
+            result = await flow.async_step_init(
+                {
+                    "scan_interval": 120,
+                    "modbus_tcp": True,
+                    "modbus_write": False,
+                    "modbus_scan_interval": "2",
                 }
             )
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -276,6 +276,7 @@ class TestQvantumConfigFlow:
         # Mock config entry
         config_entry = MagicMock()
         config_entry.data = {"username": "old@example.com", "password": "oldpass"}
+        config_entry.options = {}
         config_entry.unique_id = "test_unique_id"
 
         hass.config_entries = MagicMock()
@@ -312,7 +313,11 @@ class TestQvantumConfigFlow:
                     "modbus_tcp": False,
                     "modbus_write": False,
                 },
-                options={"modbus_tcp": False, "modbus_write": False},
+                options={
+                    "modbus_tcp": False,
+                    "modbus_write": False,
+                    "modbus_scan_interval": 15,
+                },
                 reason="reconfigure_successful",
             )
 
@@ -436,6 +441,48 @@ class TestQvantumConfigFlow:
             assert (
                 mock_update_reload.call_args.kwargs["options"]["modbus_write"] is False
             )
+
+    @pytest.mark.asyncio
+    async def test_step_reconfigure_sets_modbus_scan_interval(self, hass, config_flow):
+        """Test reconfigure stores a custom Modbus poll interval in options."""
+        config_entry = MagicMock()
+        config_entry.data = {"username": "old@example.com", "password": "oldpass"}
+        config_entry.options = {"modbus_tcp": True, "modbus_scan_interval": 15}
+        config_entry.unique_id = "test_unique_id"
+
+        hass.config_entries = MagicMock()
+        hass.config_entries.async_get_entry.return_value = config_entry
+
+        config_flow.context = {"entry_id": "test_entry_id"}
+
+        with (
+            patch(
+                "custom_components.qvantum.config_flow.validate_input"
+            ) as mock_validate,
+            patch.object(
+                config_flow, "async_update_reload_and_abort"
+            ) as mock_update_reload,
+        ):
+            mock_validate.return_value = None
+            mock_update_reload.return_value = {"type": "abort"}
+
+            result = await config_flow.async_step_reconfigure(
+                {
+                    "username": "new@example.com",
+                    "password": "newpass",
+                    "modbus_tcp": True,
+                    "modbus_write": False,
+                    "modbus_scan_interval": 5,
+                }
+            )
+
+            assert result == {"type": "abort"}
+            mock_update_reload.assert_called_once()
+            assert (
+                mock_update_reload.call_args.kwargs["options"]["modbus_scan_interval"]
+                == 5
+            )
+            assert mock_update_reload.call_args.kwargs["options"]["modbus_tcp"] is True
 
     @pytest.mark.asyncio
     async def test_options_flow_init_success(self, hass):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -584,3 +584,47 @@ class TestQvantumConfigFlow:
                     "modbus_write": False,
                 },
             )
+
+    @pytest.mark.asyncio
+    async def test_options_flow_sets_modbus_scan_interval(self, hass):
+        """Test options flow stores a custom Modbus poll interval."""
+        from custom_components.qvantum.config_flow import QvantumOptionsFlowHandler
+        from homeassistant.config_entries import ConfigEntry
+
+        config_entry = ConfigEntry(
+            version=1,
+            minor_version=1,
+            domain="qvantum",
+            title="Test",
+            data={},
+            options={"scan_interval": 120, "modbus_tcp": True},
+            source="user",
+            unique_id="test_unique_id",
+            discovery_keys={},
+            subentries_data={},
+        )
+
+        flow = QvantumOptionsFlowHandler(config_entry)
+
+        with patch.object(flow, "async_create_entry") as mock_create_entry:
+            mock_create_entry.return_value = {"type": "create_entry"}
+
+            result = await flow.async_step_init(
+                {
+                    "scan_interval": 120,
+                    "modbus_tcp": True,
+                    "modbus_write": False,
+                    "modbus_scan_interval": 5,
+                }
+            )
+
+            assert result == {"type": "create_entry"}
+            mock_create_entry.assert_called_once_with(
+                title="",
+                data={
+                    "scan_interval": 120,
+                    "modbus_tcp": True,
+                    "modbus_write": False,
+                    "modbus_scan_interval": 5,
+                },
+            )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -11,6 +11,10 @@ from custom_components.qvantum.config_flow import (
     InvalidAuth,
     validate_input,
 )
+from custom_components.qvantum.const import (
+    DEFAULT_MODBUS_SCAN_INTERVAL,
+    MIN_MODBUS_SCAN_INTERVAL,
+)
 
 
 class TestValidateInput:
@@ -316,7 +320,7 @@ class TestQvantumConfigFlow:
                 options={
                     "modbus_tcp": False,
                     "modbus_write": False,
-                    "modbus_scan_interval": 15,
+                    "modbus_scan_interval": DEFAULT_MODBUS_SCAN_INTERVAL,
                 },
                 reason="reconfigure_successful",
             )
@@ -472,7 +476,7 @@ class TestQvantumConfigFlow:
                     "password": "newpass",
                     "modbus_tcp": True,
                     "modbus_write": False,
-                    "modbus_scan_interval": 5,
+                    "modbus_scan_interval": MIN_MODBUS_SCAN_INTERVAL,
                 }
             )
 
@@ -480,7 +484,7 @@ class TestQvantumConfigFlow:
             mock_update_reload.assert_called_once()
             assert (
                 mock_update_reload.call_args.kwargs["options"]["modbus_scan_interval"]
-                == 5
+                == MIN_MODBUS_SCAN_INTERVAL
             )
             assert mock_update_reload.call_args.kwargs["options"]["modbus_tcp"] is True
 
@@ -526,7 +530,7 @@ class TestQvantumConfigFlow:
             assert result == {"type": "abort"}
             assert (
                 mock_update_reload.call_args.kwargs["options"]["modbus_scan_interval"]
-                == 15
+                == DEFAULT_MODBUS_SCAN_INTERVAL
             )
 
             mock_update_reload.reset_mock()
@@ -543,7 +547,7 @@ class TestQvantumConfigFlow:
             assert result == {"type": "abort"}
             assert (
                 mock_update_reload.call_args.kwargs["options"]["modbus_scan_interval"]
-                == 5
+                == MIN_MODBUS_SCAN_INTERVAL
             )
 
     @pytest.mark.asyncio
@@ -676,7 +680,7 @@ class TestQvantumConfigFlow:
                     "scan_interval": 120,
                     "modbus_tcp": True,
                     "modbus_write": False,
-                    "modbus_scan_interval": 5,
+                    "modbus_scan_interval": MIN_MODBUS_SCAN_INTERVAL,
                 }
             )
 
@@ -687,7 +691,7 @@ class TestQvantumConfigFlow:
                     "scan_interval": 120,
                     "modbus_tcp": True,
                     "modbus_write": False,
-                    "modbus_scan_interval": 5,
+                    "modbus_scan_interval": MIN_MODBUS_SCAN_INTERVAL,
                 },
             )
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -9,8 +9,10 @@ from custom_components.qvantum.coordinator import (
     QvantumDataUpdateCoordinator,
 )
 from custom_components.qvantum.const import (
+    CONF_MODBUS_SCAN_INTERVAL,
     CONF_MODBUS_TCP,
     DEFAULT_ENABLED_HTTP_METRICS,
+    DEFAULT_MODBUS_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     DHW_CAP_HYSTERESIS_C,
@@ -19,6 +21,7 @@ from custom_components.qvantum.const import (
     DHW_OUTLET_TEMP_THRESHOLD_DELTA_C,
     DHW_SESSION_GAP_SEC,
     DHW_SHOWER_DURATION_MIN,
+    MIN_MODBUS_SCAN_INTERVAL,
     REQUIRED_METRICS,
 )
 from homeassistant.const import CONF_SCAN_INTERVAL
@@ -389,13 +392,11 @@ class TestQvantumDataUpdateCoordinator:
         coordinator = QvantumDataUpdateCoordinator(mock_hass, config_entry)
 
         assert coordinator.modbus_enabled is True
-        assert coordinator.poll_interval == 15
+        assert coordinator.poll_interval == DEFAULT_MODBUS_SCAN_INTERVAL
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     def test_poll_interval_modbus_uses_configured_interval(self, mock_super_init):
         """Test that a configured Modbus scan interval is used when Modbus is enabled."""
-        from custom_components.qvantum.const import CONF_MODBUS_SCAN_INTERVAL
-
         mock_super_init.return_value = None
 
         mock_hass = MagicMock()
@@ -405,7 +406,7 @@ class TestQvantumDataUpdateCoordinator:
             if key == CONF_MODBUS_TCP:
                 return True
             if key == CONF_MODBUS_SCAN_INTERVAL:
-                return 5
+                return MIN_MODBUS_SCAN_INTERVAL
             return default
 
         config_entry.options.get.side_effect = options_get
@@ -413,16 +414,11 @@ class TestQvantumDataUpdateCoordinator:
 
         coordinator = QvantumDataUpdateCoordinator(mock_hass, config_entry)
 
-        assert coordinator.poll_interval == 5
+        assert coordinator.poll_interval == MIN_MODBUS_SCAN_INTERVAL
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     def test_poll_interval_modbus_enforces_minimum(self, mock_super_init):
         """Test that Modbus poll interval is clamped to the configured minimum."""
-        from custom_components.qvantum.const import (
-            CONF_MODBUS_SCAN_INTERVAL,
-            MIN_MODBUS_SCAN_INTERVAL,
-        )
-
         mock_super_init.return_value = None
 
         mock_hass = MagicMock()
@@ -432,7 +428,7 @@ class TestQvantumDataUpdateCoordinator:
             if key == CONF_MODBUS_TCP:
                 return True
             if key == CONF_MODBUS_SCAN_INTERVAL:
-                return 1
+                return MIN_MODBUS_SCAN_INTERVAL - 1
             return default
 
         config_entry.options.get.side_effect = options_get

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -377,17 +377,70 @@ class TestQvantumDataUpdateCoordinator:
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     def test_poll_interval_modbus_enabled_in_data(self, mock_super_init):
-        """Test that modbus in config_entry.data sets fast poll interval."""
+        """Test that modbus in config_entry.data sets default Modbus poll interval."""
         mock_super_init.return_value = None
 
         mock_hass = MagicMock()
         config_entry = MagicMock()
-        config_entry.options.get.side_effect = lambda key, default=None: default
+        # Empty options so CONF_MODBUS_TCP falls back to config_entry.data.
+        config_entry.options = {}
         config_entry.data = {CONF_MODBUS_TCP: True}
 
         coordinator = QvantumDataUpdateCoordinator(mock_hass, config_entry)
 
+        assert coordinator.modbus_enabled is True
         assert coordinator.poll_interval == 15
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    def test_poll_interval_modbus_uses_configured_interval(self, mock_super_init):
+        """Test that a configured Modbus scan interval is used when Modbus is enabled."""
+        from custom_components.qvantum.const import CONF_MODBUS_SCAN_INTERVAL
+
+        mock_super_init.return_value = None
+
+        mock_hass = MagicMock()
+        config_entry = MagicMock()
+
+        def options_get(key, default=None):
+            if key == CONF_MODBUS_TCP:
+                return True
+            if key == CONF_MODBUS_SCAN_INTERVAL:
+                return 5
+            return default
+
+        config_entry.options.get.side_effect = options_get
+        config_entry.data = {}
+
+        coordinator = QvantumDataUpdateCoordinator(mock_hass, config_entry)
+
+        assert coordinator.poll_interval == 5
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    def test_poll_interval_modbus_enforces_minimum(self, mock_super_init):
+        """Test that Modbus poll interval is clamped to the configured minimum."""
+        from custom_components.qvantum.const import (
+            CONF_MODBUS_SCAN_INTERVAL,
+            MIN_MODBUS_SCAN_INTERVAL,
+        )
+
+        mock_super_init.return_value = None
+
+        mock_hass = MagicMock()
+        config_entry = MagicMock()
+
+        def options_get(key, default=None):
+            if key == CONF_MODBUS_TCP:
+                return True
+            if key == CONF_MODBUS_SCAN_INTERVAL:
+                return 1
+            return default
+
+        config_entry.options.get.side_effect = options_get
+        config_entry.data = {}
+
+        coordinator = QvantumDataUpdateCoordinator(mock_hass, config_entry)
+
+        assert coordinator.poll_interval == MIN_MODBUS_SCAN_INTERVAL
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     @pytest.mark.asyncio


### PR DESCRIPTION
This pull request introduces a configurable Modbus scan interval for the Qvantum integration, allowing users to adjust how often the heat pump is polled over Modbus TCP. The default and minimum values are now defined, and the option is exposed in the reconfiguration flow and translated into multiple languages. This provides more flexibility for users who require faster or slower polling rates.

**Modbus scan interval configuration:**

* Added `CONF_MODBUS_SCAN_INTERVAL`, `DEFAULT_MODBUS_SCAN_INTERVAL`, and `MIN_MODBUS_SCAN_INTERVAL` constants to `const.py`, with a default of 15 seconds and a minimum of 5 seconds. [[1]](diffhunk://#diff-07fd7ac76e58c80e95bb6c9ca3ff34f8c124f4a881a23cd946cfefaa5719e953R6-R8) [[2]](diffhunk://#diff-07fd7ac76e58c80e95bb6c9ca3ff34f8c124f4a881a23cd946cfefaa5719e953R32)
* Updated `coordinator.py` to use the configurable Modbus scan interval, falling back to the default if unset and enforcing the minimum value. [[1]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fR23-R36) [[2]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fL95-R107)
* Modified `config_flow.py` to include the Modbus scan interval option in the reconfiguration step, using the correct default and validation. [[1]](diffhunk://#diff-c36f474429a06935f46ca95ee34bae1ae7442db3e8e8a8a57940023c87c5a29fR28-R35) [[2]](diffhunk://#diff-c36f474429a06935f46ca95ee34bae1ae7442db3e8e8a8a57940023c87c5a29fR189-R194) [[3]](diffhunk://#diff-c36f474429a06935f46ca95ee34bae1ae7442db3e8e8a8a57940023c87c5a29fR225-R232)

**Translations and UI:**

* Added the Modbus scan interval option and description to the integration's UI translations in English, German, Spanish, French, Hungarian, Dutch, and Polish. [[1]](diffhunk://#diff-acfc3b0627ed2bb0327c528addfe1335670f607c305117c84c6eaf8b8c31e780L564-R569) [[2]](diffhunk://#diff-acfc3b0627ed2bb0327c528addfe1335670f607c305117c84c6eaf8b8c31e780L205) [[3]](diffhunk://#diff-c38b12eee4843bd1f813526f2a1d519a00e26c744de32799eae5b19f0e992a4fL564-R569) [[4]](diffhunk://#diff-c38b12eee4843bd1f813526f2a1d519a00e26c744de32799eae5b19f0e992a4fL205) [[5]](diffhunk://#diff-a2a9672f511a16ec3c1617867055a659f0a84e7689dc79a1eacdb83079fbff37L565-R569) [[6]](diffhunk://#diff-a2a9672f511a16ec3c1617867055a659f0a84e7689dc79a1eacdb83079fbff37L205) [[7]](diffhunk://#diff-c5fb2d6ea185048b324440f4f45e1ba73623382c7ba888322ba0949fcabb1b9fL563-R569) [[8]](diffhunk://#diff-7a6c968b2fd371d0cc18051be96d7ed737a1d5b731a3c3d9788623a7ef61d91cL563-R569) [[9]](diffhunk://#diff-109634c5949fae269ebe22ad819b8beeaeec637b0fe83e1fcda3b18fb3ba1c0dL565-R569) [[10]](diffhunk://#diff-109634c5949fae269ebe22ad819b8beeaeec637b0fe83e1fcda3b18fb3ba1c0dL205) [[11]](diffhunk://#diff-dbadd40b4bfdf9f26a70958e8813234128be91d97acb995f648fa34b5ca7e3a3L563-R569)
* Provided user-facing help text for the new option, explaining its effect and constraints in each supported language. [[1]](diffhunk://#diff-acfc3b0627ed2bb0327c528addfe1335670f607c305117c84c6eaf8b8c31e780L564-R569) [[2]](diffhunk://#diff-c38b12eee4843bd1f813526f2a1d519a00e26c744de32799eae5b19f0e992a4fL564-R569) [[3]](diffhunk://#diff-a2a9672f511a16ec3c1617867055a659f0a84e7689dc79a1eacdb83079fbff37L565-R569) [[4]](diffhunk://#diff-c5fb2d6ea185048b324440f4f45e1ba73623382c7ba888322ba0949fcabb1b9fL563-R569) [[5]](diffhunk://#diff-7a6c968b2fd371d0cc18051be96d7ed737a1d5b731a3c3d9788623a7ef61d91cL563-R569) [[6]](diffhunk://#diff-109634c5949fae269ebe22ad819b8beeaeec637b0fe83e1fcda3b18fb3ba1c0dL565-R569) [[7]](diffhunk://#diff-dbadd40b4bfdf9f26a70958e8813234128be91d97acb995f648fa34b5ca7e3a3L563-R569)