### PR TITLE
feat: Add Czech and Danish translations

### DIFF
--- a/custom_components/qvantum/translations/cs.json
+++ b/custom_components/qvantum/translations/cs.json
@@ -165,7 +165,7 @@
         }
       },
       "smart_dhw_control_status": {
-        "name": "Smart DHW control status",
+        "name": "Stav Smart DHW",
         "state": {
           "0": "Čekání na ceny energií",
           "1": "Pohotovost",
@@ -375,10 +375,10 @@
         }
       },
       "hp_status": {
-        "name": "Heat pump status",
+        "name": "Status tepelného čerpadla",
         "state": {
           "0": "Nečinný",
-          "1": "Defrosting",
+          "1": "Odmrazování",
           "2": "Teplá voda",
           "3": "Topení",
           "4": "Chlazení"
@@ -399,7 +399,7 @@
         "name": "Zastavení extra teplé vody"
       },
       "ventilation_boost_stop": {
-        "name": "Boost ventilation stop"
+        "name": "Zastavení zvýšeného větrání"
       },
       "timestamp": {
         "name": "Poslední aktualizace"
@@ -542,7 +542,7 @@
     },
     "step": {
       "user": {
-        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. By default it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+        "description": "Modbus vám poskytne téměř okamžitá měření přímo čtením ze zařízení.\nPřed aktivací zde je třeba v nastavení instalátora v aplikaci nebo displeji čerpadla povolit Modbus. Ve výchozím nastavení čte pouze přes Modbus; zápisy a ovládání jsou stále přes HTTP API, pokud není povolen i zápis přes Modbus, kdy se některá ovládání zapisují přes Modbus.",
         "data": {
           "password": "Heslo",
           "username": "Uživatelské jméno",
@@ -550,12 +550,12 @@
           "modbus_write": "Povolit zápis přes Modbus"
         },
         "data_description": {
-          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
-          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
+          "modbus_tcp": "Modbus vám poskytne téměř okamžitá měření přímo čtením ze zařízení.\nPřed aktivací zde je třeba v nastavení instalátora v aplikaci nebo displeji čerpadla povolit Modbus. Všimněte si, že čte pouze přes Modbus; zápisy a ovládání jsou stále přes HTTP API, pokud není povolen i zápis přes Modbus, kdy se některá ovládání zapisují přes Modbus.",
+          "modbus_write": "Povolením zápisu přes Modbus přebíráte plnou odpovědnost za všechny hodnoty zapsané přes rozhraní. Výrobce nenese odpovědnost za problémy způsobené nesprávnými nebo mimo rozsah hodnotami a takové akce mohou zrušit záruku a/nebo ovlivnit životnost a výkon výrobku."
         }
       },
       "reconfigure": {
-        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. By default it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+        "description": "Modbus vám poskytne téměř okamžitá měření přímo čtením ze zařízení.\nPřed aktivací zde je třeba v nastavení instalátora v aplikaci nebo displeji čerpadla povolit Modbus. Ve výchozím nastavení čte pouze přes Modbus; zápisy a ovládání jsou stále přes HTTP API, pokud není povolen i zápis přes Modbus, kdy se některá ovládání zapisují přes Modbus.",
         "data": {
           "password": "Heslo",
           "username": "Uživatelské jméno",
@@ -564,8 +564,8 @@
           "modbus_scan_interval": "Interval skenování Modbus (sekundy)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
-          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product.",
+          "modbus_tcp": "Modbus vám poskytne téměř okamžitá měření přímo čtením ze zařízení.\nPřed aktivací zde je třeba v nastavení instalátora v aplikaci nebo displeji čerpadla povolit Modbus. Všimněte si, že čte pouze přes Modbus; zápisy a ovládání jsou stále přes HTTP API, pokud není povolen i zápis přes Modbus, kdy se některá ovládání zapisují přes Modbus.",
+          "modbus_write": "Povolením zápisu přes Modbus přebíráte plnou odpovědnost za všechny hodnoty zapsané přes rozhraní. Výrobce nenese odpovědnost za problémy způsobené nesprávnými nebo mimo rozsah hodnotami a takové akce mohou zrušit záruku a/nebo ovlivnit životnost a výkon výrobku.",
           "modbus_scan_interval": "Jak často dotazovat tepelné čerpadlo přes Modbus TCP. Nižší hodnoty poskytují téměř okamžitou přesnost průtoku a objemu. Minimum je 5 sekund. Výchozí je 15 sekund."
         }
       }
@@ -582,8 +582,8 @@
           "modbus_scan_interval": "Interval skenování Modbus (sekundy)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
-          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product.",
+          "modbus_tcp": "Modbus vám poskytne téměř okamžitá měření přímo čtením ze zařízení.\nPřed aktivací zde je třeba v nastavení instalátora v aplikaci nebo displeji čerpadla povolit Modbus. Všimněte si, že čte pouze přes Modbus; zápisy a ovládání jsou stále přes HTTP API, pokud není povolen i zápis přes Modbus, kdy se některá ovládání zapisují přes Modbus.",
+          "modbus_write": "Povolením zápisu přes Modbus přebíráte plnou odpovědnost za všechny hodnoty zapsané přes rozhraní. Výrobce nenese odpovědnost za problémy způsobené nesprávnými nebo mimo rozsah hodnotami a takové akce mohou zrušit záruku a/nebo ovlivnit životnost a výkon výrobku.",
           "modbus_scan_interval": "Jak často dotazovat tepelné čerpadlo přes Modbus TCP. Nižší hodnoty poskytují téměř okamžitou přesnost průtoku a objemu. Minimum je 5 sekund. Výchozí je 15 sekund."
         },
         "description": "Upravte své možnosti.",

--- a/custom_components/qvantum/translations/cs.json
+++ b/custom_components/qvantum/translations/cs.json
@@ -1,0 +1,610 @@
+{
+  "device": {
+    "qvantum_flvp": {
+      "name": "Qvantum"
+    }
+  },
+  "entity": {
+    "switch": {
+      "extra_tap_water": {
+        "name": "Extra teplá voda"
+      },
+      "op_man_addition": {
+        "name": "Ruční provozní režim: Příplatek"
+      },
+      "op_man_dhw": {
+        "name": "Ruční provozní režim: Teplá voda"
+      },
+      "op_mode": {
+        "name": "Ruční provozní režim"
+      },
+      "man_mode": {
+        "name": "Ruční provozní režim: Topení"
+      },
+      "enable_sc_dhw": {
+        "name": "SmartControl: TUV"
+      },
+      "enable_sc_sh": {
+        "name": "SmartControl: Topení"
+      }
+    },
+    "select": {
+      "use_adaptive": {
+        "name": "SmartControl",
+        "state": {
+          "off": "Vypnuto",
+          "0": "Eco",
+          "1": "Vyrovnané",
+          "2": "Komfort"
+        }
+      },
+      "smart_sh_mode": {
+        "name": "Režim Smart SH",
+        "state": {
+          "0": "Eco",
+          "1": "Vyrovnané",
+          "2": "Komfort"
+        }
+      },
+      "smart_dhw_mode": {
+        "name": "Režim Smart DHW",
+        "state": {
+          "0": "Eco",
+          "1": "Vyrovnané",
+          "2": "Komfort"
+        }
+      },
+      "use_operation_sensor": {
+        "name": "Zdroj vnitřního senzoru",
+        "state": {
+          "0": "Zakázáno",
+          "1": "BT2",
+          "2": "BT3",
+          "3": "AUX",
+          "4": "Externí"
+        }
+      }
+    },
+    "button": {
+      "extra_tap_water_60min": {
+        "name": "Extra teplá voda 60 min"
+      },
+      "elevate_access": {
+        "name": "Zvýšit přístup"
+      }
+    },
+    "binary_sensor": {
+      "op_man_addition": {
+        "name": "Ruční provozní režim: Příplatek"
+      },
+      "op_man_cooling": {
+        "name": "Ruční provozní režim: Chlazení"
+      },
+      "op_man_dhw": {
+        "name": "Ruční provozní režim: Teplá voda"
+      },
+      "cooling_enabled": {
+        "name": "Chlazení povoleno"
+      },
+      "use_adaptive": {
+        "name": "SmartControl"
+      },
+      "enable_sc_dhw": {
+        "name": "SmartControl: TUV"
+      },
+      "enable_sc_sh": {
+        "name": "SmartControl: Topení"
+      },
+      "picpin_relay_heat_l1": {
+        "name": "Dodatečný výkon L1"
+      },
+      "picpin_relay_heat_l2": {
+        "name": "Dodatečný výkon L2"
+      },
+      "picpin_relay_heat_l3": {
+        "name": "Dodatečný výkon L3"
+      },
+      "picpin_relay_gp10": {
+        "name": "Oběhové čerpadlo (GP10)"
+      },
+      "picpin_relay_qm10": {
+        "name": "Přepínací ventil, TUV/topení (QM10)"
+      },
+      "picpin_relay_qn8_1": {
+        "name": "Přídavný šuntový ventil (QN8_1)"
+      },
+      "picpin_relay_qn8_2": {
+        "name": "Přídavný šuntový ventil (QN8_2)"
+      },
+      "picpin_relay_gp3": {
+        "name": "Oběhové čerpadlo (GP3)"
+      },
+      "picpin_relay_pump": {
+        "name": "Oběhové čerpadlo"
+      },
+      "picpin_relay_ha12": {
+        "name": "Čerpadlo vytápěcí smyčky (HA12)"
+      },
+      "dhwdemand": {
+        "name": "Poptávka po teplé vodě"
+      },
+      "heatingdemand": {
+        "name": "Poptávka po topení"
+      },
+      "coolingdemand": {
+        "name": "Poptávka po chlazení"
+      },
+      "additiondemand": {
+        "name": "Poptávka po příplatku"
+      },
+      "additiondhwdemand": {
+        "name": "Poptávka po teplé vodě ve formě příplatku"
+      },
+      "time_to_defrost": {
+        "name": "Doba odmrazování"
+      }
+    },
+    "sensor": {
+      "compressor_state": {
+        "name": "Stav kompresoru",
+        "state": {
+          "0": "Vypnuto",
+          "1": "Nečinný",
+          "2": "Příprava na topení",
+          "3": "Příprava na chlazení",
+          "4": "Příprava 1 pro teplou vodu",
+          "5": "Příprava 2 pro teplou vodu",
+          "6": "Topení",
+          "7": "Chlazení",
+          "8": "Teplá voda",
+          "9": "Pasivní odmrazování teplé vody",
+          "10": "Pasivní odmrazování topení",
+          "11": "Příprava na bazén",
+          "12": "Bazén",
+          "13": "Pasivní odmrazování bazénu"
+        }
+      },
+      "smart_dhw_control_status": {
+        "name": "Smart DHW control status",
+        "state": {
+          "0": "Čekání na ceny energií",
+          "1": "Pohotovost",
+          "2": "Zvyšování",
+          "3": "Snižování",
+          "4": "Dlouhodobé snižování",
+          "5": "Pozastaveno"
+        }
+      },
+      "powertotal": {
+        "name": "Celkový výkon"
+      },
+      "heatingpower": {
+        "name": "Výkon topení"
+      },
+      "dhwpower": {
+        "name": "Výkon teplé vody"
+      },
+      "compressor_power": {
+        "name": "Výkon kompresoru"
+      },
+      "heatingenergy": {
+        "name": "Energie topení"
+      },
+      "dhwenergy": {
+        "name": "Energie teplé vody"
+      },
+      "inputcurrent1": {
+        "name": "Příkon L1"
+      },
+      "inputcurrent2": {
+        "name": "Příkon L2"
+      },
+      "inputcurrent3": {
+        "name": "Příkon L3"
+      },
+      "degree_minute": {
+        "name": "Stupně/minuta"
+      },
+      "bf1_l_min": {
+        "name": "Čidlo průtoku TUV (BF1)"
+      },
+      "bf1_rpm": {
+        "name": "Rychlost čerpadla čidla průtoku TUV (BF1)"
+      },
+      "bp1_pressure": {
+        "name": "Nízký tlak bar (BP1)"
+      },
+      "bp1_temp": {
+        "name": "Nízká teplota tlaku (BP1)"
+      },
+      "bp2_pressure": {
+        "name": "Vysoký tlak bar (BP2)"
+      },
+      "bp2_temp": {
+        "name": "Vysoká teplota tlaku (BP2)"
+      },
+      "bt10": {
+        "name": "Teplota kondenzátoru ven (BT10)"
+      },
+      "bt12": {
+        "name": "Tepelný nosič, vnější přívod (BT12)"
+      },
+      "bt13": {
+        "name": "Teplota kondenzátoru dovnitř (BT13)"
+      },
+      "bt14": {
+        "name": "Teplota odpadního vzduchu (BT14)"
+      },
+      "bt15": {
+        "name": "Teplota nasávaného vzduchu (BT15)"
+      },
+      "bt20": {
+        "name": "Výstupní trubka (BT20)"
+      },
+      "bt21": {
+        "name": "Kapalinová trubka (BT21)"
+      },
+      "bt22": {
+        "name": "Vstupní teplota výparníku (BT22)"
+      },
+      "bt23": {
+        "name": "Sací trubka (BT23)"
+      },
+      "bt31": {
+        "name": "Primární TUV, teplota nabíjení vstup (BT31)"
+      },
+      "bt33": {
+        "name": "Sekundární TUV, studená voda vstup (BT33)"
+      },
+      "bt34": {
+        "name": "Sekundární TUV, teplá voda výstup (BT34)"
+      },
+      "compressormeasuredspeed": {
+        "name": "Rychlost kompresoru"
+      },
+      "dhw_outl_temp_15": {
+        "name": "Výstupní teplota TUV 15"
+      },
+      "dhw_outl_temp_5": {
+        "name": "Výstupní teplota TUV 5"
+      },
+      "dhw_outl_temp_max": {
+        "name": "Maximální výstupní teplota TUV"
+      },
+      "dhw_prioritytime": {
+        "name": "Prioritní doba TUV"
+      },
+      "fan0_10v": {
+        "name": "Rychlost ventilátoru"
+      },
+      "fanrpm": {
+        "name": "Rychlost ventilátoru"
+      },
+      "qn8position": {
+        "name": "Šuntový ventil, příplatek (QN8)"
+      },
+      "gp1_speed": {
+        "name": "Oběhové čerpadlo (GP1)"
+      },
+      "gp2_speed": {
+        "name": "Čerpadlo nabíjení TUV (GP2)"
+      },
+      "guide_des_temp": {
+        "name": "Cílová teplota"
+      },
+      "guide_he": {
+        "name": "Návod k topení"
+      },
+      "man_mode": {
+        "name": "Ruční režim"
+      },
+      "op_mode": {
+        "name": "Provozní režim",
+        "state": {
+          "0": "Auto",
+          "1": "Ruční",
+          "2": "Příplatek"
+        }
+      },
+      "op_mode_sensor": {
+        "name": "Snímač provozního režimu"
+      },
+      "price_region": {
+        "name": "Cenová oblast"
+      },
+      "room_temp_ext": {
+        "name": "Venkovní teplota místnosti"
+      },
+      "compressorenergy": {
+        "name": "Energie kompresoru"
+      },
+      "totalenergy": {
+        "name": "Celková energie"
+      },
+      "bt1": {
+        "name": "Outdoor (BT1)"
+      },
+      "bt2": {
+        "name": "Indoor (BT2)"
+      },
+      "bt4": {
+        "name": "BT4"
+      },
+      "btx": {
+        "name": "BTX"
+      },
+      "smart_sh_status": {
+        "name": "Stav Smart pro topení"
+      },
+      "bt11": {
+        "name": "Tepelný medián, přívodní potrubí (BT11)"
+      },
+      "cal_heat_temp": {
+        "name": "Tepelný medián, přívodní potrubí, cíl."
+      },
+      "start_cooling_temp": {
+        "name": "Teplota spuštění chlazení"
+      },
+      "bt30": {
+        "name": "Nádrž teplé vody (BT30)"
+      },
+      "tap_water_start": {
+        "name": "Dolní hranice nádrže teplé vody"
+      },
+      "tap_water_stop": {
+        "name": "Horní hranice nádrže teplé vody"
+      },
+      "tap_water_cap": {
+        "name": "Kapacita teplé vody"
+      },
+      "tap_water_minutes": {
+        "name": "Zbývající teplá voda"
+      },
+      "additionalenergy": {
+        "name": "Dodatečná energie"
+      },
+      "hpid": {
+        "name": "ID"
+      },
+      "smart_sh_mode": {
+        "name": "Režim Smart SH",
+        "state": {
+          "0": "Eco",
+          "1": "Vyrovnané",
+          "2": "Komfort"
+        }
+      },
+      "hp_status": {
+        "name": "Heat pump status",
+        "state": {
+          "0": "Nečinný",
+          "1": "Defrosting",
+          "2": "Teplá voda",
+          "3": "Topení",
+          "4": "Chlazení"
+        }
+      },
+      "smart_dhw_status": {
+        "name": "Stav Smart pro teplou vodu"
+      },
+      "smart_dhw_mode": {
+        "name": "Režim Smart DHW",
+        "state": {
+          "0": "Eco",
+          "1": "Vyrovnané",
+          "2": "Komfort"
+        }
+      },
+      "tap_stop": {
+        "name": "Zastavení extra teplé vody"
+      },
+      "ventilation_boost_stop": {
+        "name": "Boost ventilation stop"
+      },
+      "timestamp": {
+        "name": "Poslední aktualizace"
+      },
+      "latency": {
+        "name": "Latence"
+      },
+      "disconnect_reason": {
+        "name": "Důvod odpojení",
+        "state": {
+          "client-disconnect": "Klient odpojen"
+        }
+      },
+      "heatingreleased": {
+        "name": "Vypuštěno topení"
+      },
+      "coolingreleased": {
+        "name": "Vypuštěno chlazení"
+      },
+      "compressorreleased": {
+        "name": "Vypuštěn kompresor"
+      },
+      "additionreleased": {
+        "name": "Vypuštěno navíc"
+      },
+      "dhw_prioritytimeleft": {
+        "name": "Zbývající doba priority TUV"
+      },
+      "heating_prioritytimeleft": {
+        "name": "Zbývající doba priority topení"
+      },
+      "cooling_prioritytimeleft": {
+        "name": "Zbývající doba priority chlazení"
+      },
+      "switch_state": {
+        "name": "Stav spínače"
+      },
+      "dhwstop_temp": {
+        "name": "Teplota zastavení TUV"
+      },
+      "dhwstart_temp": {
+        "name": "Teplota spuštění TUV"
+      },
+      "filtered60sec_outdoortemp": {
+        "name": "Filtrovaná venkovní teplota (60 s)"
+      },
+      "max_freq_env": {
+        "name": "Maximální frekvence prostředí"
+      },
+      "calc_suppy_cpr": {
+        "name": "Vypočítaný přísun CPR"
+      },
+      "dhw_set": {
+        "name": "Nastavení TUV"
+      },
+      "bp1_temp_20min_filter": {
+        "name": "Filtr teploty BP1 20 min"
+      },
+      "max_bp2_env": {
+        "name": "Maximální prostředí BP2"
+      },
+      "picpin_mask": {
+        "name": "Maska pinů PIC"
+      },
+      "firmware_display_fw_version": {
+        "name": "Verze firmwaru displeje"
+      },
+      "firmware_cc_fw_version": {
+        "name": "Verze firmwaru CC"
+      },
+      "firmware_inv_fw_version": {
+        "name": "Verze firmwaru měniče"
+      },
+      "firmware_last_check": {
+        "name": "Naposledy zkontrolovaný firmware"
+      },
+      "expires_at": {
+        "name": "Vypršení zvýšeného přístupu"
+      }
+    },
+    "number": {
+      "indoor_temperature_offset": {
+        "name": "Posun paralelní křivky"
+      },
+      "tap_water_capacity_target": {
+        "name": "Cílová kapacita teplé vody"
+      },
+      "room_comp_factor": {
+        "name": "Faktor kompenzace místnosti"
+      },
+      "tap_water_stop": {
+        "name": "Horní teplotní limit nádrže teplé vody"
+      },
+      "tap_water_start": {
+        "name": "Dolní teplotní limit nádrže teplé vody"
+      },
+      "fan_normal": {
+        "name": "Normální rychlost ventilátoru"
+      },
+      "fan_speed_2": {
+        "name": "Minimální rychlost ventilátoru pro kompresor"
+      },
+      "dhw_stop_extra": {
+        "name": "Teplota zastavení extra teplé vody"
+      },
+      "room_temp_external": {
+        "name": "Venkovní teplota v místnosti"
+      }
+    },
+    "climate": {
+      "indoor_climate": {
+        "name": "Vnitřní klima"
+      }
+    },
+    "fan": {
+      "fanspeedselector": {
+        "name": "Rychlost ventilátoru",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off": "Vypnuto",
+              "normal": "Normální",
+              "extra": "Extra"
+            }
+          }
+        }
+      }
+    }
+  },
+  "config": {
+    "title": "Qvantum tepelné čerpadlo",
+    "abort": {
+      "already_configured": "Zařízení je již nakonfigurováno",
+      "reconfigure_successful": "Znovu nastavení proběhlo úspěšně"
+    },
+    "error": {
+      "cannot_connect": "Nepodařilo se připojit",
+      "invalid_auth": "Neplatná autentizace",
+      "unknown": "Neočekávaná chyba"
+    },
+    "step": {
+      "user": {
+        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. By default it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+        "data": {
+          "password": "Heslo",
+          "username": "Uživatelské jméno",
+          "modbus_tcp": "Použít čtení přes Modbus místo HTTP dotazování",
+          "modbus_write": "Povolit zápis přes Modbus"
+        },
+        "data_description": {
+          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
+        }
+      },
+      "reconfigure": {
+        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. By default it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+        "data": {
+          "password": "Heslo",
+          "username": "Uživatelské jméno",
+          "modbus_tcp": "Použít čtení přes Modbus místo HTTP dotazování",
+          "modbus_write": "Povolit zápis přes Modbus",
+          "modbus_scan_interval": "Interval skenování Modbus (sekundy)"
+        },
+        "data_description": {
+          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product.",
+          "modbus_scan_interval": "Jak často dotazovat tepelné čerpadlo přes Modbus TCP. Nižší hodnoty poskytují téměř okamžitou přesnost průtoku a objemu. Minimum je 5 sekund. Výchozí je 15 sekund."
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "Interval skenování HTTP (sekundy)",
+          "modbus_tcp": "Použít čtení přes Modbus místo HTTP dotazování",
+          "modbus_host": "Host/IP Qvantum",
+          "modbus_write": "Povolit zápis přes Modbus",
+          "modbus_scan_interval": "Interval skenování Modbus (sekundy)"
+        },
+        "data_description": {
+          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product.",
+          "modbus_scan_interval": "Jak často dotazovat tepelné čerpadlo přes Modbus TCP. Nižší hodnoty poskytují téměř okamžitou přesnost průtoku a objemu. Minimum je 5 sekund. Výchozí je 15 sekund."
+        },
+        "description": "Upravte své možnosti.",
+        "title": "Možnosti"
+      }
+    }
+  },
+  "services": {
+    "extra_hot_water": {
+      "name": "Extra teplá voda",
+      "description": "Aktivovat extra teplou vodu po určitou dobu",
+      "fields": {
+        "device_id": {
+          "name": "ID zařízení",
+          "description": "ID zařízení Qvantum"
+        },
+        "minutes": {
+          "name": "Minuty",
+          "description": "Minuty pro výrobu extra teplé vody (0 minut vypne)"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/qvantum/translations/da.json
+++ b/custom_components/qvantum/translations/da.json
@@ -165,7 +165,7 @@
         }
       },
       "smart_dhw_control_status": {
-        "name": "Smart DHW control status",
+        "name": "Smart DHW-kontrolstatus",
         "state": {
           "0": "Venter på energipriser",
           "1": "Standby",
@@ -375,10 +375,10 @@
         }
       },
       "hp_status": {
-        "name": "Heat pump status",
+        "name": "Varmepumpestatus",
         "state": {
           "0": "Ledig",
-          "1": "Defrosting",
+          "1": "Afrimning",
           "2": "Varmt vand",
           "3": "Opvarmning",
           "4": "Køling"
@@ -399,7 +399,7 @@
         "name": "Ekstra varmtvandstop"
       },
       "ventilation_boost_stop": {
-        "name": "Boost ventilation stop"
+        "name": "Stop for boost-ventilation"
       },
       "timestamp": {
         "name": "Sidste opdatering"
@@ -542,7 +542,7 @@
     },
     "step": {
       "user": {
-        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. By default it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+        "description": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.\nModbus skal aktiveres i installerindstillingerne i pumpeappen/skærmen, før du aktiverer det her. Som standard læser den kun via Modbus; skrivninger/kontroller sker stadig via HTTP API, medmindre skrivning via Modbus også er aktiveret, hvor visse kontroller skrives via Modbus.",
         "data": {
           "password": "Adgangskode",
           "username": "Brugernavn",
@@ -550,12 +550,12 @@
           "modbus_write": "Aktivér skrivning via Modbus"
         },
         "data_description": {
-          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
-          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
+          "modbus_tcp": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.\nModbus skal aktiveres i installerindstillingerne i pumpeappen/skærmen, før du aktiverer det her. Bemærk, at den kun læser via Modbus; skrivninger/kontroller sker stadig via HTTP API, medmindre skrivning via Modbus også er aktiveret, hvor visse kontroller skrives via Modbus.",
+          "modbus_write": "Ved at aktivere skrivning via Modbus accepterer du fuldt ansvar for eventuelle værdier, der skrives gennem grænsefladen. Producenten er ikke ansvarlig for problemer forårsaget af forkerte eller uden for intervallet værdiers, og sådanne handlinger kan ugyldiggøre garantien og/eller påvirke produktets levetid og ydeevne."
         }
       },
       "reconfigure": {
-        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. By default it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+        "description": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.\nModbus skal aktiveres i installerindstillingerne i pumpeappen/skærmen, før du aktiverer det her. Som standard læser den kun via Modbus; skrivninger/kontroller sker stadig via HTTP API, medmindre skrivning via Modbus også er aktiveret, hvor visse kontroller skrives via Modbus.",
         "data": {
           "password": "Adgangskode",
           "username": "Brugernavn",
@@ -564,8 +564,8 @@
           "modbus_scan_interval": "Modbus-scanningsinterval (sekunder)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
-          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product.",
+          "modbus_tcp": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.\nModbus skal aktiveres i installerindstillingerne i pumpeappen/skærmen, før du aktiverer det her. Bemærk, at den kun læser via Modbus; skrivninger/kontroller sker stadig via HTTP API, medmindre skrivning via Modbus også er aktiveret, hvor visse kontroller skrives via Modbus.",
+          "modbus_write": "Ved at aktivere skrivning via Modbus accepterer du fuldt ansvar for eventuelle værdier, der skrives gennem grænsefladen. Producenten er ikke ansvarlig for problemer forårsaget af forkerte eller uden for intervallet værdiers, og sådanne handlinger kan ugyldiggøre garantien og/eller påvirke produktets levetid og ydeevne.",
           "modbus_scan_interval": "Hvor ofte der skal polles til varmepumpen over Modbus TCP. Lavere værdier giver næsten realtidsnøjagtighed for flow og volumen. Minimum er 5 sekunder. Standard er 15 sekunder."
         }
       }
@@ -582,8 +582,8 @@
           "modbus_scan_interval": "Modbus-scanningsinterval (sekunder)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
-          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product.",
+          "modbus_tcp": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.\nModbus skal aktiveres i installerindstillingerne i pumpeappen/skærmen, før du aktiverer det her. Bemærk, at den kun læser via Modbus; skrivninger/kontroller sker stadig via HTTP API, medmindre skrivning via Modbus også er aktiveret, hvor visse kontroller skrives via Modbus.",
+          "modbus_write": "Ved at aktivere skrivning via Modbus accepterer du fuldt ansvar for eventuelle værdier, der skrives gennem grænsefladen. Producenten er ikke ansvarlig for problemer forårsaget af forkerte eller uden for intervallet værdiers, og sådanne handlinger kan ugyldiggøre garantien og/eller påvirke produktets levetid og ydeevne.",
           "modbus_scan_interval": "Hvor ofte der skal polles til varmepumpen over Modbus TCP. Lavere værdier giver næsten realtidsnøjagtighed for flow og volumen. Minimum er 5 sekunder. Standard er 15 sekunder."
         },
         "description": "Ret dine indstillinger.",

--- a/custom_components/qvantum/translations/da.json
+++ b/custom_components/qvantum/translations/da.json
@@ -551,7 +551,7 @@
         },
         "data_description": {
           "modbus_tcp": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.\nModbus skal aktiveres i installerindstillingerne i pumpeappen/skærmen, før du aktiverer det her. Bemærk, at den kun læser via Modbus; skrivninger/kontroller sker stadig via HTTP API, medmindre skrivning via Modbus også er aktiveret, hvor visse kontroller skrives via Modbus.",
-          "modbus_write": "Ved at aktivere skrivning via Modbus accepterer du fuldt ansvar for eventuelle værdier, der skrives gennem grænsefladen. Producenten er ikke ansvarlig for problemer forårsaget af forkerte eller uden for intervallet værdiers, og sådanne handlinger kan ugyldiggøre garantien og/eller påvirke produktets levetid og ydeevne."
+          "modbus_write": "Ved at aktivere skrivning via Modbus accepterer du fuldt ansvar for eventuelle værdier, der skrives gennem grænsefladen. Producenten er ikke ansvarlig for problemer forårsaget af forkerte eller uden for intervallet værdier, og sådanne handlinger kan ugyldiggøre garantien og/eller påvirke produktets levetid og ydeevne."
         }
       },
       "reconfigure": {
@@ -565,7 +565,7 @@
         },
         "data_description": {
           "modbus_tcp": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.\nModbus skal aktiveres i installerindstillingerne i pumpeappen/skærmen, før du aktiverer det her. Bemærk, at den kun læser via Modbus; skrivninger/kontroller sker stadig via HTTP API, medmindre skrivning via Modbus også er aktiveret, hvor visse kontroller skrives via Modbus.",
-          "modbus_write": "Ved at aktivere skrivning via Modbus accepterer du fuldt ansvar for eventuelle værdier, der skrives gennem grænsefladen. Producenten er ikke ansvarlig for problemer forårsaget af forkerte eller uden for intervallet værdiers, og sådanne handlinger kan ugyldiggøre garantien og/eller påvirke produktets levetid og ydeevne.",
+          "modbus_write": "Ved at aktivere skrivning via Modbus accepterer du fuldt ansvar for eventuelle værdier, der skrives gennem grænsefladen. Producenten er ikke ansvarlig for problemer forårsaget af forkerte eller uden for intervallet værdier, og sådanne handlinger kan ugyldiggøre garantien og/eller påvirke produktets levetid og ydeevne.",
           "modbus_scan_interval": "Hvor ofte der skal polles til varmepumpen over Modbus TCP. Lavere værdier giver næsten realtidsnøjagtighed for flow og volumen. Minimum er 5 sekunder. Standard er 15 sekunder."
         }
       }
@@ -583,7 +583,7 @@
         },
         "data_description": {
           "modbus_tcp": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.\nModbus skal aktiveres i installerindstillingerne i pumpeappen/skærmen, før du aktiverer det her. Bemærk, at den kun læser via Modbus; skrivninger/kontroller sker stadig via HTTP API, medmindre skrivning via Modbus også er aktiveret, hvor visse kontroller skrives via Modbus.",
-          "modbus_write": "Ved at aktivere skrivning via Modbus accepterer du fuldt ansvar for eventuelle værdier, der skrives gennem grænsefladen. Producenten er ikke ansvarlig for problemer forårsaget af forkerte eller uden for intervallet værdiers, og sådanne handlinger kan ugyldiggøre garantien og/eller påvirke produktets levetid og ydeevne.",
+          "modbus_write": "Ved at aktivere skrivning via Modbus accepterer du fuldt ansvar for eventuelle værdier, der skrives gennem grænsefladen. Producenten er ikke ansvarlig for problemer forårsaget af forkerte eller uden for intervallet værdier, og sådanne handlinger kan ugyldiggøre garantien og/eller påvirke produktets levetid og ydeevne.",
           "modbus_scan_interval": "Hvor ofte der skal polles til varmepumpen over Modbus TCP. Lavere værdier giver næsten realtidsnøjagtighed for flow og volumen. Minimum er 5 sekunder. Standard er 15 sekunder."
         },
         "description": "Ret dine indstillinger.",

--- a/custom_components/qvantum/translations/da.json
+++ b/custom_components/qvantum/translations/da.json
@@ -1,0 +1,610 @@
+{
+  "device": {
+    "qvantum_flvp": {
+      "name": "Qvantum"
+    }
+  },
+  "entity": {
+    "switch": {
+      "extra_tap_water": {
+        "name": "Ekstra varmt vand"
+      },
+      "op_man_addition": {
+        "name": "Manuel driftstilstand: Tilsætning"
+      },
+      "op_man_dhw": {
+        "name": "Manuel driftstilstand: Varmt vand"
+      },
+      "op_mode": {
+        "name": "Manuel driftstilstand"
+      },
+      "man_mode": {
+        "name": "Manuel driftstilstand: Opvarmning"
+      },
+      "enable_sc_dhw": {
+        "name": "SmartControl: Varmt vand"
+      },
+      "enable_sc_sh": {
+        "name": "SmartControl: Opvarmning"
+      }
+    },
+    "select": {
+      "use_adaptive": {
+        "name": "SmartControl",
+        "state": {
+          "off": "Fra",
+          "0": "Eco",
+          "1": "Balanceret",
+          "2": "Komfort"
+        }
+      },
+      "smart_sh_mode": {
+        "name": "Smart SH-tilstand",
+        "state": {
+          "0": "Eco",
+          "1": "Balanceret",
+          "2": "Komfort"
+        }
+      },
+      "smart_dhw_mode": {
+        "name": "Smart DHW-tilstand",
+        "state": {
+          "0": "Eco",
+          "1": "Balanceret",
+          "2": "Komfort"
+        }
+      },
+      "use_operation_sensor": {
+        "name": "Kilde for indendørs sensor",
+        "state": {
+          "0": "Deaktiveret",
+          "1": "BT2",
+          "2": "BT3",
+          "3": "AUX",
+          "4": "Ekstern"
+        }
+      }
+    },
+    "button": {
+      "extra_tap_water_60min": {
+        "name": "Ekstra varmt vand i 60 min"
+      },
+      "elevate_access": {
+        "name": "Forhøj adgang"
+      }
+    },
+    "binary_sensor": {
+      "op_man_addition": {
+        "name": "Manuel driftstilstand: Tilsætning"
+      },
+      "op_man_cooling": {
+        "name": "Manuel driftstilstand: Køling"
+      },
+      "op_man_dhw": {
+        "name": "Manuel driftstilstand: Varmt vand"
+      },
+      "cooling_enabled": {
+        "name": "Køling aktiveret"
+      },
+      "use_adaptive": {
+        "name": "SmartControl"
+      },
+      "enable_sc_dhw": {
+        "name": "SmartControl: Varmt vand"
+      },
+      "enable_sc_sh": {
+        "name": "SmartControl: Opvarmning"
+      },
+      "picpin_relay_heat_l1": {
+        "name": "Ekstra effekt L1"
+      },
+      "picpin_relay_heat_l2": {
+        "name": "Ekstra effekt L2"
+      },
+      "picpin_relay_heat_l3": {
+        "name": "Ekstra effekt L3"
+      },
+      "picpin_relay_gp10": {
+        "name": "Cirkulationspumpe (GP10)"
+      },
+      "picpin_relay_qm10": {
+        "name": "Vejskifteventil, varmtvand/opvarmning (QM10)"
+      },
+      "picpin_relay_qn8_1": {
+        "name": "Shuntventil tilskud (QN8_1)"
+      },
+      "picpin_relay_qn8_2": {
+        "name": "Shuntventil tilskud (QN8_2)"
+      },
+      "picpin_relay_gp3": {
+        "name": "Cirkulationspumpe (GP3)"
+      },
+      "picpin_relay_pump": {
+        "name": "Cirkulationspumpe"
+      },
+      "picpin_relay_ha12": {
+        "name": "Varme kreds pumper (HA12)"
+      },
+      "dhwdemand": {
+        "name": "Efterspørgsel efter varmt vand"
+      },
+      "heatingdemand": {
+        "name": "Efterspørgsel efter opvarmning"
+      },
+      "coolingdemand": {
+        "name": "Efterspørgsel efter køling"
+      },
+      "additiondemand": {
+        "name": "Efterspørgsel efter tilskud"
+      },
+      "additiondhwdemand": {
+        "name": "Efterspørgsel efter varmtvandstilskud"
+      },
+      "time_to_defrost": {
+        "name": "Tid til afrimning"
+      }
+    },
+    "sensor": {
+      "compressor_state": {
+        "name": "Kompresorstatus",
+        "state": {
+          "0": "Fra",
+          "1": "Ledig",
+          "2": "Forbereder opvarmning",
+          "3": "Forbereder køling",
+          "4": "Forbereder 1 til varmt vand",
+          "5": "Forbereder 2 til varmt vand",
+          "6": "Opvarmning",
+          "7": "Køling",
+          "8": "Varmt vand",
+          "9": "Afrimning af varmt vand passiv",
+          "10": "Afrimning af opvarmning passiv",
+          "11": "Forbereder pool",
+          "12": "Pool",
+          "13": "Afrimning af pool passiv"
+        }
+      },
+      "smart_dhw_control_status": {
+        "name": "Smart DHW control status",
+        "state": {
+          "0": "Venter på energipriser",
+          "1": "Standby",
+          "2": "Øger",
+          "3": "Sænker",
+          "4": "Sænker på lang sigt",
+          "5": "Pauset"
+        }
+      },
+      "powertotal": {
+        "name": "Samlet effekt"
+      },
+      "heatingpower": {
+        "name": "Varmeeffekt"
+      },
+      "dhwpower": {
+        "name": "Varmt vand effekt"
+      },
+      "compressor_power": {
+        "name": "Kompresoreffekt"
+      },
+      "heatingenergy": {
+        "name": "Varmeenergi"
+      },
+      "dhwenergy": {
+        "name": "Varmtvandsenergi"
+      },
+      "inputcurrent1": {
+        "name": "Indgangsstrøm L1"
+      },
+      "inputcurrent2": {
+        "name": "Indgangsstrøm L2"
+      },
+      "inputcurrent3": {
+        "name": "Indgangsstrøm L3"
+      },
+      "degree_minute": {
+        "name": "Gradminut"
+      },
+      "bf1_l_min": {
+        "name": "Flowføler for varmtvand (BF1)"
+      },
+      "bf1_rpm": {
+        "name": "Flowføler for pumperpm (BF1)"
+      },
+      "bp1_pressure": {
+        "name": "Lavtryksbar (BP1)"
+      },
+      "bp1_temp": {
+        "name": "Lavtrykstemp (BP1)"
+      },
+      "bp2_pressure": {
+        "name": "Højtryksbar (BP2)"
+      },
+      "bp2_temp": {
+        "name": "Højtrykstemp (BP2)"
+      },
+      "bt10": {
+        "name": "Kondensator temperatur ud (BT10)"
+      },
+      "bt12": {
+        "name": "Varmebærer, ekstern fremløbsledning (BT12)"
+      },
+      "bt13": {
+        "name": "Kondensator temperatur ind (BT13)"
+      },
+      "bt14": {
+        "name": "Udblæst lufttemperatur (BT14)"
+      },
+      "bt15": {
+        "name": "Indtag lufttemperatur (BT15)"
+      },
+      "bt20": {
+        "name": "Afkastledning (BT20)"
+      },
+      "bt21": {
+        "name": "Væskeledning (BT21)"
+      },
+      "bt22": {
+        "name": "Fordamper indløbstemp (BT22)"
+      },
+      "bt23": {
+        "name": "Sugledning (BT23)"
+      },
+      "bt31": {
+        "name": "Varmtvands primær, ladetemp ind (BT31)"
+      },
+      "bt33": {
+        "name": "Varmtvands sekundær, koldt vand ind (BT33)"
+      },
+      "bt34": {
+        "name": "Varmtvands sekundær, varmt vand ud (BT34)"
+      },
+      "compressormeasuredspeed": {
+        "name": "Kompresorhastighed"
+      },
+      "dhw_outl_temp_15": {
+        "name": "Varmtvandsudgangstemperatur 15"
+      },
+      "dhw_outl_temp_5": {
+        "name": "Varmtvandsudgangstemperatur 5"
+      },
+      "dhw_outl_temp_max": {
+        "name": "Varmtvandsudgangstemperatur maks."
+      },
+      "dhw_prioritytime": {
+        "name": "Prioritetstid for varmt vand"
+      },
+      "fan0_10v": {
+        "name": "Ventilatorhastighed"
+      },
+      "fanrpm": {
+        "name": "Ventilatorhastighed"
+      },
+      "qn8position": {
+        "name": "Shuntventil, tilskud (QN8)"
+      },
+      "gp1_speed": {
+        "name": "Cirkulationspumpe (GP1)"
+      },
+      "gp2_speed": {
+        "name": "Varmtvandsladningspumpe (GP2)"
+      },
+      "guide_des_temp": {
+        "name": "Guide ønsket temperatur"
+      },
+      "guide_he": {
+        "name": "Guide opvarmning"
+      },
+      "man_mode": {
+        "name": "Manuel tilstand"
+      },
+      "op_mode": {
+        "name": "Driftstilstand",
+        "state": {
+          "0": "Auto",
+          "1": "Manuel",
+          "2": "Tilskud"
+        }
+      },
+      "op_mode_sensor": {
+        "name": "Driftstilstandssensor"
+      },
+      "price_region": {
+        "name": "Prisregion"
+      },
+      "room_temp_ext": {
+        "name": "Rumtemperatur ekstern"
+      },
+      "compressorenergy": {
+        "name": "Kompresorenergi"
+      },
+      "totalenergy": {
+        "name": "Samlet energi"
+      },
+      "bt1": {
+        "name": "Outdoor (BT1)"
+      },
+      "bt2": {
+        "name": "Indoor (BT2)"
+      },
+      "bt4": {
+        "name": "BT4"
+      },
+      "btx": {
+        "name": "BTX"
+      },
+      "smart_sh_status": {
+        "name": "Smart status for opvarmning"
+      },
+      "bt11": {
+        "name": "Varmebærer, fremløbsledning (BT11)"
+      },
+      "cal_heat_temp": {
+        "name": "Varmebærer, fremløbsledning, mål."
+      },
+      "start_cooling_temp": {
+        "name": "Starttemperatur for køling"
+      },
+      "bt30": {
+        "name": "Varmtvandsbeholder (BT30)"
+      },
+      "tap_water_start": {
+        "name": "Nedre grænse for varmtvandsbeholder"
+      },
+      "tap_water_stop": {
+        "name": "Øvre grænse for varmtvandsbeholder"
+      },
+      "tap_water_cap": {
+        "name": "Varmtvandskapacitet"
+      },
+      "tap_water_minutes": {
+        "name": "Varmt vand tilbage"
+      },
+      "additionalenergy": {
+        "name": "Ekstra energi"
+      },
+      "hpid": {
+        "name": "Id"
+      },
+      "smart_sh_mode": {
+        "name": "Smart SH-tilstand",
+        "state": {
+          "0": "Eco",
+          "1": "Balanceret",
+          "2": "Komfort"
+        }
+      },
+      "hp_status": {
+        "name": "Heat pump status",
+        "state": {
+          "0": "Ledig",
+          "1": "Defrosting",
+          "2": "Varmt vand",
+          "3": "Opvarmning",
+          "4": "Køling"
+        }
+      },
+      "smart_dhw_status": {
+        "name": "Smart status for varmt vand"
+      },
+      "smart_dhw_mode": {
+        "name": "Smart DHW-tilstand",
+        "state": {
+          "0": "Eco",
+          "1": "Balanceret",
+          "2": "Komfort"
+        }
+      },
+      "tap_stop": {
+        "name": "Ekstra varmtvandstop"
+      },
+      "ventilation_boost_stop": {
+        "name": "Boost ventilation stop"
+      },
+      "timestamp": {
+        "name": "Sidste opdatering"
+      },
+      "latency": {
+        "name": "Latency"
+      },
+      "disconnect_reason": {
+        "name": "Afbrydelsesårsag",
+        "state": {
+          "client-disconnect": "Klient afbrudt"
+        }
+      },
+      "heatingreleased": {
+        "name": "Opvarmning frigivet"
+      },
+      "coolingreleased": {
+        "name": "Køling frigivet"
+      },
+      "compressorreleased": {
+        "name": "Kompresor frigivet"
+      },
+      "additionreleased": {
+        "name": "Ekstra frigivet"
+      },
+      "dhw_prioritytimeleft": {
+        "name": "Tid tilbage af varmtvandsprioritet"
+      },
+      "heating_prioritytimeleft": {
+        "name": "Tid tilbage af varmeprioritet"
+      },
+      "cooling_prioritytimeleft": {
+        "name": "Tid tilbage af køleprioritet"
+      },
+      "switch_state": {
+        "name": "Kontaktstatus"
+      },
+      "dhwstop_temp": {
+        "name": "Stoptemperatur for varmt vand"
+      },
+      "dhwstart_temp": {
+        "name": "Starttemperatur for varmt vand"
+      },
+      "filtered60sec_outdoortemp": {
+        "name": "Filtreret udetemperatur (60 s)"
+      },
+      "max_freq_env": {
+        "name": "Maks. frekvens i miljøet"
+      },
+      "calc_suppy_cpr": {
+        "name": "Beregnet forsynings-CPR"
+      },
+      "dhw_set": {
+        "name": "Varmtvandsindstilling"
+      },
+      "bp1_temp_20min_filter": {
+        "name": "BP1-temp 20 min filter"
+      },
+      "max_bp2_env": {
+        "name": "Maks. BP2 i miljøet"
+      },
+      "picpin_mask": {
+        "name": "PIC-pinmaske"
+      },
+      "firmware_display_fw_version": {
+        "name": "Visningsfirmwareversion"
+      },
+      "firmware_cc_fw_version": {
+        "name": "CC-firmwareversion"
+      },
+      "firmware_inv_fw_version": {
+        "name": "Omformerfirmwareversion"
+      },
+      "firmware_last_check": {
+        "name": "Firmware sidst kontrolleret"
+      },
+      "expires_at": {
+        "name": "Udløbstid for forhøjet adgang"
+      }
+    },
+    "number": {
+      "indoor_temperature_offset": {
+        "name": "Parallel kurveoffset"
+      },
+      "tap_water_capacity_target": {
+        "name": "Mål for varmtvandskapacitet"
+      },
+      "room_comp_factor": {
+        "name": "Rumkompensationsfaktor"
+      },
+      "tap_water_stop": {
+        "name": "Øvre temperaturgrænse for varmtvandsbeholder"
+      },
+      "tap_water_start": {
+        "name": "Nedre temperaturgrænse for varmtvandsbeholder"
+      },
+      "fan_normal": {
+        "name": "Normal ventilatorhastighed"
+      },
+      "fan_speed_2": {
+        "name": "Minimum ventilatorhastighed for kompressor"
+      },
+      "dhw_stop_extra": {
+        "name": "Stoptemperatur for ekstra varmt vand"
+      },
+      "room_temp_external": {
+        "name": "Ekstern indetemperatur"
+      }
+    },
+    "climate": {
+      "indoor_climate": {
+        "name": "Indeklima"
+      }
+    },
+    "fan": {
+      "fanspeedselector": {
+        "name": "Ventilatorhastighed",
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off": "Fra",
+              "normal": "Normal",
+              "extra": "Ekstra"
+            }
+          }
+        }
+      }
+    }
+  },
+  "config": {
+    "title": "Qvantum varmepumpe",
+    "abort": {
+      "already_configured": "Enheden er allerede konfigureret",
+      "reconfigure_successful": "Genkonfiguration lykkedes"
+    },
+    "error": {
+      "cannot_connect": "Kunne ikke oprette forbindelse",
+      "invalid_auth": "Ugyldig autentifikation",
+      "unknown": "Uventet fejl"
+    },
+    "step": {
+      "user": {
+        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. By default it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+        "data": {
+          "password": "Adgangskode",
+          "username": "Brugernavn",
+          "modbus_tcp": "Brug Modbus-læsning i stedet for HTTP-polling",
+          "modbus_write": "Aktivér skrivning via Modbus"
+        },
+        "data_description": {
+          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
+        }
+      },
+      "reconfigure": {
+        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. By default it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+        "data": {
+          "password": "Adgangskode",
+          "username": "Brugernavn",
+          "modbus_tcp": "Brug Modbus-læsning i stedet for HTTP-polling",
+          "modbus_write": "Aktivér skrivning via Modbus",
+          "modbus_scan_interval": "Modbus-scanningsinterval (sekunder)"
+        },
+        "data_description": {
+          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product.",
+          "modbus_scan_interval": "Hvor ofte der skal polles til varmepumpen over Modbus TCP. Lavere værdier giver næsten realtidsnøjagtighed for flow og volumen. Minimum er 5 sekunder. Standard er 15 sekunder."
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "scan_interval": "HTTP-scanningsinterval (sekunder)",
+          "modbus_tcp": "Brug Modbus-læsning i stedet for HTTP-polling",
+          "modbus_host": "Qvantum vært/IP",
+          "modbus_write": "Aktivér skrivning via Modbus",
+          "modbus_scan_interval": "Modbus-scanningsinterval (sekunder)"
+        },
+        "data_description": {
+          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product.",
+          "modbus_scan_interval": "Hvor ofte der skal polles til varmepumpen over Modbus TCP. Lavere værdier giver næsten realtidsnøjagtighed for flow og volumen. Minimum er 5 sekunder. Standard er 15 sekunder."
+        },
+        "description": "Ret dine indstillinger.",
+        "title": "Indstillinger"
+      }
+    }
+  },
+  "services": {
+    "extra_hot_water": {
+      "name": "Ekstra varmt vand",
+      "description": "Aktivér ekstra varmt vand i en periode",
+      "fields": {
+        "device_id": {
+          "name": "Enheds-ID",
+          "description": "Qvantum-enhedens ID"
+        },
+        "minutes": {
+          "name": "Minutter",
+          "description": "Minutter til at producere ekstra varmt vand (0 minutter slukker)"
+        }
+      }
+    }
+  }
+}

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,31 @@
+import json
+from pathlib import Path
+
+
+TRANSLATIONS_DIR = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "qvantum"
+    / "translations"
+)
+
+
+def test_danish_and_czech_translations_are_available():
+    expected_strings = {
+        "da": {
+            "config_title": "Qvantum varmepumpe",
+            "powertotal": "Samlet effekt",
+        },
+        "cs": {
+            "config_title": "Qvantum tepelné čerpadlo",
+            "powertotal": "Celkový výkon",
+        },
+    }
+
+    for locale, expected in expected_strings.items():
+        path = TRANSLATIONS_DIR / f"{locale}.json"
+        assert path.exists(), f"Missing translation file for {locale}"
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["config"]["title"] == expected["config_title"]
+        assert data["entity"]["sensor"]["powertotal"]["name"] == expected["powertotal"]

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -15,10 +15,18 @@ def test_danish_and_czech_translations_are_available():
         "da": {
             "config_title": "Qvantum varmepumpe",
             "powertotal": "Samlet effekt",
+            "smart_dhw_control_status": "Smart DHW-kontrolstatus",
+            "hp_status_name": "Varmepumpestatus",
+            "hp_status_defrosting": "Afrimning",
+            "config_description": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.",
         },
         "cs": {
             "config_title": "Qvantum tepelné čerpadlo",
             "powertotal": "Celkový výkon",
+            "smart_dhw_control_status": "Stav Smart DHW",
+            "hp_status_name": "Status tepelného čerpadla",
+            "hp_status_defrosting": "Odmrazování",
+            "config_description": "Modbus vám poskytne téměř okamžitá měření přímo čtením ze zařízení.",
         },
     }
 
@@ -29,3 +37,10 @@ def test_danish_and_czech_translations_are_available():
         data = json.loads(path.read_text(encoding="utf-8"))
         assert data["config"]["title"] == expected["config_title"]
         assert data["entity"]["sensor"]["powertotal"]["name"] == expected["powertotal"]
+        assert (
+            data["entity"]["sensor"]["smart_dhw_control_status"]["name"]
+            == expected["smart_dhw_control_status"]
+        )
+        assert data["entity"]["sensor"]["hp_status"]["name"] == expected["hp_status_name"]
+        assert data["entity"]["sensor"]["hp_status"]["state"]["1"] == expected["hp_status_defrosting"]
+        assert expected["config_description"] in data["config"]["step"]["user"]["description"]


### PR DESCRIPTION
This pull request adds a new test to ensure that Danish and Czech translation files exist and contain the expected strings for configuration titles and sensor names.

Testing improvements:

* Added `test_danish_and_czech_translations_are_available` in `tests/test_translations.py` to verify the existence and correctness of Danish (`da.json`) and Czech (`cs.json`) translation files and their key strings.