### PR TITLE
feat: Allow restart of HA without Cloud API being available.

### DIFF
--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -39,6 +39,7 @@ from .const import (
     DEFAULT_MODBUS_HOST,
     DEFAULT_MODBUS_PORT,
     DEFAULT_MODBUS_UNIT_ID,
+    HTTP_CLOUD_LOOKUP_TIMEOUT,
 )
 from .coordinator import QvantumDataUpdateCoordinator
 from .maintenance_coordinator import QvantumMaintenanceCoordinator
@@ -172,9 +173,16 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) ->
         hass, config_entry, coordinator
     )
     try:
-        await maintenance_coordinator.async_config_entry_first_refresh()
-    except ConfigEntryNotReady as err:
+        await asyncio.wait_for(
+            maintenance_coordinator.async_config_entry_first_refresh(),
+            timeout=HTTP_CLOUD_LOOKUP_TIMEOUT,
+        )
+    except (ConfigEntryNotReady, asyncio.TimeoutError) as err:
         if not modbus_enabled:
+            if isinstance(err, asyncio.TimeoutError):
+                raise ConfigEntryNotReady(
+                    "Firmware/access check timed out"
+                ) from err
             raise
         _LOGGER.warning(
             "Cloud API unavailable during firmware/access check; continuing with local Modbus: %s",

--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.const import Platform
 from homeassistant.core import callback
 from homeassistant.const import MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -59,6 +60,32 @@ PLATFORMS: list[Platform] = [
 type MyConfigEntry = ConfigEntry[RuntimeData]
 
 
+def _coordinator_device(coordinator: QvantumDataUpdateCoordinator) -> dict:
+    """Return the coordinator device dict, or {} when missing."""
+    data = getattr(coordinator, "data", None) or {}
+    device = data.get("device") if isinstance(data, dict) else None
+    return device if isinstance(device, dict) else {}
+
+
+def _has_required_device(device: dict, *, require_metadata: bool) -> bool:
+    """Return True when setup has enough device identity to continue."""
+    if not device.get("id"):
+        return False
+    if require_metadata and not device.get("device_metadata"):
+        return False
+    return True
+
+
+def _device_sw_version(device_metadata: dict) -> str | None:
+    """Format firmware versions for DeviceInfo, omitting an empty triple."""
+    display = device_metadata.get("display_fw_version")
+    cc = device_metadata.get("cc_fw_version")
+    inv = device_metadata.get("inv_fw_version")
+    if not (display or cc or inv):
+        return None
+    return f"{display}/{cc}/{inv}"
+
+
 @dataclass
 class RuntimeData:
     """Class to hold your data."""
@@ -99,33 +126,35 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) ->
     await coordinator.async_restore_dhw_state()
     await coordinator.async_config_entry_first_refresh()
 
-    if not coordinator.data.get("device") or not coordinator.data.get("device").get(
-        "device_metadata"
-    ):
+    # HTTP mode needs live cloud metadata. Modbus mode only needs a device id
+    # (from HTTP, cache, or the device registry) so a down cloud API cannot
+    # block local startup.
+    require_metadata = not modbus_enabled
+    device_data = _coordinator_device(coordinator)
+    if not _has_required_device(device_data, require_metadata=require_metadata):
         _LOGGER.error(
             "No device data found when setting up Qvantum integration, 2nd attempt"
         )
         await coordinator.async_config_entry_first_refresh()
+        device_data = _coordinator_device(coordinator)
 
-    if not coordinator.data.get("device") or not coordinator.data.get("device").get(
-        "device_metadata"
-    ):
+    if not _has_required_device(device_data, require_metadata=require_metadata):
         _LOGGER.error(
             "No device data found when setting up Qvantum integration, failure"
         )
         return False
 
-    device_metadata = coordinator.data.get("device").get("device_metadata")
+    device_metadata = device_data.get("device_metadata") or {}
     device = DeviceInfo(
         identifiers={
-            (DOMAIN, f"qvantum-{coordinator.data.get('device').get('id')}"),
+            (DOMAIN, f"qvantum-{device_data.get('id')}"),
         },
-        manufacturer=coordinator.data.get("device").get("vendor"),
-        model=coordinator.data.get("device").get("model"),
+        manufacturer=device_data.get("vendor"),
+        model=device_data.get("model"),
         translation_key="qvantum_flvp",
         name="Qvantum",
-        serial_number=coordinator.data.get("device").get("serial"),
-        sw_version=f"{device_metadata.get('display_fw_version')}/{device_metadata.get('cc_fw_version')}/{device_metadata.get('inv_fw_version')}",
+        serial_number=device_data.get("serial"),
+        sw_version=_device_sw_version(device_metadata),
     )
 
     # Only register the service if it hasn't been registered yet
@@ -136,7 +165,15 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) ->
     maintenance_coordinator = QvantumMaintenanceCoordinator(
         hass, config_entry, coordinator
     )
-    await maintenance_coordinator.async_config_entry_first_refresh()
+    try:
+        await maintenance_coordinator.async_config_entry_first_refresh()
+    except ConfigEntryNotReady as err:
+        if not modbus_enabled:
+            raise
+        _LOGGER.warning(
+            "Cloud API unavailable during firmware/access check; continuing with local Modbus: %s",
+            err,
+        )
 
     remove_listener = config_entry.add_update_listener(_async_update_listener)
     config_entry.async_on_unload(remove_listener)

--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -77,13 +77,19 @@ def _has_required_device(device: dict, *, require_metadata: bool) -> bool:
 
 
 def _device_sw_version(device_metadata: dict) -> str | None:
-    """Format firmware versions for DeviceInfo, omitting an empty triple."""
-    display = device_metadata.get("display_fw_version")
-    cc = device_metadata.get("cc_fw_version")
-    inv = device_metadata.get("inv_fw_version")
-    if not (display or cc or inv):
+    """Format firmware versions for DeviceInfo, omitting an empty triple.
+
+    Missing slots are empty strings (not the literal ``"None"``) so the
+    registry parser can restore them without inventing firmware versions.
+    """
+    parts = [
+        device_metadata.get("display_fw_version"),
+        device_metadata.get("cc_fw_version"),
+        device_metadata.get("inv_fw_version"),
+    ]
+    if not any(parts):
         return None
-    return f"{display}/{cc}/{inv}"
+    return "/".join("" if value is None else str(value) for value in parts)
 
 
 @dataclass

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -33,6 +33,8 @@ CONF_MODBUS_SCAN_INTERVAL = "modbus_scan_interval"
 DEFAULT_MODBUS_HOST = "Qvantum-HP"
 DEFAULT_MODBUS_PORT = 502
 DEFAULT_MODBUS_UNIT_ID = 1
+# Bound cloud lookups so a down HTTP API cannot stall Modbus startup.
+HTTP_CLOUD_LOOKUP_TIMEOUT = 15
 
 # Metrics available in both HTTP and Modbus modes
 DEFAULT_ENABLED_METRICS = [

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Optional
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
@@ -247,9 +248,33 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         except Exception:
             _LOGGER.debug("Failed to load cached device info", exc_info=True)
             return None
-        if self._is_usable_cached_device(data):
-            return data
+        device = self._device_from_store_payload(data)
+        if self._is_usable_cached_device(device):
+            return device
         return None
+
+    def _current_username(self) -> str | None:
+        """Return the configured account username, if any."""
+        data = getattr(self._config_entry, "data", None) or {}
+        username = data.get(CONF_USERNAME)
+        return username if isinstance(username, str) and username else None
+
+    def _device_from_store_payload(self, data: dict | None) -> dict | None:
+        """Unwrap a stored device bound to the current account.
+
+        Payloads without an account binding are ignored so a reconfigure that
+        keeps the same config-entry ID cannot keep serving the previous device.
+        """
+        if not isinstance(data, dict):
+            return None
+        stored_user = data.get("username")
+        device = data.get("device")
+        if stored_user != self._current_username():
+            _LOGGER.debug(
+                "Ignoring cached device identity bound to a different account"
+            )
+            return None
+        return device if isinstance(device, dict) else None
 
     def _is_usable_cached_device(self, cached: dict | None) -> bool:
         """Return True when cached identity is enough for the current transport.
@@ -268,8 +293,13 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         """Persist device identity so Modbus can start without the HTTP API."""
         if not isinstance(self._device, dict) or not self._device.get("id"):
             return
+        username = self._current_username()
+        if not username:
+            return
         try:
-            await self._device_store.async_save(self._device)
+            await self._device_store.async_save(
+                {"username": username, "device": self._device}
+            )
         except Exception:
             _LOGGER.debug("Failed to persist device info", exc_info=True)
 

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -185,6 +185,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=config_entry,
             name=f"{DOMAIN} ({config_entry.unique_id})",
             update_method=self.async_update_data,
             update_interval=timedelta(seconds=self.poll_interval),

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -180,6 +180,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         self._device_store: Store = Store(
             hass, 1, f"{DOMAIN}.device.{config_entry.entry_id}"
         )
+        self._store_account_mismatch = False
 
         super().__init__(
             hass,
@@ -243,6 +244,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
 
     async def _load_cached_device(self) -> dict | None:
         """Load last-known device identity from persistent storage."""
+        self._store_account_mismatch = False
         try:
             data = await self._device_store.async_load()
         except Exception:
@@ -270,6 +272,11 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         stored_user = data.get("username")
         device = data.get("device")
         if stored_user != self._current_username():
+            # A present binding for another account must also block registry
+            # recovery: reconfigure keeps this config-entry ID, so the HA
+            # device registry still points at the previous account's device.
+            if stored_user:
+                self._store_account_mismatch = True
             _LOGGER.debug(
                 "Ignoring cached device identity bound to a different account"
             )
@@ -385,7 +392,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
                 "Failed to fetch device info from HTTP API: %s", err
             )
 
-        if self.modbus_enabled:
+        if self.modbus_enabled and not self._store_account_mismatch:
             from_registry = self._device_from_registry()
             if from_registry:
                 self._device = from_registry
@@ -394,6 +401,10 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
                     "HTTP API unavailable; using device registry for local Modbus startup"
                 )
                 return
+        if self._store_account_mismatch:
+            _LOGGER.warning(
+                "Skipping device registry recovery; cached identity is bound to a different account"
+            )
 
         if http_error is not None:
             raise http_error

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -23,6 +23,7 @@ from .const import (
     DEFAULT_MODBUS_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    FIRMWARE_KEYS,
     HP_STATUS_COOLING,
     HP_STATUS_DEFROSTING,
     HP_STATUS_HEATING,
@@ -39,6 +40,9 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+# Bound cloud device lookups so a down HTTP API cannot stall Modbus startup.
+_HTTP_DEVICE_LOOKUP_TIMEOUT = 15
 
 _COMPRESSOR_TO_HP_STATUS_MAP = {
     2: HP_STATUS_HEATING,   # Heating → Heating
@@ -79,6 +83,18 @@ async def handle_setting_update_response(
     return False
 
 
+def _firmware_metadata_from_sw_version(sw_version: str | None) -> dict:
+    """Parse DeviceInfo sw_version (display/cc/inv) back into metadata keys."""
+    if not sw_version:
+        return {}
+    parts = str(sw_version).split("/")
+    return {
+        key: part
+        for key, part in zip(FIRMWARE_KEYS, parts)
+        if part
+    }
+
+
 class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinator):
     """Qvantum coordinator."""
 
@@ -116,6 +132,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         )
 
         self.api = hass.data[DOMAIN]
+        self._config_entry = config_entry
         self._device = None
         self._last_tap_stop_fetch: datetime | None = None
         self._cached_tap_stop: Any = None
@@ -157,6 +174,9 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         self._last_persisted_dhw_state: tuple | None = None
         self._dhw_store: Store = Store(
             hass, 1, f"{DOMAIN}.dhw_ema.{config_entry.entry_id}"
+        )
+        self._device_store: Store = Store(
+            hass, 1, f"{DOMAIN}.device.{config_entry.entry_id}"
         )
 
         super().__init__(
@@ -218,6 +238,121 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
                 self._last_shower_duration_min or 0.0,
                 self._last_tap_water_cap or 0.0,
             )
+
+    async def _load_cached_device(self) -> dict | None:
+        """Load last-known device identity from persistent storage."""
+        try:
+            data = await self._device_store.async_load()
+        except Exception:
+            _LOGGER.debug("Failed to load cached device info", exc_info=True)
+            return None
+        if isinstance(data, dict) and data.get("id"):
+            return data
+        return None
+
+    async def _persist_device_state(self) -> None:
+        """Persist device identity so Modbus can start without the HTTP API."""
+        if not isinstance(self._device, dict) or not self._device.get("id"):
+            return
+        try:
+            await self._device_store.async_save(self._device)
+        except Exception:
+            _LOGGER.debug("Failed to persist device info", exc_info=True)
+
+    def _device_from_registry(self) -> dict | None:
+        """Rebuild device identity from the HA device registry after a restart."""
+        try:
+            from homeassistant.helpers import device_registry as dr
+
+            registry = dr.async_get(self.hass)
+        except Exception:
+            return None
+        if registry is None:
+            return None
+
+        devices = getattr(registry, "devices", None)
+        if devices is None:
+            return None
+
+        entry_id = getattr(self._config_entry, "entry_id", None)
+        values = devices.values() if hasattr(devices, "values") else devices
+        prefix = f"{DOMAIN}-"
+        for ha_device in values:
+            config_entries = getattr(ha_device, "config_entries", None)
+            if (
+                entry_id
+                and config_entries is not None
+                and entry_id not in config_entries
+            ):
+                continue
+            identifiers = getattr(ha_device, "identifiers", None) or set()
+            for identifier in identifiers:
+                if not isinstance(identifier, (tuple, list)) or len(identifier) != 2:
+                    continue
+                domain, raw_id = identifier
+                if domain != DOMAIN or not isinstance(raw_id, str):
+                    continue
+                if not raw_id.startswith(prefix):
+                    continue
+                device_id = raw_id[len(prefix) :]
+                if not device_id:
+                    continue
+                return {
+                    "id": device_id,
+                    "vendor": getattr(ha_device, "manufacturer", None),
+                    "model": getattr(ha_device, "model", None),
+                    "serial": getattr(ha_device, "serial_number", None),
+                    "device_metadata": _firmware_metadata_from_sw_version(
+                        getattr(ha_device, "sw_version", None)
+                    ),
+                }
+        return None
+
+    async def _ensure_device(self) -> None:
+        """Populate device identity from cache, HTTP, or the device registry.
+
+        Cached identity is preferred so Modbus mode can start while the cloud
+        API is down. HTTP is only contacted when no cache is available.
+        """
+        if self._device is None:
+            cached = await self._load_cached_device()
+            if isinstance(cached, dict) and cached.get("id"):
+                self._device = cached
+                _LOGGER.debug(
+                    "Loaded cached device info for %s", cached.get("id")
+                )
+
+        if self._device is not None:
+            return
+
+        http_error: Exception | None = None
+        try:
+            device = await asyncio.wait_for(
+                self.api.get_primary_device(),
+                timeout=_HTTP_DEVICE_LOOKUP_TIMEOUT,
+            )
+            if isinstance(device, dict) and device.get("id"):
+                self._device = device
+                await self._persist_device_state()
+                return
+        except Exception as err:
+            http_error = err
+            _LOGGER.warning(
+                "Failed to fetch device info from HTTP API: %s", err
+            )
+
+        if self.modbus_enabled:
+            from_registry = self._device_from_registry()
+            if from_registry:
+                self._device = from_registry
+                await self._persist_device_state()
+                _LOGGER.warning(
+                    "HTTP API unavailable; using device registry for local Modbus startup"
+                )
+                return
+
+        if http_error is not None:
+            raise http_error
 
     def _persist_dhw_state(self) -> None:
         """Save DHW EMA snapshot via a debounced write so it survives a restart.
@@ -457,10 +592,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
     async def async_update_data(self):
         """Fetch data from API endpoint."""
         try:
-            # Get device info if not cached
-            if self._device is None:
-                _LOGGER.debug("Fetching primary device info")
-                self._device = await self.api.get_primary_device()
+            await self._ensure_device()
 
             # Validate device information before accessing it
             if self._device is None:
@@ -559,22 +691,28 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         except APIAuthError as err:
             _LOGGER.error(
                 "Authentication error for device %s: %s",
-                getattr(self, "_device", {}).get("id", "unknown"),
+                self._logged_device_id(),
                 err,
             )
             raise UpdateFailed(f"Authentication failed: {err}") from err
         except asyncio.TimeoutError as err:
             _LOGGER.error(
                 "Timeout fetching data for device %s",
-                getattr(self, "_device", {}).get("id", "unknown"),
+                self._logged_device_id(),
             )
             raise UpdateFailed("Request timeout") from err
         except Exception as err:
-            device_id = getattr(self, "_device", {}).get("id", "unknown")
             _LOGGER.error(
                 "Unexpected error fetching data for device %s: %s",
-                device_id,
+                self._logged_device_id(),
                 err,
                 exc_info=True,
             )
             raise UpdateFailed(f"Error communicating with API: {err}") from err
+
+    def _logged_device_id(self) -> str:
+        """Return a device id safe to include in error logs."""
+        device = self._device
+        if isinstance(device, dict):
+            return str(device.get("id") or "unknown")
+        return "unknown"

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -36,13 +36,13 @@ from .const import (
     REQUIRED_MODBUS_METRICS,
     CONF_MODBUS_SCAN_INTERVAL,
     CONF_MODBUS_TCP,
+    HTTP_CLOUD_LOOKUP_TIMEOUT,
     TAP_WATER_CAPACITY_MAPPINGS,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-# Bound cloud device lookups so a down HTTP API cannot stall Modbus startup.
-_HTTP_DEVICE_LOOKUP_TIMEOUT = 15
+
 
 _COMPRESSOR_TO_HP_STATUS_MAP = {
     2: HP_STATUS_HEATING,   # Heating → Heating
@@ -343,7 +343,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         try:
             device = await asyncio.wait_for(
                 self.api.get_primary_device(),
-                timeout=_HTTP_DEVICE_LOOKUP_TIMEOUT,
+                timeout=HTTP_CLOUD_LOOKUP_TIMEOUT,
             )
             if isinstance(device, dict) and device.get("id"):
                 self._device = device

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -88,11 +88,12 @@ def _firmware_metadata_from_sw_version(sw_version: str | None) -> dict:
     if not sw_version:
         return {}
     parts = str(sw_version).split("/")
-    return {
-        key: part
-        for key, part in zip(FIRMWARE_KEYS, parts)
-        if part
-    }
+    metadata = {}
+    for key, part in zip(FIRMWARE_KEYS, parts):
+        if not part or part == "None":
+            continue
+        metadata[key] = part
+    return metadata
 
 
 class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinator):
@@ -246,9 +247,22 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         except Exception:
             _LOGGER.debug("Failed to load cached device info", exc_info=True)
             return None
-        if isinstance(data, dict) and data.get("id"):
+        if self._is_usable_cached_device(data):
             return data
         return None
+
+    def _is_usable_cached_device(self, cached: dict | None) -> bool:
+        """Return True when cached identity is enough for the current transport.
+
+        HTTP mode needs metadata so a previous empty metadata response cannot
+        permanently skip a recovered cloud lookup. Modbus mode only needs an id.
+        """
+        if not isinstance(cached, dict) or not cached.get("id"):
+            return False
+        if self.modbus_enabled:
+            return True
+        metadata = cached.get("device_metadata")
+        return isinstance(metadata, dict) and bool(metadata)
 
     async def _persist_device_state(self) -> None:
         """Persist device identity so Modbus can start without the HTTP API."""

--- a/custom_components/qvantum/entity.py
+++ b/custom_components/qvantum/entity.py
@@ -52,6 +52,10 @@ class QvantumAccessMixin:
                 self.coordinator.config_entry.runtime_data.maintenance_coordinator
             )
             if not maintenance_coordinator or not maintenance_coordinator.data:
+                # Cloud access cannot be checked (HTTP API down). Local Modbus
+                # writes remain available when the user has enabled them.
+                if hasattr(self, "_is_modbus_write_allowed"):
+                    return self._is_modbus_write_allowed()
                 return False
             access_level = maintenance_coordinator.data.get("access_level", {})
             return access_level.get("writeAccessLevel", 0) >= 20

--- a/custom_components/qvantum/entity.py
+++ b/custom_components/qvantum/entity.py
@@ -51,13 +51,15 @@ class QvantumAccessMixin:
             maintenance_coordinator = (
                 self.coordinator.config_entry.runtime_data.maintenance_coordinator
             )
-            if not maintenance_coordinator or not maintenance_coordinator.data:
-                # Cloud access cannot be checked (HTTP API down). Local Modbus
-                # writes remain available when the user has enabled them.
-                if hasattr(self, "_is_modbus_write_allowed"):
-                    return self._is_modbus_write_allowed()
-                return False
-            access_level = maintenance_coordinator.data.get("access_level", {})
+            if not maintenance_coordinator:
+                return self._local_write_available()
+            data = maintenance_coordinator.data
+            # Missing/cleared access_level means the cloud check is unavailable,
+            # not that write access is denied. Only entities that actually write
+            # via Modbus remain available.
+            if not data or data.get("access_level") is None:
+                return self._local_write_available()
+            access_level = data.get("access_level") or {}
             return access_level.get("writeAccessLevel", 0) >= 20
         except AttributeError:
             # For tests or incomplete setup, deny write access and log misconfiguration once per entity
@@ -69,6 +71,19 @@ class QvantumAccessMixin:
                 )
                 self._write_access_warning_logged = True
             return False
+
+    def _local_write_available(self) -> bool:
+        """Return True when this entity can write locally without the cloud API."""
+        return False
+
+
+# Metrics whose entity implementations write via Modbus holding registers.
+# HTTP-backed controls must not become writable just because Modbus TCP is on.
+_LOCAL_MODBUS_WRITE_METRICS = {
+    "dhw_stop_extra",
+    "room_temp_external",
+    "use_operation_sensor",
+}
 
 
 # Centralized icon map for all Qvantum entities keyed by metric_key
@@ -150,6 +165,13 @@ class QvantumEntity(QvantumAccessMixin, CoordinatorEntity):
             config_entry.data.get(CONF_MODBUS_TCP, False),
         )
         return modbus_write_enabled and modbus_tcp_enabled
+
+    def _local_write_available(self) -> bool:
+        """Return True when this metric writes via Modbus and writes are enabled."""
+        return (
+            self._is_modbus_write_allowed()
+            and getattr(self, "_metric_key", None) in _LOCAL_MODBUS_WRITE_METRICS
+        )
 
     def _resolve_device_id(self, device: DeviceInfo | dict[str, object]) -> str | None:
         """Resolve device ID from device info or coordinator data."""

--- a/custom_components/qvantum/maintenance_coordinator.py
+++ b/custom_components/qvantum/maintenance_coordinator.py
@@ -133,7 +133,11 @@ class QvantumMaintenanceCoordinator(DataUpdateCoordinator):
                     "continuing with local Modbus: %s",
                     err,
                 )
-                return self.data or {}
+                previous = dict(self.data or {})
+                # Drop stale authorization so callers can tell an outage from
+                # a fresh access-level result.
+                previous["access_level"] = None
+                return previous
             _LOGGER.error("Error checking firmware updates: %s", err)
             stack_trace = traceback.format_exc()
             raise UpdateFailed(

--- a/custom_components/qvantum/maintenance_coordinator.py
+++ b/custom_components/qvantum/maintenance_coordinator.py
@@ -145,7 +145,7 @@ class QvantumMaintenanceCoordinator(DataUpdateCoordinator):
             err,
         )
         previous = dict(self.data or {})
-        previous["access_level"] = None
+        previous.pop("access_level", None)
         return previous
 
     async def _create_firmware_update_notifications(

--- a/custom_components/qvantum/maintenance_coordinator.py
+++ b/custom_components/qvantum/maintenance_coordinator.py
@@ -38,6 +38,7 @@ class QvantumMaintenanceCoordinator(DataUpdateCoordinator):
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=config_entry,
             name=f"{DOMAIN} Firmware ({config_entry.unique_id})",
             update_method=self.async_check_firmware_updates,
             update_interval=timedelta(hours=2),  # Check every 2 hours

--- a/custom_components/qvantum/maintenance_coordinator.py
+++ b/custom_components/qvantum/maintenance_coordinator.py
@@ -124,25 +124,29 @@ class QvantumMaintenanceCoordinator(DataUpdateCoordinator):
             }
 
         except APIAuthError as err:
+            if getattr(self.main_coordinator, "modbus_enabled", False):
+                return self._cloud_unavailable_result(err)
             _LOGGER.error("Authentication error during firmware check: %s", err)
             raise UpdateFailed(err) from err
         except Exception as err:
             if getattr(self.main_coordinator, "modbus_enabled", False):
-                _LOGGER.warning(
-                    "Cloud API unavailable during firmware/access check; "
-                    "continuing with local Modbus: %s",
-                    err,
-                )
-                previous = dict(self.data or {})
-                # Drop stale authorization so callers can tell an outage from
-                # a fresh access-level result.
-                previous["access_level"] = None
-                return previous
+                return self._cloud_unavailable_result(err)
             _LOGGER.error("Error checking firmware updates: %s", err)
             stack_trace = traceback.format_exc()
             raise UpdateFailed(
                 f"Error checking firmware updates: {err}\nStack trace:\n{stack_trace}"
             ) from err
+
+    def _cloud_unavailable_result(self, err: Exception) -> dict:
+        """Keep last firmware data but clear stale authorization after a cloud outage."""
+        _LOGGER.warning(
+            "Cloud API unavailable during firmware/access check; "
+            "continuing with local Modbus: %s",
+            err,
+        )
+        previous = dict(self.data or {})
+        previous["access_level"] = None
+        return previous
 
     async def _create_firmware_update_notifications(
         self, device_id: str, firmware_changes: list[dict[str, str]]

--- a/custom_components/qvantum/maintenance_coordinator.py
+++ b/custom_components/qvantum/maintenance_coordinator.py
@@ -127,6 +127,13 @@ class QvantumMaintenanceCoordinator(DataUpdateCoordinator):
             _LOGGER.error("Authentication error during firmware check: %s", err)
             raise UpdateFailed(err) from err
         except Exception as err:
+            if getattr(self.main_coordinator, "modbus_enabled", False):
+                _LOGGER.warning(
+                    "Cloud API unavailable during firmware/access check; "
+                    "continuing with local Modbus: %s",
+                    err,
+                )
+                return self.data or {}
             _LOGGER.error("Error checking firmware updates: %s", err)
             stack_trace = traceback.format_exc()
             raise UpdateFailed(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,11 @@ def mock_storage_save():
             Mock(return_value=None),
             raising=False,
         )
+        mp.setattr(
+            "homeassistant.helpers.storage.Store.async_load",
+            AsyncMock(return_value=None),
+            raising=False,
+        )
         yield
 
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from custom_components.qvantum.coordinator import (
     handle_setting_update_response,
     QvantumDataUpdateCoordinator,
+    _firmware_metadata_from_sw_version,
 )
 from custom_components.qvantum.const import (
     CONF_MODBUS_SCAN_INTERVAL,
@@ -3151,3 +3152,129 @@ class TestCalculateTapWaterCap:
         )
         assert coordinator._last_shower_flow_lpm is None
         assert coordinator._shower_event_history == []
+
+
+class TestDeviceLookupWhenHttpDown:
+    """Device identity must not depend on a live HTTP API in Modbus mode."""
+
+    def _make_coordinator(self, mock_super_init, *, modbus: bool):
+        mock_super_init.return_value = None
+        mock_api = MagicMock()
+        mock_hass = MagicMock()
+        mock_hass.data = {
+            DOMAIN: mock_api,
+            "device_registry": MagicMock(),
+            "entity_registry": MagicMock(),
+        }
+        mock_config_entry = MagicMock()
+        mock_config_entry.entry_id = "test_entry_id"
+        mock_config_entry.unique_id = "test_device_123"
+        mock_config_entry.data = {}
+        if modbus:
+            mock_config_entry.options.get.side_effect = _modbus_options_get
+        else:
+            mock_config_entry.options.get.side_effect = lambda key, default=None: default
+        coordinator = QvantumDataUpdateCoordinator(mock_hass, mock_config_entry)
+        coordinator.api = mock_api
+        coordinator.hass = mock_hass
+        coordinator._device_store = MagicMock()
+        coordinator._device_store.async_load = AsyncMock(return_value=None)
+        coordinator._device_store.async_save = AsyncMock()
+        return coordinator, mock_api
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_uses_cached_device_when_http_down(self, mock_super_init):
+        """Cached device identity is used so Modbus can start without HTTP."""
+        coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
+        cached = {
+            "id": "test_device_123",
+            "vendor": "Qvantum",
+            "model": "QE-6",
+            "device_metadata": {"display_fw_version": "1.3.6"},
+        }
+        coordinator._device_store.async_load = AsyncMock(return_value=cached)
+        mock_api.get_metrics = AsyncMock(
+            return_value={"metrics": {"hpid": "test_device_123", "bt1": 7.5}}
+        )
+        mock_api.get_settings = AsyncMock(return_value={"settings": []})
+
+        result = await coordinator.async_update_data()
+
+        mock_api.get_primary_device.assert_not_called()
+        assert result["device"]["id"] == "test_device_123"
+        assert result["values"]["bt1"] == 7.5
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_uses_device_registry_when_http_down(self, mock_super_init):
+        """After a restart with no store file, fall back to the device registry."""
+        coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
+        mock_api.get_primary_device = AsyncMock(side_effect=Exception("HTTP API down"))
+        mock_api.get_metrics = AsyncMock(
+            return_value={"metrics": {"hpid": "test_device_123"}}
+        )
+        mock_api.get_settings = AsyncMock(return_value={"settings": []})
+
+        ha_device = MagicMock()
+        ha_device.config_entries = {"test_entry_id"}
+        ha_device.identifiers = {(DOMAIN, "qvantum-test_device_123")}
+        ha_device.manufacturer = "Qvantum"
+        ha_device.model = "QE-6"
+        ha_device.serial_number = "test_device_123"
+        ha_device.sw_version = "1.3.6/140/140"
+
+        mock_registry = MagicMock()
+        mock_registry.devices.values.return_value = [ha_device]
+
+        with patch(
+            "homeassistant.helpers.device_registry.async_get",
+            return_value=mock_registry,
+        ):
+            result = await coordinator.async_update_data()
+
+        assert result["device"]["id"] == "test_device_123"
+        assert result["device"]["device_metadata"]["display_fw_version"] == "1.3.6"
+        mock_api.get_primary_device.assert_awaited()
+        coordinator._device_store.async_save.assert_awaited()
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_http_mode_still_fails_when_api_down(self, mock_super_init):
+        """HTTP-only mode still requires a live cloud device lookup."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=False)
+        mock_api.get_primary_device = AsyncMock(side_effect=Exception("HTTP API down"))
+
+        with pytest.raises(UpdateFailed):
+            await coordinator.async_update_data()
+
+        mock_api.get_metrics.assert_not_called()
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_persists_device_after_successful_http_lookup(self, mock_super_init):
+        """A successful HTTP lookup is stored for later Modbus-only startups."""
+        coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
+        device = {
+            "id": "test_device_123",
+            "vendor": "Qvantum",
+            "model": "QE-6",
+            "device_metadata": {"display_fw_version": "1.3.6"},
+        }
+        mock_api.get_primary_device = AsyncMock(return_value=device)
+        mock_api.get_metrics = AsyncMock(return_value={"metrics": {}})
+        mock_api.get_settings = AsyncMock(return_value={"settings": []})
+
+        await coordinator.async_update_data()
+
+        coordinator._device_store.async_save.assert_awaited_once_with(device)
+
+    def test_firmware_metadata_from_sw_version(self):
+        assert _firmware_metadata_from_sw_version(None) == {}
+        assert _firmware_metadata_from_sw_version("1.3.6/140/141") == {
+            "display_fw_version": "1.3.6",
+            "cc_fw_version": "140",
+            "inv_fw_version": "141",
+        }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -129,6 +129,23 @@ class TestQvantumDataUpdateCoordinator:
     """Test the QvantumDataUpdateCoordinator class."""
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    def test_passes_config_entry_to_parent(self, mock_super_init):
+        """Parent DataUpdateCoordinator must receive config_entry explicitly."""
+        mock_super_init.return_value = None
+        mock_hass = MagicMock()
+        mock_hass.data = {DOMAIN: MagicMock()}
+        config_entry = MagicMock()
+        config_entry.options.get.return_value = 30
+        config_entry.unique_id = "test_device"
+        config_entry.entry_id = "test_entry_id"
+
+        coordinator = QvantumDataUpdateCoordinator(mock_hass, config_entry)
+
+        mock_super_init.assert_called_once()
+        assert mock_super_init.call_args.kwargs["config_entry"] is config_entry
+        assert coordinator._config_entry is config_entry
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     def test_get_enabled_metrics_with_device_found(self, mock_super_init):
         """Test _get_enabled_metrics when device is found in registry."""
         # Create mock hass with registries and API

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3169,7 +3169,7 @@ class TestDeviceLookupWhenHttpDown:
         mock_config_entry = MagicMock()
         mock_config_entry.entry_id = "test_entry_id"
         mock_config_entry.unique_id = "test_device_123"
-        mock_config_entry.data = {}
+        mock_config_entry.data = {"username": "test@example.com"}
         if modbus:
             mock_config_entry.options.get.side_effect = _modbus_options_get
         else:
@@ -3193,7 +3193,9 @@ class TestDeviceLookupWhenHttpDown:
             "model": "QE-6",
             "device_metadata": {"display_fw_version": "1.3.6"},
         }
-        coordinator._device_store.async_load = AsyncMock(return_value=cached)
+        coordinator._device_store.async_load = AsyncMock(
+            return_value={"username": "test@example.com", "device": cached}
+        )
         mock_api.get_metrics = AsyncMock(
             return_value={"metrics": {"hpid": "test_device_123", "bt1": 7.5}}
         )
@@ -3269,7 +3271,9 @@ class TestDeviceLookupWhenHttpDown:
 
         await coordinator.async_update_data()
 
-        coordinator._device_store.async_save.assert_awaited_once_with(device)
+        coordinator._device_store.async_save.assert_awaited_once_with(
+            {"username": "test@example.com", "device": device}
+        )
 
     def test_firmware_metadata_from_sw_version(self):
         assert _firmware_metadata_from_sw_version(None) == {}
@@ -3291,7 +3295,10 @@ class TestDeviceLookupWhenHttpDown:
         """Incomplete cached identity must not skip HTTP metadata lookup."""
         coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=False)
         coordinator._device_store.async_load = AsyncMock(
-            return_value={"id": "test_device_123"}
+            return_value={
+                "username": "test@example.com",
+                "device": {"id": "test_device_123"},
+            }
         )
         device = {
             "id": "test_device_123",
@@ -3312,7 +3319,10 @@ class TestDeviceLookupWhenHttpDown:
         """Modbus startup only needs a device id from cache."""
         coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
         coordinator._device_store.async_load = AsyncMock(
-            return_value={"id": "test_device_123"}
+            return_value={
+                "username": "test@example.com",
+                "device": {"id": "test_device_123"},
+            }
         )
         mock_api.get_metrics = AsyncMock(return_value={"metrics": {}})
         mock_api.get_settings = AsyncMock(return_value={"settings": []})
@@ -3321,3 +3331,29 @@ class TestDeviceLookupWhenHttpDown:
 
         mock_api.get_primary_device.assert_not_called()
         assert result["device"]["id"] == "test_device_123"
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_modbus_mode_rejects_cache_for_other_account(self, mock_super_init):
+        """Cached identity from a previous account must not be reused after reconfigure."""
+        coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
+        coordinator._device_store.async_load = AsyncMock(
+            return_value={
+                "username": "old@example.com",
+                "device": {"id": "old_device", "model": "QE-6"},
+            }
+        )
+        device = {
+            "id": "new_device",
+            "vendor": "Qvantum",
+            "model": "QE-6",
+            "device_metadata": {"display_fw_version": "1.3.6"},
+        }
+        mock_api.get_primary_device = AsyncMock(return_value=device)
+        mock_api.get_metrics = AsyncMock(return_value={"metrics": {}})
+        mock_api.get_settings = AsyncMock(return_value={"settings": []})
+
+        result = await coordinator.async_update_data()
+
+        mock_api.get_primary_device.assert_awaited()
+        assert result["device"]["id"] == "new_device"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3278,3 +3278,46 @@ class TestDeviceLookupWhenHttpDown:
             "cc_fw_version": "140",
             "inv_fw_version": "141",
         }
+        assert _firmware_metadata_from_sw_version("1.0/None/None") == {
+            "display_fw_version": "1.0",
+        }
+        assert _firmware_metadata_from_sw_version("1.0//") == {
+            "display_fw_version": "1.0",
+        }
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_http_mode_ignores_id_only_cache(self, mock_super_init):
+        """Incomplete cached identity must not skip HTTP metadata lookup."""
+        coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=False)
+        coordinator._device_store.async_load = AsyncMock(
+            return_value={"id": "test_device_123"}
+        )
+        device = {
+            "id": "test_device_123",
+            "device_metadata": {"display_fw_version": "1.3.6"},
+        }
+        mock_api.get_primary_device = AsyncMock(return_value=device)
+        mock_api.get_metrics = AsyncMock(return_value={"metrics": {}})
+        mock_api.get_settings = AsyncMock(return_value={"settings": []})
+
+        result = await coordinator.async_update_data()
+
+        mock_api.get_primary_device.assert_awaited()
+        assert result["device"]["device_metadata"]["display_fw_version"] == "1.3.6"
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_modbus_mode_accepts_id_only_cache(self, mock_super_init):
+        """Modbus startup only needs a device id from cache."""
+        coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
+        coordinator._device_store.async_load = AsyncMock(
+            return_value={"id": "test_device_123"}
+        )
+        mock_api.get_metrics = AsyncMock(return_value={"metrics": {}})
+        mock_api.get_settings = AsyncMock(return_value={"settings": []})
+
+        result = await coordinator.async_update_data()
+
+        mock_api.get_primary_device.assert_not_called()
+        assert result["device"]["id"] == "test_device_123"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3360,6 +3360,79 @@ class TestDeviceLookupWhenHttpDown:
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     @pytest.mark.asyncio
+    async def test_modbus_mode_skips_registry_when_store_bound_to_other_account(
+        self, mock_super_init
+    ):
+        """Registry recovery must not rebind the previous account's device after reconfigure."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
+        coordinator._device_store.async_load = AsyncMock(
+            return_value={
+                "username": "old@example.com",
+                "device": {"id": "old_device", "model": "QE-6"},
+            }
+        )
+        mock_api.get_primary_device = AsyncMock(side_effect=Exception("HTTP API down"))
+
+        ha_device = MagicMock()
+        ha_device.config_entries = {"test_entry_id"}
+        ha_device.identifiers = {(DOMAIN, "qvantum-old_device")}
+        ha_device.manufacturer = "Qvantum"
+        ha_device.model = "QE-6"
+        ha_device.serial_number = "old_device"
+        ha_device.sw_version = "1.3.6/140/140"
+
+        mock_registry = MagicMock()
+        mock_registry.devices.values.return_value = [ha_device]
+
+        with patch(
+            "homeassistant.helpers.device_registry.async_get",
+            return_value=mock_registry,
+        ):
+            with pytest.raises(UpdateFailed):
+                await coordinator.async_update_data()
+
+        coordinator._device_store.async_save.assert_not_called()
+        mock_api.get_metrics.assert_not_called()
+        assert coordinator._device is None
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_modbus_mode_uses_registry_for_legacy_unbound_store(
+        self, mock_super_init
+    ):
+        """A store without an account binding still allows registry recovery."""
+        coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
+        coordinator._device_store.async_load = AsyncMock(
+            return_value={"id": "test_device_123", "model": "QE-6"}
+        )
+        mock_api.get_primary_device = AsyncMock(side_effect=Exception("HTTP API down"))
+        mock_api.get_metrics = AsyncMock(return_value={"metrics": {}})
+        mock_api.get_settings = AsyncMock(return_value={"settings": []})
+
+        ha_device = MagicMock()
+        ha_device.config_entries = {"test_entry_id"}
+        ha_device.identifiers = {(DOMAIN, "qvantum-test_device_123")}
+        ha_device.manufacturer = "Qvantum"
+        ha_device.model = "QE-6"
+        ha_device.serial_number = "test_device_123"
+        ha_device.sw_version = "1.3.6/140/140"
+
+        mock_registry = MagicMock()
+        mock_registry.devices.values.return_value = [ha_device]
+
+        with patch(
+            "homeassistant.helpers.device_registry.async_get",
+            return_value=mock_registry,
+        ):
+            result = await coordinator.async_update_data()
+
+        assert result["device"]["id"] == "test_device_123"
+        coordinator._device_store.async_save.assert_awaited()
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
     async def test_load_cached_device_swallows_store_errors(self, mock_super_init):
         """A corrupted device store must not prevent an HTTP lookup."""
         coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3357,3 +3357,102 @@ class TestDeviceLookupWhenHttpDown:
 
         mock_api.get_primary_device.assert_awaited()
         assert result["device"]["id"] == "new_device"
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_load_cached_device_swallows_store_errors(self, mock_super_init):
+        """A corrupted device store must not prevent an HTTP lookup."""
+        coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
+        coordinator._device_store.async_load = AsyncMock(side_effect=OSError("disk"))
+        device = {"id": "test_device_123", "device_metadata": {"display_fw_version": "1"}}
+        mock_api.get_primary_device = AsyncMock(return_value=device)
+        mock_api.get_metrics = AsyncMock(return_value={"metrics": {}})
+        mock_api.get_settings = AsyncMock(return_value={"settings": []})
+
+        result = await coordinator.async_update_data()
+
+        assert result["device"]["id"] == "test_device_123"
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_persist_device_skips_without_username_or_id(self, mock_super_init):
+        coordinator, _ = self._make_coordinator(mock_super_init, modbus=True)
+        coordinator._device = {}
+        await coordinator._persist_device_state()
+        coordinator._device_store.async_save.assert_not_called()
+
+        coordinator._device = {"id": "test_device_123"}
+        coordinator._config_entry.data = {"username": ""}
+        await coordinator._persist_device_state()
+        coordinator._device_store.async_save.assert_not_called()
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_persist_device_swallows_store_errors(self, mock_super_init):
+        coordinator, _ = self._make_coordinator(mock_super_init, modbus=True)
+        coordinator._device = {"id": "test_device_123"}
+        coordinator._device_store.async_save = AsyncMock(side_effect=OSError("disk"))
+        await coordinator._persist_device_state()
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    def test_device_from_registry_skips_unusable_entries(self, mock_super_init):
+        """Registry fallback must ignore devices that are not this config entry."""
+        coordinator, _ = self._make_coordinator(mock_super_init, modbus=True)
+
+        other_entry = MagicMock()
+        other_entry.config_entries = {"other_entry"}
+        other_entry.identifiers = {(DOMAIN, "qvantum-other")}
+
+        bad_identifier = MagicMock()
+        bad_identifier.config_entries = {"test_entry_id"}
+        bad_identifier.identifiers = {
+            "not-a-tuple",
+            (DOMAIN,),
+            ("other", "qvantum-x"),
+            (DOMAIN, 123),
+            (DOMAIN, "not-prefixed"),
+            (DOMAIN, "qvantum-"),
+        }
+
+        mock_registry = MagicMock()
+        mock_registry.devices.values.return_value = [other_entry, bad_identifier]
+
+        with patch(
+            "homeassistant.helpers.device_registry.async_get",
+            return_value=mock_registry,
+        ):
+            assert coordinator._device_from_registry() is None
+
+        with patch(
+            "homeassistant.helpers.device_registry.async_get",
+            side_effect=RuntimeError("registry unavailable"),
+        ):
+            assert coordinator._device_from_registry() is None
+
+        with patch(
+            "homeassistant.helpers.device_registry.async_get",
+            return_value=None,
+        ):
+            assert coordinator._device_from_registry() is None
+
+        empty_registry = MagicMock()
+        empty_registry.devices = None
+        with patch(
+            "homeassistant.helpers.device_registry.async_get",
+            return_value=empty_registry,
+        ):
+            assert coordinator._device_from_registry() is None
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    def test_device_id_property_without_device(self, mock_super_init):
+        coordinator, _ = self._make_coordinator(mock_super_init, modbus=True)
+        coordinator._device = None
+        assert coordinator.device_id is None
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    def test_current_username_requires_non_empty_string(self, mock_super_init):
+        coordinator, _ = self._make_coordinator(mock_super_init, modbus=True)
+        coordinator._config_entry.data = {"username": 123}
+        assert coordinator._current_username() is None
+        coordinator._config_entry.data = {"username": ""}
+        assert coordinator._current_username() is None

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -96,7 +96,6 @@ def test_has_write_access_treats_cleared_access_level_as_outage():
     maintenance_coordinator = MagicMock()
     maintenance_coordinator.data = {
         "firmware_versions": {"display_fw_version": "1.3.6"},
-        "access_level": None,
     }
     coordinator.config_entry.runtime_data = MagicMock(
         maintenance_coordinator=maintenance_coordinator

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -87,6 +87,30 @@ def test_has_write_access_allows_modbus_metric_when_cloud_unavailable():
     assert entity._has_write_access is True
 
 
+def test_has_write_access_treats_empty_maintenance_data_as_outage():
+    """An empty maintenance payload is an outage, not a write denial."""
+    from custom_components.qvantum.coordinator import QvantumDataUpdateCoordinator
+
+    coordinator = QvantumDataUpdateCoordinator.__new__(QvantumDataUpdateCoordinator)
+    coordinator.config_entry = MagicMock()
+    maintenance_coordinator = MagicMock()
+    maintenance_coordinator.data = {}
+    coordinator.config_entry.runtime_data = MagicMock(
+        maintenance_coordinator=maintenance_coordinator
+    )
+
+    class DummyModbusWriteEntity(QvantumAccessMixin):
+        def __init__(self, coordinator):
+            self.coordinator = coordinator
+            self._write_access_warning_logged = False
+
+        def _local_write_available(self):
+            return True
+
+    entity = DummyModbusWriteEntity(coordinator)
+    assert entity._has_write_access is True
+
+
 def test_has_write_access_treats_cleared_access_level_as_outage():
     """Stale firmware data with a cleared access_level uses the local fallback."""
     from custom_components.qvantum.coordinator import QvantumDataUpdateCoordinator
@@ -137,6 +161,28 @@ def test_has_write_access_enabled_when_write_level_sufficient():
 
     entity = DummyAccessEntity(coordinator)
     assert entity._has_write_access is True
+
+
+def test_has_write_access_uses_live_access_level_on_qvantum_coordinator():
+    """A successful cloud check still gates writes on writeAccessLevel."""
+    from custom_components.qvantum.coordinator import QvantumDataUpdateCoordinator
+
+    coordinator = QvantumDataUpdateCoordinator.__new__(QvantumDataUpdateCoordinator)
+    coordinator.config_entry = MagicMock()
+    maintenance_coordinator = MagicMock()
+    maintenance_coordinator.data = {"access_level": {"writeAccessLevel": 20}}
+    coordinator.config_entry.runtime_data = MagicMock(
+        maintenance_coordinator=maintenance_coordinator
+    )
+
+    entity = DummyAccessEntity(coordinator)
+    assert entity._has_write_access is True
+
+    maintenance_coordinator.data = {"access_level": {"writeAccessLevel": 10}}
+    assert entity._has_write_access is False
+
+    maintenance_coordinator.data = {"access_level": 0}
+    assert entity._has_write_access is False
 
 
 def test_resolve_device_id_from_identifier():

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -34,7 +34,80 @@ def test_has_write_access_allows_modbus_write_when_cloud_unavailable():
             self.coordinator = coordinator
             self._write_access_warning_logged = False
 
-        def _is_modbus_write_allowed(self):
+        def _local_write_available(self):
+            return True
+
+    entity = DummyModbusWriteEntity(coordinator)
+    assert entity._has_write_access is True
+
+
+def test_has_write_access_denies_http_only_entity_when_cloud_unavailable():
+    """HTTP-backed Qvantum entities must not become writable during an outage."""
+    from custom_components.qvantum.coordinator import QvantumDataUpdateCoordinator
+    from custom_components.qvantum.const import CONF_MODBUS_TCP, CONF_MODBUS_WRITE
+
+    coordinator = QvantumDataUpdateCoordinator.__new__(QvantumDataUpdateCoordinator)
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.options = {
+        CONF_MODBUS_TCP: True,
+        CONF_MODBUS_WRITE: True,
+    }
+    coordinator.config_entry.data = {}
+    coordinator.config_entry.runtime_data = MagicMock()
+    coordinator.config_entry.runtime_data.maintenance_coordinator = None
+
+    entity = QvantumEntity.__new__(QvantumEntity)
+    entity.coordinator = coordinator
+    entity._write_access_warning_logged = False
+    entity._metric_key = "extra_tap_water"
+
+    assert entity._has_write_access is False
+
+
+def test_has_write_access_allows_modbus_metric_when_cloud_unavailable():
+    """Entities that write via holding registers stay available offline."""
+    from custom_components.qvantum.coordinator import QvantumDataUpdateCoordinator
+    from custom_components.qvantum.const import CONF_MODBUS_TCP, CONF_MODBUS_WRITE
+
+    coordinator = QvantumDataUpdateCoordinator.__new__(QvantumDataUpdateCoordinator)
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.options = {
+        CONF_MODBUS_TCP: True,
+        CONF_MODBUS_WRITE: True,
+    }
+    coordinator.config_entry.data = {}
+    coordinator.config_entry.runtime_data = MagicMock()
+    coordinator.config_entry.runtime_data.maintenance_coordinator = None
+
+    entity = QvantumEntity.__new__(QvantumEntity)
+    entity.coordinator = coordinator
+    entity._write_access_warning_logged = False
+    entity._metric_key = "room_temp_external"
+
+    assert entity._has_write_access is True
+
+
+def test_has_write_access_treats_cleared_access_level_as_outage():
+    """Stale firmware data with a cleared access_level uses the local fallback."""
+    from custom_components.qvantum.coordinator import QvantumDataUpdateCoordinator
+
+    coordinator = QvantumDataUpdateCoordinator.__new__(QvantumDataUpdateCoordinator)
+    coordinator.config_entry = MagicMock()
+    maintenance_coordinator = MagicMock()
+    maintenance_coordinator.data = {
+        "firmware_versions": {"display_fw_version": "1.3.6"},
+        "access_level": None,
+    }
+    coordinator.config_entry.runtime_data = MagicMock(
+        maintenance_coordinator=maintenance_coordinator
+    )
+
+    class DummyModbusWriteEntity(QvantumAccessMixin):
+        def __init__(self, coordinator):
+            self.coordinator = coordinator
+            self._write_access_warning_logged = False
+
+        def _local_write_available(self):
             return True
 
     entity = DummyModbusWriteEntity(coordinator)

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -20,6 +20,27 @@ def test_has_write_access_maintenance_entity():
     assert entity._has_write_access is True
 
 
+def test_has_write_access_allows_modbus_write_when_cloud_unavailable():
+    """Local Modbus writes stay available when the HTTP API cannot be checked."""
+    from custom_components.qvantum.coordinator import QvantumDataUpdateCoordinator
+
+    coordinator = QvantumDataUpdateCoordinator.__new__(QvantumDataUpdateCoordinator)
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.runtime_data = MagicMock()
+    coordinator.config_entry.runtime_data.maintenance_coordinator = None
+
+    class DummyModbusWriteEntity(QvantumAccessMixin):
+        def __init__(self, coordinator):
+            self.coordinator = coordinator
+            self._write_access_warning_logged = False
+
+        def _is_modbus_write_allowed(self):
+            return True
+
+    entity = DummyModbusWriteEntity(coordinator)
+    assert entity._has_write_access is True
+
+
 def test_has_write_access_denies_without_data():
     """Missing runtime_data should deny write access and log warning once."""
     from custom_components.qvantum.coordinator import QvantumDataUpdateCoordinator

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,6 +12,7 @@ from custom_components.qvantum import (
     async_migrate_entry,
     PLATFORMS,
     _async_update_listener,
+    _coordinator_device,
     _has_required_device,
     _device_sw_version,
 )
@@ -40,6 +41,20 @@ class TestSetupDeviceRequirements:
     def test_device_sw_version_omits_empty(self):
         assert _device_sw_version({}) is None
         assert _device_sw_version({"display_fw_version": "1.0"}) == "1.0//"
+
+    def test_coordinator_device_handles_missing_or_invalid_payload(self):
+        coordinator = MagicMock()
+        coordinator.data = None
+        assert _coordinator_device(coordinator) == {}
+
+        coordinator.data = "not-a-dict"
+        assert _coordinator_device(coordinator) == {}
+
+        coordinator.data = {"device": "not-a-dict"}
+        assert _coordinator_device(coordinator) == {}
+
+        coordinator.data = {"device": {"id": "abc"}}
+        assert _coordinator_device(coordinator) == {"id": "abc"}
 
 
 class TestIntegrationSetup:
@@ -475,6 +490,86 @@ class TestIntegrationSetup:
             result = await async_setup_entry(hass, mock_config_entry)
 
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_async_setup_entry_http_timeout_raises_not_ready(
+        self, hass, mock_config_entry, mock_api, mock_coordinator
+    ):
+        """HTTP mode must surface a hung firmware check as ConfigEntryNotReady."""
+        from homeassistant.exceptions import ConfigEntryNotReady
+
+        mock_config_entry.options = {}
+        mock_coordinator.data = {
+            "device": {
+                "id": "test_device_123",
+                "model": "QE-6",
+                "vendor": "Qvantum",
+                "device_metadata": {"display_fw_version": "1.0"},
+            },
+            "values": {},
+        }
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.async_restore_dhw_state = AsyncMock()
+
+        mock_firmware_coordinator = MagicMock()
+        mock_firmware_coordinator.async_config_entry_first_refresh = AsyncMock(
+            side_effect=TimeoutError()
+        )
+
+        with (
+            patch("custom_components.qvantum.QvantumAPI", return_value=mock_api),
+            patch(
+                "custom_components.qvantum.QvantumDataUpdateCoordinator",
+                return_value=mock_coordinator,
+            ),
+            patch(
+                "custom_components.qvantum.QvantumMaintenanceCoordinator",
+                return_value=mock_firmware_coordinator,
+            ),
+            patch("custom_components.qvantum.services.async_setup_services"),
+        ):
+            with pytest.raises(ConfigEntryNotReady, match="timed out"):
+                await async_setup_entry(hass, mock_config_entry)
+
+    @pytest.mark.asyncio
+    async def test_async_setup_entry_http_not_ready_propagates(
+        self, hass, mock_config_entry, mock_api, mock_coordinator
+    ):
+        """HTTP mode must not swallow ConfigEntryNotReady from firmware check."""
+        from homeassistant.exceptions import ConfigEntryNotReady
+
+        mock_config_entry.options = {}
+        mock_coordinator.data = {
+            "device": {
+                "id": "test_device_123",
+                "model": "QE-6",
+                "vendor": "Qvantum",
+                "device_metadata": {"display_fw_version": "1.0"},
+            },
+            "values": {},
+        }
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.async_restore_dhw_state = AsyncMock()
+
+        mock_firmware_coordinator = MagicMock()
+        mock_firmware_coordinator.async_config_entry_first_refresh = AsyncMock(
+            side_effect=ConfigEntryNotReady("HTTP API down")
+        )
+
+        with (
+            patch("custom_components.qvantum.QvantumAPI", return_value=mock_api),
+            patch(
+                "custom_components.qvantum.QvantumDataUpdateCoordinator",
+                return_value=mock_coordinator,
+            ),
+            patch(
+                "custom_components.qvantum.QvantumMaintenanceCoordinator",
+                return_value=mock_firmware_coordinator,
+            ),
+            patch("custom_components.qvantum.services.async_setup_services"),
+        ):
+            with pytest.raises(ConfigEntryNotReady, match="HTTP API down"):
+                await async_setup_entry(hass, mock_config_entry)
 
     @pytest.mark.asyncio
     async def test_async_setup_entry_empty_device_metadata_fails(self, hass, mock_config_entry):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,10 +12,34 @@ from custom_components.qvantum import (
     async_migrate_entry,
     PLATFORMS,
     _async_update_listener,
+    _has_required_device,
+    _device_sw_version,
 )
 
 # Mock HA imports after importing real functions
 # sys.modules['custom_components.qvantum'] = MagicMock()
+
+
+class TestSetupDeviceRequirements:
+    """Unit tests for setup device-identity helpers."""
+
+    def test_has_required_device_http_needs_metadata(self):
+        assert _has_required_device({"id": "abc"}, require_metadata=True) is False
+        assert (
+            _has_required_device(
+                {"id": "abc", "device_metadata": {"display_fw_version": "1"}},
+                require_metadata=True,
+            )
+            is True
+        )
+
+    def test_has_required_device_modbus_needs_id_only(self):
+        assert _has_required_device({}, require_metadata=False) is False
+        assert _has_required_device({"id": "abc"}, require_metadata=False) is True
+
+    def test_device_sw_version_omits_empty(self):
+        assert _device_sw_version({}) is None
+        assert _device_sw_version({"display_fw_version": "1.0"}) == "1.0/None/None"
 
 
 class TestIntegrationSetup:
@@ -331,6 +355,86 @@ class TestIntegrationSetup:
             mock_config_entry.entry_id
         )
         mock_coordinator.apply_poll_interval.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_setup_entry_modbus_without_metadata_succeeds(
+        self, hass, mock_config_entry, mock_api, mock_coordinator
+    ):
+        """Modbus setup should succeed with a device id even if cloud metadata is missing."""
+        mock_config_entry.options = {"modbus_tcp": True}
+        mock_coordinator.data = {
+            "device": {
+                "id": "test_device_123",
+                "model": "QE-6",
+                "vendor": "Qvantum",
+            },
+            "values": {},
+        }
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.async_restore_dhw_state = AsyncMock()
+        mock_config_entry.add_update_listener = MagicMock()
+
+        mock_firmware_coordinator = MagicMock()
+        mock_firmware_coordinator.async_config_entry_first_refresh = AsyncMock()
+
+        with (
+            patch("custom_components.qvantum.QvantumAPI", return_value=mock_api),
+            patch(
+                "custom_components.qvantum.QvantumDataUpdateCoordinator",
+                return_value=mock_coordinator,
+            ),
+            patch(
+                "custom_components.qvantum.QvantumMaintenanceCoordinator",
+                return_value=mock_firmware_coordinator,
+            ),
+            patch("custom_components.qvantum.services.async_setup_services"),
+        ):
+            result = await async_setup_entry(hass, mock_config_entry)
+
+        assert result is True
+        hass.config_entries.async_forward_entry_setups.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_setup_entry_modbus_continues_when_maintenance_http_down(
+        self, hass, mock_config_entry, mock_api, mock_coordinator
+    ):
+        """A down cloud API must not block Modbus setup at firmware-check time."""
+        from homeassistant.exceptions import ConfigEntryNotReady
+
+        mock_config_entry.options = {"modbus_tcp": True}
+        mock_coordinator.data = {
+            "device": {
+                "id": "test_device_123",
+                "model": "QE-6",
+                "vendor": "Qvantum",
+                "device_metadata": {"display_fw_version": "1.0"},
+            },
+            "values": {},
+        }
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.async_restore_dhw_state = AsyncMock()
+        mock_config_entry.add_update_listener = MagicMock()
+
+        mock_firmware_coordinator = MagicMock()
+        mock_firmware_coordinator.async_config_entry_first_refresh = AsyncMock(
+            side_effect=ConfigEntryNotReady("HTTP API down")
+        )
+
+        with (
+            patch("custom_components.qvantum.QvantumAPI", return_value=mock_api),
+            patch(
+                "custom_components.qvantum.QvantumDataUpdateCoordinator",
+                return_value=mock_coordinator,
+            ),
+            patch(
+                "custom_components.qvantum.QvantumMaintenanceCoordinator",
+                return_value=mock_firmware_coordinator,
+            ),
+            patch("custom_components.qvantum.services.async_setup_services"),
+        ):
+            result = await async_setup_entry(hass, mock_config_entry)
+
+        assert result is True
 
     @pytest.mark.asyncio
     async def test_async_setup_entry_empty_device_metadata_fails(self, hass, mock_config_entry):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -39,7 +39,7 @@ class TestSetupDeviceRequirements:
 
     def test_device_sw_version_omits_empty(self):
         assert _device_sw_version({}) is None
-        assert _device_sw_version({"display_fw_version": "1.0"}) == "1.0/None/None"
+        assert _device_sw_version({"display_fw_version": "1.0"}) == "1.0//"
 
 
 class TestIntegrationSetup:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -437,6 +437,46 @@ class TestIntegrationSetup:
         assert result is True
 
     @pytest.mark.asyncio
+    async def test_async_setup_entry_modbus_continues_when_maintenance_times_out(
+        self, hass, mock_config_entry, mock_api, mock_coordinator
+    ):
+        """A hung cloud firmware check must not stall Modbus setup."""
+        mock_config_entry.options = {"modbus_tcp": True}
+        mock_coordinator.data = {
+            "device": {
+                "id": "test_device_123",
+                "model": "QE-6",
+                "vendor": "Qvantum",
+                "device_metadata": {"display_fw_version": "1.0"},
+            },
+            "values": {},
+        }
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.async_restore_dhw_state = AsyncMock()
+        mock_config_entry.add_update_listener = MagicMock()
+
+        mock_firmware_coordinator = MagicMock()
+        mock_firmware_coordinator.async_config_entry_first_refresh = AsyncMock(
+            side_effect=TimeoutError()
+        )
+
+        with (
+            patch("custom_components.qvantum.QvantumAPI", return_value=mock_api),
+            patch(
+                "custom_components.qvantum.QvantumDataUpdateCoordinator",
+                return_value=mock_coordinator,
+            ),
+            patch(
+                "custom_components.qvantum.QvantumMaintenanceCoordinator",
+                return_value=mock_firmware_coordinator,
+            ),
+            patch("custom_components.qvantum.services.async_setup_services"),
+        ):
+            result = await async_setup_entry(hass, mock_config_entry)
+
+        assert result is True
+
+    @pytest.mark.asyncio
     async def test_async_setup_entry_empty_device_metadata_fails(self, hass, mock_config_entry):
         mock_api = MagicMock()
         mock_api.get_primary_device = AsyncMock(return_value={"id": "device123"})

--- a/tests/test_maintenance_coordinator.py
+++ b/tests/test_maintenance_coordinator.py
@@ -5,6 +5,7 @@ import pytest_asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
+from custom_components.qvantum.api import APIAuthError
 from custom_components.qvantum.maintenance_coordinator import (
     QvantumMaintenanceCoordinator,
 )
@@ -225,6 +226,40 @@ class TestQvantumMaintenanceCoordinator:
 
         assert result["access_level"] is None
         assert result["firmware_versions"]["display_fw_version"] == "1.3.6"
+
+    @pytest.mark.asyncio
+    async def test_async_check_firmware_updates_auth_error_modbus_clears_access(
+        self, maintenance_coordinator, mock_main_coordinator
+    ):
+        """Auth failures in Modbus mode must not keep a previous access_level."""
+        mock_main_coordinator.modbus_enabled = True
+        maintenance_coordinator.data = {
+            "firmware_versions": {"display_fw_version": "1.3.6"},
+            "access_level": {"writeAccessLevel": 20},
+        }
+        maintenance_coordinator.api.get_device_metadata = AsyncMock(
+            side_effect=APIAuthError(None, "token refresh failed")
+        )
+
+        result = await maintenance_coordinator.async_check_firmware_updates()
+
+        assert result["access_level"] is None
+        assert result["firmware_versions"]["display_fw_version"] == "1.3.6"
+
+    @pytest.mark.asyncio
+    async def test_async_check_firmware_updates_auth_error_http_still_fails(
+        self, maintenance_coordinator, mock_main_coordinator
+    ):
+        """HTTP mode still treats authentication errors as a failed update."""
+        from homeassistant.helpers.update_coordinator import UpdateFailed
+
+        mock_main_coordinator.modbus_enabled = False
+        maintenance_coordinator.api.get_device_metadata = AsyncMock(
+            side_effect=APIAuthError(None, "token refresh failed")
+        )
+
+        with pytest.raises(UpdateFailed):
+            await maintenance_coordinator.async_check_firmware_updates()
 
     @pytest.mark.asyncio
     async def test_create_firmware_update_notifications(

--- a/tests/test_maintenance_coordinator.py
+++ b/tests/test_maintenance_coordinator.py
@@ -206,7 +206,7 @@ class TestQvantumMaintenanceCoordinator:
 
         result = await maintenance_coordinator.async_check_firmware_updates()
 
-        assert result["access_level"] is None
+        assert "access_level" not in result
 
     @pytest.mark.asyncio
     async def test_async_check_firmware_updates_http_down_clears_stale_access(
@@ -224,7 +224,7 @@ class TestQvantumMaintenanceCoordinator:
 
         result = await maintenance_coordinator.async_check_firmware_updates()
 
-        assert result["access_level"] is None
+        assert "access_level" not in result
         assert result["firmware_versions"]["display_fw_version"] == "1.3.6"
 
     @pytest.mark.asyncio
@@ -243,7 +243,7 @@ class TestQvantumMaintenanceCoordinator:
 
         result = await maintenance_coordinator.async_check_firmware_updates()
 
-        assert result["access_level"] is None
+        assert "access_level" not in result
         assert result["firmware_versions"]["display_fw_version"] == "1.3.6"
 
     @pytest.mark.asyncio

--- a/tests/test_maintenance_coordinator.py
+++ b/tests/test_maintenance_coordinator.py
@@ -205,7 +205,26 @@ class TestQvantumMaintenanceCoordinator:
 
         result = await maintenance_coordinator.async_check_firmware_updates()
 
-        assert result == {}
+        assert result["access_level"] is None
+
+    @pytest.mark.asyncio
+    async def test_async_check_firmware_updates_http_down_clears_stale_access(
+        self, maintenance_coordinator, mock_main_coordinator
+    ):
+        """A later outage must not keep a previous access_level in effect."""
+        mock_main_coordinator.modbus_enabled = True
+        maintenance_coordinator.data = {
+            "firmware_versions": {"display_fw_version": "1.3.6"},
+            "access_level": {"writeAccessLevel": 20},
+        }
+        maintenance_coordinator.api.get_device_metadata = AsyncMock(
+            side_effect=Exception("HTTP API down")
+        )
+
+        result = await maintenance_coordinator.async_check_firmware_updates()
+
+        assert result["access_level"] is None
+        assert result["firmware_versions"]["display_fw_version"] == "1.3.6"
 
     @pytest.mark.asyncio
     async def test_create_firmware_update_notifications(

--- a/tests/test_maintenance_coordinator.py
+++ b/tests/test_maintenance_coordinator.py
@@ -39,6 +39,7 @@ class TestQvantumMaintenanceCoordinator:
             }
         }
         coordinator._device = coordinator.data["device"]
+        coordinator.modbus_enabled = False
         return coordinator
 
     @pytest_asyncio.fixture
@@ -191,6 +192,20 @@ class TestQvantumMaintenanceCoordinator:
 
         with pytest.raises(Exception):
             await maintenance_coordinator.async_check_firmware_updates()
+
+    @pytest.mark.asyncio
+    async def test_async_check_firmware_updates_http_down_modbus_continues(
+        self, maintenance_coordinator, mock_main_coordinator
+    ):
+        """Modbus mode must not fail firmware check when the HTTP API is down."""
+        mock_main_coordinator.modbus_enabled = True
+        maintenance_coordinator.api.get_device_metadata = AsyncMock(
+            side_effect=Exception("HTTP API down")
+        )
+
+        result = await maintenance_coordinator.async_check_firmware_updates()
+
+        assert result == {}
 
     @pytest.mark.asyncio
     async def test_create_firmware_update_notifications(

--- a/tests/test_maintenance_coordinator.py
+++ b/tests/test_maintenance_coordinator.py
@@ -63,6 +63,20 @@ class TestQvantumMaintenanceCoordinator:
             )
         return coordinator
 
+    def test_passes_config_entry_to_parent(
+        self, hass, mock_config_entry, mock_main_coordinator
+    ):
+        """Parent DataUpdateCoordinator must receive config_entry explicitly."""
+        from custom_components.qvantum.const import DOMAIN
+
+        hass.data[DOMAIN] = MagicMock()
+        coordinator = QvantumMaintenanceCoordinator(
+            hass=hass,
+            config_entry=mock_config_entry,
+            main_coordinator=mock_main_coordinator,
+        )
+        assert coordinator.config_entry is mock_config_entry
+
     @pytest.mark.asyncio
     async def test_async_check_firmware_updates_no_device(
         self, maintenance_coordinator, mock_main_coordinator


### PR DESCRIPTION
This pull request introduces robust fallback mechanisms and improved reliability for the Qvantum Home Assistant integration, especially for scenarios where the cloud API is unavailable. The main themes are: enabling Modbus mode to start independently of the cloud API, persisting device identity for offline startup, handling firmware checks gracefully during cloud outages, and ensuring entity write access logic is correct when the cloud is down. The changes also improve error logging and code maintainability.

**Startup reliability and Modbus fallback:**

* Added logic in `QvantumDataUpdateCoordinator` to persist and restore device identity, allowing Modbus mode to start even if the cloud API is unavailable. Device identity is loaded from cache, the device registry, or fetched from the cloud as needed (`coordinator.py`). [[1]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fR243-R370) [[2]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fL460-R609)
* Introduced a timeout (`HTTP_CLOUD_LOOKUP_TIMEOUT`) for cloud lookups so that a down cloud API cannot indefinitely block Modbus startup (`const.py`, `__init__.py`, `coordinator.py`). [[1]](diffhunk://#diff-07fd7ac76e58c80e95bb6c9ca3ff34f8c124f4a881a23cd946cfefaa5719e953R36-R37) [[2]](diffhunk://#diff-f300fba86f000d6d8711727fe08b5370e23b650afd4a3918292d8ce003200eb8R42) [[3]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fR39-R46) [[4]](diffhunk://#diff-f300fba86f000d6d8711727fe08b5370e23b650afd4a3918292d8ce003200eb8L139-R190)

**Device info and firmware version handling:**

* Added helpers to format and parse firmware versions for device info, ensuring correct restoration and display of firmware metadata (`__init__.py`, `coordinator.py`). [[1]](diffhunk://#diff-f300fba86f000d6d8711727fe08b5370e23b650afd4a3918292d8ce003200eb8R64-R95) [[2]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fR86-R98)

**Entity write access logic:**

* Improved entity write access checks to allow local Modbus writes when the cloud API is down, while ensuring HTTP-backed entities do not become writable just because Modbus is enabled (`entity.py`). [[1]](diffhunk://#diff-46476246b1f100aed1892d0fbacd6705ae0ad1d4eee38f1cb2709de7e0d78384L54-R62) [[2]](diffhunk://#diff-46476246b1f100aed1892d0fbacd6705ae0ad1d4eee38f1cb2709de7e0d78384R75-R87) [[3]](diffhunk://#diff-46476246b1f100aed1892d0fbacd6705ae0ad1d4eee38f1cb2709de7e0d78384R169-R175)

**Cloud outage handling for maintenance:**

* Modified firmware/access checks to retain previous firmware data but clear stale authorization if the cloud is unavailable, allowing local Modbus operation to continue (`maintenance_coordinator.py`).

**Other improvements:**

* Enhanced error logging with device IDs and improved test mocks for persistent storage (`coordinator.py`, `tests/conftest.py`). [[1]](diffhunk://#diff-65dc9f1833d81992fe30b5f001545f3dc56c2a104be05a9850f1ae038ea1030fL562-R732) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R32-R36)

These changes significantly improve the resilience and user experience of the integration, particularly for installations relying on local Modbus control.