### PR TITLE
feat: Adopt modbus-connection with shared HA units and pooled reads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13", "3.14"]
+        python-version: ["3.14"]
 
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Disrupting the ordinary takes courage, but with experience, deep knowledge and d
 
 ### Installation
 
+Requires Home Assistant **2026.9** or newer (shared Modbus connection).
+
 1. **Install via HACS** (recommended):
    - Search for "Qvantum Heat Pump" in HACS
    - Install the Qvantum Heat Pump integration

--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -518,10 +518,11 @@ async def async_migrate_entry(hass, config_entry: ConfigEntry):
 async def async_unload_entry(hass: HomeAssistant, config_entry: MyConfigEntry) -> bool:
     """Unload Qvantum Heat Pump Integration.
 
-    Shut down coordinators before closing the shared API client so in-flight
-    Modbus/HTTP polls are cancelled cleanly. Otherwise a poll cancelled mid-
-    request can fall back to HTTP against a closed session, or leave the Modbus
-    half-open so the next setup cannot reconnect without a full HA restart.
+    Shut down coordinators before closing the HTTP API client so in-flight
+    polls are cancelled first. Otherwise a cancelled Modbus poll can fall
+    back to HTTP against a session that is already closing. The shared
+    Modbus TCP connection is released by Home Assistant when this config
+    entry unloads; this integration never closes it.
     """
     runtime = getattr(config_entry, "runtime_data", None)
 

--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -13,7 +13,7 @@ from homeassistant.const import Platform
 from homeassistant.core import callback
 from homeassistant.const import MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -36,6 +36,8 @@ from .const import (
     FIRMWARE_KEYS,
     CONF_MODBUS_TCP,
     CONF_MODBUS_HOST,
+    CONF_MODBUS_PORT,
+    CONF_MODBUS_UNIT_ID,
     DEFAULT_MODBUS_HOST,
     DEFAULT_MODBUS_PORT,
     DEFAULT_MODBUS_UNIT_ID,
@@ -59,6 +61,51 @@ PLATFORMS: list[Platform] = [
 ]
 
 type MyConfigEntry = ConfigEntry[RuntimeData]
+
+
+def _modbus_link_settings(config_entry: ConfigEntry) -> tuple[bool, str, int, int]:
+    """Return (enabled, host, port, unit_id) from entry options/data."""
+    enabled = bool(
+        config_entry.options.get(
+            CONF_MODBUS_TCP,
+            config_entry.data.get(CONF_MODBUS_TCP, False),
+        )
+    )
+    host = str(
+        config_entry.options.get(
+            CONF_MODBUS_HOST,
+            config_entry.data.get(CONF_MODBUS_HOST, DEFAULT_MODBUS_HOST),
+        )
+    )
+    port = int(
+        config_entry.options.get(
+            CONF_MODBUS_PORT,
+            config_entry.data.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT),
+        )
+    )
+    unit_id = int(
+        config_entry.options.get(
+            CONF_MODBUS_UNIT_ID,
+            config_entry.data.get(CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID),
+        )
+    )
+    return enabled, host, port, unit_id
+
+
+def _async_modbus_unit(hass: HomeAssistant, config_entry: ConfigEntry):
+    """Borrow a unit from the shared Home Assistant Modbus connection."""
+    enabled, host, port, unit_id = _modbus_link_settings(config_entry)
+    if not enabled:
+        return None
+    from homeassistant.components.modbus import async_get_unit
+    from modbus_connection import ModbusTcpParams
+
+    return async_get_unit(
+        hass,
+        config_entry,
+        ModbusTcpParams(host=host, port=port),
+        unit_id,
+    )
 
 
 def _coordinator_device(coordinator: QvantumDataUpdateCoordinator) -> dict:
@@ -109,14 +156,16 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) ->
     password = config_entry.data[CONF_PASSWORD]
     user_agent = f"Home Assistant/{MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION} Qvantum/{VERSION}"
 
-    modbus_enabled = config_entry.options.get(
-        CONF_MODBUS_TCP,
-        config_entry.data.get(CONF_MODBUS_TCP, False),
+    modbus_enabled, modbus_host, modbus_port, modbus_unit_id = _modbus_link_settings(
+        config_entry
     )
-    modbus_host = config_entry.options.get(
-        CONF_MODBUS_HOST,
-        config_entry.data.get(CONF_MODBUS_HOST, DEFAULT_MODBUS_HOST),
-    )
+    try:
+        modbus_unit = _async_modbus_unit(hass, config_entry)
+    except HomeAssistantError as err:
+        raise ConfigEntryNotReady(
+            f"Modbus connection for {modbus_host}:{modbus_port} is already in use "
+            f"with different link settings: {err}"
+        ) from err
 
     hass.data[DOMAIN] = QvantumAPI(
         username=username,
@@ -124,8 +173,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) ->
         user_agent=user_agent,
         modbus_tcp=modbus_enabled,
         modbus_host=modbus_host,
-        modbus_port=DEFAULT_MODBUS_PORT,
-        modbus_unit_id=DEFAULT_MODBUS_UNIT_ID,
+        modbus_port=modbus_port,
+        modbus_unit_id=modbus_unit_id,
+        modbus_unit=modbus_unit,
     )
     hass.data[DOMAIN].hass = hass
 
@@ -204,35 +254,26 @@ def _modbus_transport_changed(
     config_entry: ConfigEntry, runtime: RuntimeData
 ) -> bool:
     """Return True when Modbus enablement or host requires a full reload."""
-    new_modbus_enabled = bool(
-        config_entry.options.get(
-            CONF_MODBUS_TCP,
-            config_entry.data.get(CONF_MODBUS_TCP, False),
-        )
-    )
-    new_modbus_host = str(
-        config_entry.options.get(
-            CONF_MODBUS_HOST,
-            config_entry.data.get(CONF_MODBUS_HOST, DEFAULT_MODBUS_HOST),
-        )
-    )
+    new_enabled, new_host, new_port, new_unit_id = _modbus_link_settings(config_entry)
 
     coordinator = getattr(runtime, "coordinator", None)
     if coordinator is None:
         return True
 
-    if new_modbus_enabled != bool(getattr(coordinator, "modbus_enabled", False)):
+    if new_enabled != bool(getattr(coordinator, "modbus_enabled", False)):
         return True
 
     api = getattr(coordinator, "api", None)
     if api is not None:
-        current_host = str(getattr(api, "_modbus_host", DEFAULT_MODBUS_HOST))
-        if new_modbus_host != current_host:
+        if new_host != str(getattr(api, "_modbus_host", DEFAULT_MODBUS_HOST)):
             return True
-        current_enabled = bool(
-            getattr(api, "_modbus_tcp", coordinator.modbus_enabled)
-        )
-        if new_modbus_enabled != current_enabled:
+        if new_port != int(getattr(api, "_modbus_port", DEFAULT_MODBUS_PORT)):
+            return True
+        if new_unit_id != int(
+            getattr(api, "_modbus_unit_id", DEFAULT_MODBUS_UNIT_ID)
+        ):
+            return True
+        if new_enabled != bool(getattr(api, "_modbus_tcp", coordinator.modbus_enabled)):
             return True
 
     return False
@@ -479,7 +520,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: MyConfigEntry) -
 
     Shut down coordinators before closing the shared API client so in-flight
     Modbus/HTTP polls are cancelled cleanly. Otherwise a poll cancelled mid-
-    request can fall back to HTTP against a closed session, or leave pymodbus
+    request can fall back to HTTP against a closed session, or leave the Modbus
     half-open so the next setup cannot reconnect without a full HA restart.
     """
     runtime = getattr(config_entry, "runtime_data", None)

--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -2,36 +2,20 @@
 
 import aiohttp
 import asyncio
-import inspect
 import json
 from datetime import datetime, timedelta, timezone
 import logging
 from typing import Any, Optional
 
-from pymodbus.client.tcp import AsyncModbusTcpClient
-from pymodbus.pdu.register_message import (
-    ReadHoldingRegistersRequest,
-    ReadInputRegistersRequest,
-    WriteSingleRegisterRequest,
-)
-from pymodbus.exceptions import ModbusException
+from modbus_connection import ClientClosedError, ModbusError, ModbusUnit
 
 from .const import (
-    FAN_SPEED_STATE_EXTRA,
-    FAN_SPEED_STATE_NORMAL,
-    FAN_SPEED_STATE_OFF,
     DEFAULT_ENABLED_HTTP_METRICS,
     DEFAULT_ENABLED_MODBUS_METRICS,
     TAP_WATER_CAPACITY_MAPPINGS,
-    RELAY_STAGE_POWER_MAP,
-    BASE_SYSTEM_POWER_W,
 )
-from .modbus import (
-    MODBUS_INPUT_REGISTER_MAP,
-    MODBUS_HOLDING_REGISTER_MAP,
-    RELAY_BIT_MAP,
-    MODBUS_HOLDING_TO_SETTINGS_MAP,
-)
+from .modbus import MODBUS_HOLDING_REGISTER_MAP, MODBUS_HOLDING_TO_SETTINGS_MAP
+from .modbus_device import QvantumModbusDevice, holding_field_for_metric
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,6 +49,7 @@ class QvantumAPI:
         modbus_host: str = "qvantum-hp",
         modbus_port: int = 502,
         modbus_unit_id: int = 1,
+        modbus_unit: Optional[ModbusUnit] = None,
     ) -> None:
         """Initialise."""
         self._auth_url = AUTH_URL
@@ -78,7 +63,8 @@ class QvantumAPI:
         self._modbus_host = modbus_host
         self._modbus_port = modbus_port
         self._modbus_unit_id = modbus_unit_id
-        self._modbus_client = None
+        self._modbus_unit = modbus_unit
+        self._modbus_device: QvantumModbusDevice | None = None
         self._modbus_lock = asyncio.Lock()
         self._closed = False
         # Accept an optional aiohttp session for easier testing. If not provided,
@@ -113,46 +99,38 @@ class QvantumAPI:
         if self._closed:
             raise APIConnectionError(None, "API client is closed")
 
-    def _init_modbus_client(self):
-        """Initialize Modbus TCP client if not already done."""
+    def _ensure_modbus_device(self) -> QvantumModbusDevice | None:
+        """Return the device wrapper for the Home Assistant-owned Modbus unit."""
         if self._closed:
-            return
-        if self._modbus_tcp and self._modbus_client is None:
-            self._modbus_client = AsyncModbusTcpClient(
-                host=self._modbus_host,
-                port=self._modbus_port,
-                timeout=10.0,  # Increased timeout
-                retries=3,
-            )
+            return None
+        if not self._modbus_tcp:
+            return None
+        if self._modbus_device is None:
+            if self._modbus_unit is None:
+                return None
+            self._modbus_device = QvantumModbusDevice(self._modbus_unit)
+        return self._modbus_device
 
     async def _reset_modbus_client(self):
-        """Close and clear Modbus client so reconnect starts from scratch.
+        """Drop the device wrapper. The shared connection is owned by ``modbus``.
 
         Must only be called while holding ``_modbus_lock`` (or during final
         teardown after no more Modbus work can start).
         """
-        if self._modbus_client:
-            try:
-                close_result = self._modbus_client.close()
-                if inspect.isawaitable(close_result):
-                    await close_result
-            except Exception as exc:
-                _LOGGER.debug("Error closing modbus client during reset: %s", exc)
-            self._modbus_client = None
+        self._modbus_device = None
 
     async def close(self):
-        """Close HTTP session and Modbus client; reject further API use.
+        """Close HTTP session and stop Modbus use; reject further API use.
 
         Acquires the Modbus lock so an in-flight register read/write finishes
-        (or is cancelled by the coordinator) before the TCP client is torn down.
-        This avoids leaving a half-closed pymodbus client that blocks reconnects
-        after config option changes (e.g. poll interval reload).
+        before the wrapper is dropped. The TCP connection itself is owned by
+        Home Assistant's ``modbus`` integration and is released with the entry.
         """
         if self._closed:
             return
         self._closed = True
 
-        # Wait for any in-flight Modbus operation, then dispose the client.
+        # Wait for any in-flight Modbus operation, then drop the wrapper.
         async with self._modbus_lock:
             await self._reset_modbus_client()
 
@@ -168,283 +146,62 @@ class QvantumAPI:
                 _LOGGER.debug("Error closing HTTP session: %s", exc)
             self._session = None
 
-    def _normalize_modbus_value(self, value: float, scale: float) -> int | float:
-        """Normalize a Modbus register value to the correct type and precision."""
-        if scale == 1.0:
-            return int(value)
-        return round(value, 2)
-
-    async def _read_modbus_registers(
+    async def _run_modbus(
         self,
-        device_id: str,
-        enabled_items: list[str],
-        register_map: dict,
-        use_input_registers: bool = True,
-        handle_relay_bits: bool = False,
+        operation,
+        *,
+        error_label: str,
+        missing_client_message: str = "Modbus client not initialized",
+        failure_prefix: str = "Modbus communication failed",
     ):
-        """Generic method to read Modbus registers (input or holding)."""
+        """Run a Modbus device operation under the lock, mapping errors."""
         self._ensure_open()
         async with self._modbus_lock:
             self._ensure_open()
-            self._init_modbus_client()
-            if not self._modbus_client:
-                raise APIConnectionError(None, "Modbus client not initialized")
-
-            data = {}
-            data["hpid"] = device_id
-
+            device = self._ensure_modbus_device()
+            if not device:
+                raise APIConnectionError(None, missing_client_message)
             try:
-                if not self._modbus_client.connected:
-                    await self._modbus_client.connect()
-                    if not self._modbus_client.connected:
-                        raise APIConnectionError(None, "Modbus client connection failed")
-
-                # Collect all registers we need to read
-                registers_to_read = {}
-                relay_items = [] if handle_relay_bits else None
-
-                for item_name in enabled_items:
-                    if handle_relay_bits and item_name in RELAY_BIT_MAP:
-                        relay_items.append(item_name)
-                    elif item_name in register_map:
-                        addr, data_type, scale = register_map[item_name]
-                        registers_to_read[addr] = (item_name, data_type, scale, 1)
-
-                # Group registers into contiguous blocks for efficient reading
-                if registers_to_read:
-                    sorted_addresses = sorted(registers_to_read.keys())
-                    blocks = []
-                    current_block_start = sorted_addresses[0]
-                    current_block_end = sorted_addresses[0]
-
-                    for addr in sorted_addresses[1:]:
-                        if addr == current_block_end + 1:
-                            current_block_end = addr
-                        else:
-                            blocks.append((current_block_start, current_block_end))
-                            current_block_start = addr
-                            current_block_end = addr
-                    blocks.append((current_block_start, current_block_end))
-
-                    # Read each block
-                    for block_start, block_end in blocks:
-                        count = block_end - block_start + 1
-                        if use_input_registers:
-                            request = ReadInputRegistersRequest(
-                                dev_id=self._modbus_unit_id,
-                                address=block_start,
-                                count=count,
-                            )
-                        else:
-                            request = ReadHoldingRegistersRequest(
-                                dev_id=self._modbus_unit_id,
-                                address=block_start,
-                                count=count,
-                            )
-                        result = await self._modbus_client.execute(False, request)
-                        if result is None:
-                            raise APIConnectionError(
-                                None,
-                                "Modbus operation failed: no response received from device",
-                            )
-                        if result.isError():
-                            register_type = "input" if use_input_registers else "holding"
-                            _LOGGER.warning(
-                                f"Failed to read {register_type} register block {block_start}-{block_end}"
-                            )
-                            continue
-
-                        # Parse the block results
-                        for i, addr in enumerate(range(block_start, block_end + 1)):
-                            if addr in registers_to_read:
-                                item_name, data_type, scale, reg_count = registers_to_read[
-                                    addr
-                                ]
-                                if item_name in data:
-                                    continue  # Already processed this item
-
-                                if data_type in ("int16", "uint16"):
-                                    value = result.registers[i]
-                                    if data_type == "int16":
-                                        if value > 32767:
-                                            value -= 65536
-                                    value *= scale
-
-                                    data[item_name] = self._normalize_modbus_value(
-                                        value, scale
-                                    )
-
-                # Handle relay bit extraction from relays_bitmask
-                if handle_relay_bits and relay_items:
-                    bitmask_addr = register_map["relays_bitmask"][0]
-                    request = ReadInputRegistersRequest(
-                        dev_id=self._modbus_unit_id, address=bitmask_addr, count=1
-                    )
-                    result = await self._modbus_client.execute(False, request)
-                    if result is None:
-                        raise APIConnectionError(
-                            None,
-                            "Modbus operation failed: no response received from device",
-                        )
-                    if result.isError():
-                        _LOGGER.warning(
-                            f"Failed to read relays bitmask from register {bitmask_addr}"
-                        )
-                    else:
-                        bitmask = result.registers[0]
-                        for item_name in relay_items:
-                            bit = RELAY_BIT_MAP[item_name]
-                            value = (bitmask >> bit) & 1
-                            data[item_name] = value
-
+                return await operation(device)
             except asyncio.CancelledError:
-                # Reload/unload cancels in-flight polls; reset the client so the
-                # next setup does not inherit a half-closed TCP session.
-                await self._reset_modbus_client()
+                # Reload/unload cancels in-flight polls. Do not close or
+                # disconnect the shared connection; other consumers may hold it.
                 raise
-            except ModbusException as e:
-                error_msg = f"Modbus error reading {'input' if use_input_registers else 'holding'} registers: {e}"
-                _LOGGER.error(error_msg)
-                await self._reset_modbus_client()
-                raise APIConnectionError(None, f"Modbus communication failed: {e}")
-            except APIConnectionError:
-                await self._reset_modbus_client()
+            except ClientClosedError as err:
+                raise APIConnectionError(None, "API client is closed") from err
+            except ModbusError as err:
+                _LOGGER.error("Modbus error %s: %s", error_label, err)
+                raise APIConnectionError(None, f"{failure_prefix}: {err}") from err
+            except (APIConnectionError, ValueError):
                 raise
-            except Exception as e:
-                # Catch non-Modbus exceptions (e.g. NoneType on execute) and recover gracefully.
+            except Exception as err:
                 _LOGGER.error(
-                    "Unexpected error reading %s registers: %s",
-                    'input' if use_input_registers else 'holding',
-                    e,
-                    exc_info=True,
+                    "Unexpected error %s: %s", error_label, err, exc_info=True
                 )
-                await self._reset_modbus_client()
-                raise APIConnectionError(None, f"Modbus communication failed: {e}")
-
-            # Keep Modbus client open for subsequent reads to reuse the connection.
-            return data
+                raise APIConnectionError(None, f"{failure_prefix}: {err}") from err
 
     async def _read_modbus_metrics(self, device_id: str, enabled_metrics: list[str]):
         """Read metrics from Modbus TCP."""
-        metrics = await self._read_modbus_registers(
-            device_id=device_id,
-            enabled_items=enabled_metrics,
-            register_map=MODBUS_INPUT_REGISTER_MAP,
-            use_input_registers=True,
-            handle_relay_bits=True,
-        )
 
-        _LOGGER.debug("Raw Modbus metrics read: %s", sorted(metrics.items()))
-
-        # Derive use_adaptive from smart control modes if both are available
-        if "smart_dhw_mode" in metrics:
+        async def _update(device: QvantumModbusDevice):
+            await device.async_update_inputs()
+            payload = device.metrics_payload(device_id, enabled_metrics)
             _LOGGER.debug(
-                "Deriving smart_sh_mode and use_adaptive from smart_dhw_mode: %s",
-                metrics["smart_dhw_mode"],
+                "Raw Modbus metrics read: %s",
+                sorted(payload.get("metrics", {}).items()),
             )
-            # Both HTTP and Modbus use -1 to represent "smart control disabled".
-            # Any non-negative value indicates a specific smart/adaptive mode.
-            # Modbus specification is inconsistent here, so we standardize on -1 for disabled and 0/1/2 for modes.
-            # Mirror smart_dhw_mode into smart_sh_mode and derive use_adaptive from it.
-            metrics["smart_sh_mode"] = metrics["smart_dhw_mode"]
-            metrics["use_adaptive"] = metrics["smart_dhw_mode"] != -1
+            return payload
 
-        # Provide a combined power metric using compressor power and the three relay heat stages.
-        # Relay stage values are boolean (0/1), with each stage representing fixed wattage.
-        # power values are configured in const.py for maintainability and future model-specific changes.
-        stage_power_map = RELAY_STAGE_POWER_MAP
-        relay_sum = 0.0
-        for key, wattage in stage_power_map.items():
-            value = metrics.get(key, 0)
-            try:
-                relay_sum += float(value) * wattage
-            except (TypeError, ValueError):
-                continue
-
-        compressor_power = float(metrics.get("compressor_power", 0.0))
-        metrics.pop("compressor_power", None)
-
-        # Add fixed base power overhead from system baseline consumption.
-        # This includes circulation pumps, controls and other auxiliary constant loads.
-        metrics["powertotal"] = round(
-            BASE_SYSTEM_POWER_W + relay_sum + compressor_power, 2
-        )
-
-        # Compute energy from mwh/kwh components (preferred modbus format: kwh entry scaled x10).
-        # Only derive an energy counter when both components are present and numeric.
-        # This avoids synthesizing misleading 0 values during transient partial reads.
-        for prefix in ["compressor", "additional", "heating", "cooling", "dhw"]:
-            mwh = metrics.get(f"{prefix}_mwh")
-            kwh = metrics.get(f"{prefix}_kwh")
-            if mwh is not None and kwh is not None:
-                try:
-                    mwh_val = float(mwh)
-                    kwh_val = float(kwh)
-                except (TypeError, ValueError):
-                    _LOGGER.debug(
-                        "Skipping energy derivation for %s due to non-numeric components: mwh=%s, kwh=%s",
-                        prefix,
-                        mwh,
-                        kwh,
-                    )
-                else:
-                    # NOTE: kwh values in `metrics` are already normalized by the Modbus register map
-                    # (e.g. raw x10 register values have been de-scaled), so we can add them directly
-                    # to mwh * 1000.0 here without applying any additional scaling factor.
-                    metrics[f"{prefix}energy"] = round(mwh_val * 1000.0 + kwh_val, 2)
-            metrics.pop(f"{prefix}_mwh", None)
-            metrics.pop(f"{prefix}_kwh", None)
-
-            _LOGGER.debug(
-                "Computed energy for %s: mwh=%s, kwh=%s, total energy=%s",
-                prefix,
-                mwh,
-                kwh,
-                metrics.get(f"{prefix}energy"),
-            )
-
-        return {"metrics": metrics}
+        return await self._run_modbus(_update, error_label="reading input registers")
 
     async def _read_modbus_settings(self, device_id: str, enabled_settings: list[str]):
         """Read settings from Modbus TCP holding registers."""
-        settings = await self._read_modbus_registers(
-            device_id=device_id,
-            enabled_items=enabled_settings,
-            register_map=MODBUS_HOLDING_REGISTER_MAP,
-            use_input_registers=False,
-            handle_relay_bits=False,
-        )
 
-        # Convert to the same format as HTTP API and include original modbus keys for compatibility.
-        settings_dict: dict[str, Any] = {}
-        for k, v in settings.items():
-            if k == "hpid":
-                continue
-            settings_dict[k] = v
-            http_key = MODBUS_HOLDING_TO_SETTINGS_MAP.get(k)
-            if http_key and http_key != k:
-                settings_dict[http_key] = v
+        async def _update(device: QvantumModbusDevice):
+            await device.async_update_settings()
+            return device.settings_payload(enabled_settings)
 
-        if "extra_tap_water" in settings_dict:
-            settings_dict["extra_tap_water"] = (
-                # If the value is 2, it means "on" (max tap water), otherwise "off" (normal tap water)
-                "on" if settings_dict["extra_tap_water"] == 2 else "off"
-            )
-
-        if "fanspeedselector" in settings_dict:
-            match settings_dict["fanspeedselector"]:
-                case 0:
-                    settings_dict["fanspeedselector"] = FAN_SPEED_STATE_OFF
-                case 1:
-                    settings_dict["fanspeedselector"] = FAN_SPEED_STATE_NORMAL
-                case 2:
-                    settings_dict["fanspeedselector"] = FAN_SPEED_STATE_EXTRA
-
-        # hide internal dhw_* keys from public settings output
-        for hide_key in ["dhw_start_normal", "dhw_stop_normal"]:
-            settings_dict.pop(hide_key, None)
-
-        return {"settings": [{"name": n, "value": v} for n, v in settings_dict.items()]}
+        return await self._run_modbus(_update, error_label="reading holding registers")
 
     async def _handle_response(self, response: aiohttp.ClientResponse):
         """Handle API response, raising exceptions for errors."""
@@ -590,87 +347,34 @@ class QvantumAPI:
         self, device_id: str, register_address: int, value: int
     ) -> dict:
         """Write a single Modbus holding register and return a status dict."""
-        self._ensure_open()
-        async with self._modbus_lock:
-            self._ensure_open()
-            self._init_modbus_client()
-            if not self._modbus_client:
-                raise APIConnectionError(
-                    None, f"Modbus client not initialized for device {device_id}"
-                )
 
-            try:
-                if not self._modbus_client.connected:
-                    await self._modbus_client.connect()
-                    if not self._modbus_client.connected:
-                        raise APIConnectionError(
-                            None,
-                            f"Modbus client connection failed for device {device_id}",
-                        )
+        async def _write(device: QvantumModbusDevice):
+            await device.write_holding_register(register_address, int(value))
+            return {"status": "APPLIED"}
 
-                request = WriteSingleRegisterRequest(
-                    dev_id=self._modbus_unit_id,
-                    address=register_address,
-                    # pymodbus 3.x uses a shared ModbusPDU base class where all register
-                    # values are stored as list[int]. For WriteSingleRegisterRequest the
-                    # value to write is accessed as registers[0] internally, so a
-                    # single-element list is the correct API.
-                    registers=[value],
-                )
-                result = await self._modbus_client.execute(False, request)
-                if result is None:
-                    raise APIConnectionError(
-                        None,
-                        f"Modbus write failed for device {device_id}: no response received from device",
-                    )
-                if result.isError():
-                    raise APIConnectionError(
-                        None,
-                        f"Modbus write error on register {register_address} for device {device_id}: {result}",
-                    )
-            except asyncio.CancelledError:
-                await self._reset_modbus_client()
-                raise
-            except ModbusException as e:
-                _LOGGER.error(
-                    "Modbus error writing holding register %d for device %s: %s",
-                    register_address,
-                    device_id,
-                    e,
-                )
-                await self._reset_modbus_client()
-                raise APIConnectionError(None, f"Modbus write failed: {e}")
-            except APIConnectionError:
-                await self._reset_modbus_client()
-                raise
-            except Exception as e:
-                _LOGGER.error(
-                    "Unexpected error writing holding register %d for device %s: %s",
-                    register_address,
-                    device_id,
-                    e,
-                    exc_info=True,
-                )
-                await self._reset_modbus_client()
-                raise APIConnectionError(None, f"Modbus write failed: {e}")
-
-        return {"status": "APPLIED"}
+        return await self._run_modbus(
+            _write,
+            error_label=f"writing holding register {register_address} for device {device_id}",
+            missing_client_message=f"Modbus client not initialized for device {device_id}",
+            failure_prefix="Modbus write failed",
+        )
 
     async def write_holding_register_for_metric(
         self, device_id: str, metric_key: str, value: float
     ) -> dict:
         """Write a Modbus holding register looked up by metric key."""
-        holding_key = next(
-            (k for k, v in MODBUS_HOLDING_TO_SETTINGS_MAP.items() if v == metric_key),
-            None,
+        holding_field_for_metric(metric_key)
+
+        async def _write(device: QvantumModbusDevice):
+            await device.write_metric(metric_key, value)
+            return {"status": "APPLIED"}
+
+        return await self._run_modbus(
+            _write,
+            error_label=f"writing metric {metric_key} for device {device_id}",
+            missing_client_message=f"Modbus client not initialized for device {device_id}",
+            failure_prefix="Modbus write failed",
         )
-        if holding_key is None or holding_key not in MODBUS_HOLDING_REGISTER_MAP:
-            raise ValueError(
-                f"No Modbus holding register mapping found for metric '{metric_key}'"
-            )
-        register_address, _data_type, scale = MODBUS_HOLDING_REGISTER_MAP[holding_key]
-        raw_value = int(round(value / scale)) if scale != 1.0 else int(value)
-        return await self.write_holding_register(device_id, register_address, raw_value)
 
     async def _update_settings(self, device_id: str, payload: dict):
         """Update one or several settings."""

--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 import logging
 from typing import Any, Optional
 
-from modbus_connection import ClientClosedError, ModbusError, ModbusUnit
+from modbus_connection import ModbusError, ModbusUnit
 
 from .const import (
     DEFAULT_ENABLED_HTTP_METRICS,
@@ -167,8 +167,6 @@ class QvantumAPI:
                 # Reload/unload cancels in-flight polls. Do not close or
                 # disconnect the shared connection; other consumers may hold it.
                 raise
-            except ClientClosedError as err:
-                raise APIConnectionError(None, "API client is closed") from err
             except ModbusError as err:
                 _LOGGER.error("Modbus error %s: %s", error_label, err)
                 raise APIConnectionError(None, f"{failure_prefix}: {err}") from err

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -22,6 +22,8 @@ FAN_SPEED_VALUE_NORMAL = 1
 FAN_SPEED_VALUE_EXTRA = 2
 VERSION = "2026.8.3"
 CONFIG_VERSION = 7
+# Shared Modbus units (`async_get_unit`) shipped in Home Assistant 2026.9.
+MIN_HA_VERSION = "2026.9.0"
 
 # Modbus TCP configuration
 CONF_MODBUS_TCP = "modbus_tcp"

--- a/custom_components/qvantum/manifest.json
+++ b/custom_components/qvantum/manifest.json
@@ -5,12 +5,14 @@
         "@perosb"
     ],
     "config_flow": true,
-    "dependencies": [],
+    "dependencies": [
+        "modbus"
+    ],
     "documentation": "https://github.com/perosb/qvantum_custom_component",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/perosb/qvantum_custom_component/issues",
     "requirements": [
-        "pymodbus>=3.0.0,<4.0.0"
+        "modbus-connection>=4.10.0,<5.0.0"
     ],
     "single_config_entry": true,
     "version": "2026.8.3"

--- a/custom_components/qvantum/modbus.py
+++ b/custom_components/qvantum/modbus.py
@@ -1,4 +1,9 @@
-"""Modbus constants and mappings for the Qvantum Heat Pump Integration."""
+"""Modbus constants and mappings for the Qvantum Heat Pump Integration.
+
+These maps are the datasheet. ``modbus_model`` builds typed components from
+them, and ``modbus_device`` adapts decoded values to the HTTP-shaped payloads
+the rest of the integration already consumes.
+"""
 
 # Modbus input register map using internal metric names as keys.
 # Format: internal_name -> (register_address, data_type, scale)

--- a/custom_components/qvantum/modbus_device.py
+++ b/custom_components/qvantum/modbus_device.py
@@ -1,0 +1,188 @@
+"""Qvantum Modbus device object and dict adapter.
+
+Consumes a ``ModbusUnit`` and exposes the same metrics/settings payloads the
+HTTP path uses, so coordinators and entities do not need to change.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING
+
+from .const import (
+    BASE_SYSTEM_POWER_W,
+    FAN_SPEED_STATE_EXTRA,
+    FAN_SPEED_STATE_NORMAL,
+    FAN_SPEED_STATE_OFF,
+    RELAY_STAGE_POWER_MAP,
+)
+from .modbus import MODBUS_HOLDING_TO_SETTINGS_MAP
+from .modbus_model import QvantumInputs, QvantumSettings
+
+if TYPE_CHECKING:
+    from modbus_connection import ModbusUnit
+
+_ENERGY_PREFIXES = ("compressor", "additional", "heating", "cooling", "dhw")
+_HIDDEN_SETTINGS = frozenset({"dhw_start_normal", "dhw_stop_normal"})
+_SETTINGS_NAME_TO_HOLDING = {
+    settings_name: holding_key
+    for holding_key, settings_name in MODBUS_HOLDING_TO_SETTINGS_MAP.items()
+}
+
+# Fan holding register 68: 0/1/2 -> off/normal/extra.
+_FAN_SPEED_STATES = {
+    0: FAN_SPEED_STATE_OFF,
+    1: FAN_SPEED_STATE_NORMAL,
+    2: FAN_SPEED_STATE_EXTRA,
+}
+
+
+def component_values(component) -> dict[str, Any]:
+    """Return decoded public values for a component, skipping unread fields."""
+    data: dict[str, Any] = {}
+    for name, field in component.declared_fields.items():
+        value = getattr(component, name)
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            data[name] = int(value)
+            continue
+        scale = getattr(field, "scale", 1.0) or 1.0
+        if scale == 1.0:
+            data[name] = int(value)
+        else:
+            data[name] = round(float(value), 2)
+    return data
+
+
+def build_metrics_payload(
+    device_id: str,
+    values: dict[str, Any],
+    enabled_metrics: list[str] | None = None,
+) -> dict[str, Any]:
+    """Turn raw input-register values into the metrics dict used by the API."""
+    metrics = dict(values)
+    if enabled_metrics is not None:
+        enabled = set(enabled_metrics)
+        metrics = {key: value for key, value in metrics.items() if key in enabled}
+
+    if "smart_dhw_mode" in metrics:
+        metrics["smart_sh_mode"] = metrics["smart_dhw_mode"]
+        metrics["use_adaptive"] = metrics["smart_dhw_mode"] != -1
+
+    relay_sum = 0.0
+    for key, wattage in RELAY_STAGE_POWER_MAP.items():
+        value = metrics.get(key, 0)
+        try:
+            relay_sum += float(value) * wattage
+        except (TypeError, ValueError):
+            continue
+
+    compressor_power = 0.0
+    raw_power = metrics.pop("compressor_power", 0.0)
+    try:
+        compressor_power = float(raw_power)
+    except (TypeError, ValueError):
+        compressor_power = 0.0
+
+    metrics["powertotal"] = round(
+        BASE_SYSTEM_POWER_W + relay_sum + compressor_power, 2
+    )
+
+    for prefix in _ENERGY_PREFIXES:
+        mwh = metrics.get(f"{prefix}_mwh")
+        kwh = metrics.get(f"{prefix}_kwh")
+        if mwh is not None and kwh is not None:
+            try:
+                metrics[f"{prefix}energy"] = round(float(mwh) * 1000.0 + float(kwh), 2)
+            except (TypeError, ValueError):
+                pass
+        metrics.pop(f"{prefix}_mwh", None)
+        metrics.pop(f"{prefix}_kwh", None)
+
+    metrics["hpid"] = device_id
+    return {"metrics": metrics}
+
+
+def build_settings_payload(
+    values: dict[str, Any],
+    enabled_settings: list[str] | None = None,
+) -> dict[str, Any]:
+    """Turn holding-register values into the settings list used by the API."""
+    if enabled_settings is not None:
+        enabled = set(enabled_settings)
+        values = {key: value for key, value in values.items() if key in enabled}
+
+    settings_dict: dict[str, Any] = {}
+    for key, value in values.items():
+        settings_dict[key] = value
+        http_key = MODBUS_HOLDING_TO_SETTINGS_MAP.get(key)
+        if http_key and http_key != key:
+            settings_dict[http_key] = value
+
+    if "extra_tap_water" in settings_dict:
+        settings_dict["extra_tap_water"] = (
+            "on" if settings_dict["extra_tap_water"] == 2 else "off"
+        )
+
+    if "fanspeedselector" in settings_dict:
+        settings_dict["fanspeedselector"] = _FAN_SPEED_STATES.get(
+            settings_dict["fanspeedselector"],
+            settings_dict["fanspeedselector"],
+        )
+
+    for hide_key in _HIDDEN_SETTINGS:
+        settings_dict.pop(hide_key, None)
+
+    return {"settings": [{"name": name, "value": value} for name, value in settings_dict.items()]}
+
+
+def holding_field_for_metric(metric_key: str) -> str:
+    """Resolve an HTTP/settings metric key to a holding-register field name."""
+    if metric_key in QvantumSettings.declared_fields:
+        return metric_key
+    holding_key = _SETTINGS_NAME_TO_HOLDING.get(metric_key)
+    if holding_key in QvantumSettings.declared_fields:
+        return holding_key
+    raise ValueError(f"No Modbus holding register mapping found for metric '{metric_key}'")
+
+
+class QvantumModbusDevice:
+    """Qvantum heat pump reached through a ``ModbusUnit``."""
+
+    def __init__(self, unit: ModbusUnit) -> None:
+        self.unit = unit
+        self.inputs = QvantumInputs(unit)
+        self.settings = QvantumSettings(unit)
+
+    async def async_update_inputs(self) -> None:
+        """Refresh input-register metrics."""
+        await self.inputs.async_update()
+
+    async def async_update_settings(self) -> None:
+        """Refresh holding-register settings."""
+        await self.settings.async_update()
+
+    def metrics_payload(
+        self, device_id: str, enabled_metrics: list[str] | None = None
+    ) -> dict[str, Any]:
+        """Build the metrics dict from the last input-register update."""
+        return build_metrics_payload(
+            device_id, component_values(self.inputs), enabled_metrics
+        )
+
+    def settings_payload(
+        self, enabled_settings: list[str] | None = None
+    ) -> dict[str, Any]:
+        """Build the settings list from the last holding-register update."""
+        return build_settings_payload(
+            component_values(self.settings), enabled_settings
+        )
+
+    async def write_holding_register(self, address: int, value: int) -> None:
+        """Write a raw holding register (FC06)."""
+        await self.unit.write_register(address, value)
+
+    async def write_metric(self, metric_key: str, value: float) -> None:
+        """Write a holding field by HTTP/settings metric name, applying scale."""
+        field_name = holding_field_for_metric(metric_key)
+        await self.settings.write(field_name, value)

--- a/custom_components/qvantum/modbus_model.py
+++ b/custom_components/qvantum/modbus_model.py
@@ -1,0 +1,78 @@
+"""Typed Modbus components for the Qvantum heat pump.
+
+Field layouts are generated from the register maps in ``modbus.py`` so the
+maps stay the datasheet and the components stay in lock-step with them.
+Relay bits replace the ``relays_bitmask`` word rather than duplicating it.
+"""
+
+from __future__ import annotations
+
+from modbus_connection.model import Component, bit, gauge, integer
+
+from .modbus import (
+    MODBUS_HOLDING_REGISTER_MAP,
+    MODBUS_INPUT_REGISTER_MAP,
+    RELAY_BIT_MAP,
+)
+
+_RELAYS_BITMASK_ADDRESS = MODBUS_INPUT_REGISTER_MAP["relays_bitmask"][0]
+
+
+def _register_field(
+    data_type: str, address: int, scale: float, *, writable: bool = False
+):
+    """Return a gauge or integer field matching a register-map tuple."""
+    signed = data_type == "int16"
+    if scale == 1.0:
+        return integer(address, signed=signed, writable=writable)
+    return gauge(address, scale, signed=signed, writable=writable)
+
+
+def _component_from_map(
+    name: str,
+    register_space: str,
+    register_map: dict,
+    *,
+    writable: bool = False,
+    extra: dict | None = None,
+    skip: frozenset[str] = frozenset(),
+    max_gap: int = 16,
+    register_ranges: tuple[tuple[int, int], ...] | None = None,
+) -> type[Component]:
+    # max_gap=16 matches a live Qvantum-HP probe: documented holes answer.
+    # register_ranges keep reads off the refused input 105-160 span.
+    attrs: dict = {"register_space": register_space, "max_gap": max_gap}
+    if register_ranges is not None:
+        attrs["register_ranges"] = register_ranges
+    for field_name, (address, data_type, scale) in register_map.items():
+        if field_name in skip:
+            continue
+        attrs[field_name] = _register_field(
+            data_type, address, scale, writable=writable
+        )
+    if extra:
+        attrs.update(extra)
+    return type(name, (Component,), attrs)
+
+
+QvantumInputs = _component_from_map(
+    "QvantumInputs",
+    "input",
+    MODBUS_INPUT_REGISTER_MAP,
+    skip=frozenset({"relays_bitmask"}),
+    extra={
+        name: bit(_RELAYS_BITMASK_ADDRESS, index)
+        for name, index in RELAY_BIT_MAP.items()
+    },
+    # Live probe: 0-104 answers, 105-160 raises 0x04, 161-164 answers.
+    register_ranges=((0, 104), (161, 164)),
+)
+
+QvantumSettings = _component_from_map(
+    "QvantumSettings",
+    "holding",
+    MODBUS_HOLDING_REGISTER_MAP,
+    writable=True,
+    # Live probe: the mapped holding span 0-88 answers as one block.
+    register_ranges=((0, 88),),
+)

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
     "name": "Qvantum Heat Pump",
     "zip_release": true,
-    "filename": "qvantum.zip"
+    "filename": "qvantum.zip",
+    "homeassistant": "2026.9.0b0"
   }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,12 @@
-[tool:pytest]
+[pytest]
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*
 python_functions = test_*
 pythonpath = /home/perosb/build/qvantum_custom_component/custom_components
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+asyncio_default_test_loop_scope = function
 addopts =
     --strict-markers
     --strict-config

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,4 +5,4 @@ pytest-cov>=4.0.0
 pytest-homeassistant-custom-component>=0.13.0
 homeassistant>=2025.10.0
 voluptuous>=0.13.0
-pymodbus>=3.0.0,<4.0.0
+modbus-connection>=4.10.0,<5.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,7 +2,7 @@
 pytest>=7.0.0
 pytest-asyncio>=1.3.0
 pytest-cov>=4.0.0
-pytest-homeassistant-custom-component>=0.13.0
-homeassistant>=2025.10.0
+pytest-homeassistant-custom-component>=0.13.358
+homeassistant>=2026.9.0b0
 voluptuous>=0.13.0
 modbus-connection>=4.10.0,<5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Runtime dependencies for Qvantum Heat Pump custom component
-pymodbus>=3.0.0,<4.0.0
+modbus-connection>=4.10.0,<5.0.0

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -12,19 +12,19 @@ if [ ! -f "custom_components/qvantum/__init__.py" ]; then
 fi
 
 # Install test dependencies if needed
-if [ ! -d ".venv" ] || ! python3 -c "import homeassistant" 2>/dev/null; then
+if [ ! -d ".venv" ]; then
     echo "Setting up virtual environment..."
-    rm -rf .venv
     python3 -m venv .venv
+    # shellcheck disable=SC1091
     source .venv/bin/activate
     pip install --upgrade pip
     pip install -r requirements-test.txt
 else
+    # shellcheck disable=SC1091
     source .venv/bin/activate
-    # Ensure pymodbus is installed
-    if ! python3 -c "import pymodbus" 2>/dev/null; then
-        echo "Installing pymodbus..."
-        pip install "pymodbus>=3.0.0"
+    if ! python -c "import homeassistant, modbus_connection" 2>/dev/null; then
+        echo "Installing test dependencies..."
+        pip install -r requirements-test.txt
     fi
 fi
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,22 +11,17 @@ if [ ! -f "custom_components/qvantum/__init__.py" ]; then
     exit 1
 fi
 
-# Install test dependencies if needed
+# Create the venv if needed, then always install requirements so pip
+# upgrades stale Home Assistant / modbus-connection versions.
 if [ ! -d ".venv" ]; then
     echo "Setting up virtual environment..."
     python3 -m venv .venv
-    # shellcheck disable=SC1091
-    source .venv/bin/activate
-    pip install --upgrade pip
-    pip install -r requirements-test.txt
-else
-    # shellcheck disable=SC1091
-    source .venv/bin/activate
-    if ! python -c "import homeassistant, modbus_connection" 2>/dev/null; then
-        echo "Installing test dependencies..."
-        pip install -r requirements-test.txt
-    fi
 fi
+# shellcheck disable=SC1091
+source .venv/bin/activate
+pip install --upgrade pip
+echo "Installing test dependencies..."
+pip install -r requirements-test.txt
 
 # Run tests
 echo "Running pytest..."

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,19 @@ import os
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from modbus_connection import ModbusConnectionError, ModbusTimeoutError
+from modbus_connection.mock import MockModbusConnection
+
 from custom_components.qvantum.api import QvantumAPI
+from custom_components.qvantum.modbus_device import QvantumModbusDevice
+
+
+def attach_mock_modbus(api):
+    """Attach an in-memory Modbus unit so tests never open a TCP socket."""
+    connection = MockModbusConnection()
+    api._modbus_unit = connection.for_unit(api._modbus_unit_id)
+    api._modbus_device = QvantumModbusDevice(api._modbus_unit)
+    return connection, api._modbus_device
 
 
 def load_test_data(filename):
@@ -102,155 +114,6 @@ class TestQvantumAPI:
         assert result["metrics"]["latency"] == metrics_data["total_latency"]
 
     @pytest.mark.asyncio
-    async def test_read_modbus_metrics_powertotal_computed(self, mock_session):
-        """Test power total is derived from relay stages and compressor power."""
-        api = QvantumAPI(
-            "test@example.com", "password", "test-agent", session=mock_session
-        )
-
-        with patch.object(
-            QvantumAPI,
-            "_read_modbus_registers",
-            AsyncMock(
-                return_value={
-                    "picpin_relay_heat_l1": 1,
-                    "picpin_relay_heat_l2": 1,
-                    "picpin_relay_heat_l3": 1,
-                    "compressor_power": 100,
-                }
-            ),
-        ):
-            result = await api._read_modbus_metrics(
-                "test_device_123",
-                [
-                    "picpin_relay_heat_l1",
-                    "picpin_relay_heat_l2",
-                    "picpin_relay_heat_l3",
-                    "compressor_power",
-                ],
-            )
-
-        metrics = result["metrics"]
-        assert metrics["powertotal"] == 5260.0
-
-    @pytest.mark.asyncio
-    async def test_read_modbus_metrics_compressorenergy_from_mwh_kwh(
-        self, mock_session
-    ):
-        """Test compressorenergy tracks combined mwh+kwh data from modbus."""
-        api = QvantumAPI(
-            "test@example.com", "password", "test-agent", session=mock_session
-        )
-
-        with patch.object(
-            QvantumAPI,
-            "_read_modbus_registers",
-            AsyncMock(
-                return_value={
-                    "compressor_mwh": 4,
-                    # As the modbus register reads have already applied the scaling factor from the register map (e.g. 0.1 for kwh values),
-                    # we need to provide the scaled value here too.
-                    "compressor_kwh": 8010 * 0.1,
-                }
-            ),
-        ):
-            result = await api._read_modbus_metrics(
-                "test_device_123", ["compressor_mwh", "compressor_kwh"]
-            )
-
-        metrics = result["metrics"]
-        assert metrics["compressorenergy"] == 4801.0
-
-    @pytest.mark.asyncio
-    async def test_read_modbus_metrics_skips_energy_if_component_missing(
-        self, mock_session
-    ):
-        """Do not derive energy when mwh/kwh pair is incomplete."""
-        api = QvantumAPI(
-            "test@example.com", "password", "test-agent", session=mock_session
-        )
-
-        with patch.object(
-            QvantumAPI,
-            "_read_modbus_registers",
-            AsyncMock(
-                return_value={
-                    "compressor_mwh": 4,
-                    # compressor_kwh intentionally missing to simulate transient partial read
-                }
-            ),
-        ):
-            result = await api._read_modbus_metrics(
-                "test_device_123", ["compressor_mwh", "compressor_kwh"]
-            )
-
-        metrics = result["metrics"]
-        assert "compressorenergy" not in metrics
-
-    @pytest.mark.asyncio
-    async def test_read_modbus_metrics_skips_energy_if_component_non_numeric(
-        self, mock_session
-    ):
-        """Do not derive energy when mwh/kwh values are malformed."""
-        api = QvantumAPI(
-            "test@example.com", "password", "test-agent", session=mock_session
-        )
-
-        with patch.object(
-            QvantumAPI,
-            "_read_modbus_registers",
-            AsyncMock(
-                return_value={
-                    "compressor_mwh": "not-a-number",
-                    "compressor_kwh": 1,
-                }
-            ),
-        ):
-            result = await api._read_modbus_metrics(
-                "test_device_123", ["compressor_mwh", "compressor_kwh"]
-            )
-
-        metrics = result["metrics"]
-        assert "compressorenergy" not in metrics
-
-    @pytest.mark.asyncio
-    async def test_read_modbus_metrics_rounds_to_two_decimals(self, mock_session):
-        """Test numeric outputs from modbus are rounded to two decimals."""
-        api = QvantumAPI(
-            "test@example.com", "password", "test-agent", session=mock_session
-        )
-
-        with patch.object(
-            QvantumAPI,
-            "_read_modbus_registers",
-            AsyncMock(
-                return_value={
-                    "picpin_relay_heat_l1": 1,
-                    "picpin_relay_heat_l2": 0,
-                    "picpin_relay_heat_l3": 0,
-                    "compressor_power": 100.12345,
-                    "compressor_mwh": 1.2345,
-                    "compressor_kwh": 2.3456,
-                }
-            ),
-        ):
-            result = await api._read_modbus_metrics(
-                "test_device_123",
-                [
-                    "picpin_relay_heat_l1",
-                    "picpin_relay_heat_l2",
-                    "picpin_relay_heat_l3",
-                    "compressor_power",
-                    "compressor_mwh",
-                    "compressor_kwh",
-                ],
-            )
-
-        metrics = result["metrics"]
-        assert metrics["powertotal"] == 2260.12
-        assert metrics["compressorenergy"] == 1236.85
-
-    @pytest.mark.asyncio
     async def test_get_metrics_modbus_tcp_failure_fallback_http(self, mock_session):
         """Modbus TCP failures should fall back to HTTP when explicitly enabled."""
         api = QvantumAPI(
@@ -310,173 +173,60 @@ class TestQvantumAPI:
     async def test_get_metrics_modbus_no_latency_placeholder_in_registers(
         self, mock_session
     ):
-        """_read_modbus_registers must not inject a latency key; latency is set in get_metrics."""
+        """Modbus metrics payloads must not inject latency; get_metrics measures it."""
         api = QvantumAPI(
-            "test@example.com", "password", "test-agent", session=mock_session
+            "test@example.com",
+            "password",
+            "test-agent",
+            session=mock_session,
+            modbus_tcp=True,
         )
-
-        with patch.object(
-            QvantumAPI,
-            "_read_modbus_registers",
-            AsyncMock(return_value={"hpid": "dev", "bt1": 20}),
-        ):
-            raw = await api._read_modbus_metrics("dev", ["bt1"])
-
-        # latency must not be present unless explicitly measured and injected
+        attach_mock_modbus(api)
+        raw = await api._read_modbus_metrics("dev", ["bt1"])
         assert "latency" not in raw.get("metrics", {})
 
     @pytest.mark.asyncio
-    async def test_read_modbus_settings_aliasing(self, mock_session):
-        """Test that Modbus settings values are mapped to HTTP and modbus alias keys."""
-        api = QvantumAPI(
-            "test@example.com", "password", "test-agent", session=mock_session
-        )
-
-        with patch.object(
-            QvantumAPI,
-            "_read_modbus_registers",
-            AsyncMock(
-                return_value={
-                    "dhw_start_normal": 52,
-                    "dhw_stop_normal": 62,
-                    "operation_mode": 1,
-                }
-            ),
-        ):
-            result = await api._read_modbus_settings(
-                "test_device",
-                [
-                    "dhw start temperature normal",
-                    "dhw stop temperature normal",
-                    "operation mode",
-                ],
-            )
-
-        settings = {item["name"]: item["value"] for item in result["settings"]}
-
-        # dhw_* internal keys should be hidden from public settings output
-        assert "dhw_start_normal" not in settings
-        assert "dhw_stop_normal" not in settings
-
-        # tap_water *_ values should still be available for number entity usage
-        assert settings["tap_water_start"] == 52
-        assert settings["tap_water_stop"] == 62
-
-        assert "use_adaptive" not in settings
-        assert settings["op_mode"] == 1
-
-    @pytest.mark.asyncio
-    async def test_read_modbus_reuse_client_between_reads(self):
-        """Modbus client should remain open across successful reads."""
+    async def test_read_modbus_reuse_connection_between_reads(self):
+        """Modbus connection should remain open across successful reads."""
         api = QvantumAPI("test@example.com", "password", "test-agent", modbus_tcp=True)
+        connection, _device = attach_mock_modbus(api)
 
-        created_clients = []
-        client = None
+        result1 = await api._read_modbus_metrics("test_device", ["bt1"])
+        assert result1["metrics"]["hpid"] == "test_device"
+        assert api._modbus_unit is connection.for_unit(api._modbus_unit_id)
 
-        async def fake_connect():
-            nonlocal client
-            client.connected = True
-
-        async def fake_close():
-            nonlocal client
-            client.connected = False
-
-        def fake_init():
-            nonlocal client
-            if api._modbus_client is not None:
-                return
-            client = MagicMock()
-            client.connected = False
-            client.connect = AsyncMock(side_effect=fake_connect)
-            client.close = AsyncMock(side_effect=fake_close)
-            created_clients.append(client)
-            api._modbus_client = client
-
-        api._init_modbus_client = fake_init
-
-        # First attempt should create a client and keep it open after read
-        result1 = await api._read_modbus_registers(
-            "test_device", [], {}, use_input_registers=True
-        )
-        assert result1["hpid"] == "test_device"
-        assert api._modbus_client is client
-
-        # Second attempt should reuse the same client
-        result2 = await api._read_modbus_registers(
-            "test_device", [], {}, use_input_registers=True
-        )
-        assert result2["hpid"] == "test_device"
-        assert api._modbus_client is client
-
-        assert len(created_clients) == 1
+        result2 = await api._read_modbus_metrics("test_device", ["bt1"])
+        assert result2["metrics"]["hpid"] == "test_device"
+        assert api._modbus_device is not None
 
     @pytest.mark.asyncio
     async def test_read_modbus_concurrent_access_is_serialized(self):
-        """Ensure concurrent Modbus reads are serialized via lock to avoid client conflicts."""
+        """Concurrent Modbus reads are serialized via the API lock."""
         api = QvantumAPI("test@example.com", "password", "test-agent", modbus_tcp=True)
+        _connection, device = attach_mock_modbus(api)
 
-        created_clients = []
-        client = None
+        in_flight = 0
+        max_in_flight = 0
+        original = device.async_update_inputs
 
-        async def fake_connect():
-            client.connected = True
-            return True
-
-        async def fake_close():
-            client.connected = False
-
-        class DummyResult:
-            def __init__(self, value):
-                self.registers = [value]
-
-            def isError(self):
-                return False
-
-        async def fake_execute(_sync, _request):
-            # Simulate slow long-running request to force concurrent timing
+        async def slow_update():
+            nonlocal in_flight, max_in_flight
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
             await asyncio.sleep(0.05)
-            return DummyResult(100)
+            in_flight -= 1
+            return await original()
 
-        def fake_init():
-            nonlocal client
-            if api._modbus_client is not None:
-                return
-            client = MagicMock()
-            client.connected = False
-            client.connect = AsyncMock(side_effect=fake_connect)
-            client.close = AsyncMock(side_effect=fake_close)
-            client.execute = AsyncMock(side_effect=fake_execute)
-            created_clients.append(client)
-            api._modbus_client = client
+        device.async_update_inputs = slow_update
 
-        api._init_modbus_client = fake_init
-
-        # Run two reads concurrently that should serialize via _modbus_lock.
-        task1 = asyncio.create_task(
-            api._read_modbus_registers(
-                "test_device",
-                ["bt1 - fast filtered (1min) outdoor temp"],
-                {"bt1 - fast filtered (1min) outdoor temp": (0, "int16", 1.0)},
-                use_input_registers=True,
-            )
-        )
-        task2 = asyncio.create_task(
-            api._read_modbus_registers(
-                "test_device",
-                ["bt1 - fast filtered (1min) outdoor temp"],
-                {"bt1 - fast filtered (1min) outdoor temp": (0, "int16", 1.0)},
-                use_input_registers=True,
-            )
+        results = await asyncio.gather(
+            api._read_modbus_metrics("test_device", ["bt1"]),
+            api._read_modbus_metrics("test_device", ["bt1"]),
         )
 
-        await asyncio.sleep(0.01)
-        assert client.execute.call_count == 1
-
-        results = await asyncio.gather(task1, task2)
-
-        assert results[0]["bt1 - fast filtered (1min) outdoor temp"] == 100
-        assert results[1]["bt1 - fast filtered (1min) outdoor temp"] == 100
-        assert client.execute.call_count == 2
+        assert max_in_flight == 1
+        assert results[0]["metrics"]["hpid"] == "test_device"
+        assert results[1]["metrics"]["hpid"] == "test_device"
 
     @pytest.mark.asyncio
     async def test_set_tap_water(self, mock_session):
@@ -524,23 +274,22 @@ class TestQvantumAPI:
 
     @pytest.mark.asyncio
     async def test_close_owned_session_and_modbus_client(self):
-        """Owned HTTP session and Modbus client are closed under the lock."""
+        """Owned HTTP session and Modbus connection are closed under the lock."""
         api = QvantumAPI("test@example.com", "password", "test-agent", modbus_tcp=True)
         mock_session = MagicMock()
         mock_session.close = AsyncMock()
         api._session = mock_session
         api._session_owner = True
 
-        mock_client = MagicMock()
-        mock_client.close = AsyncMock()
-        api._modbus_client = mock_client
+        connection, _device = attach_mock_modbus(api)
+        connection.close = AsyncMock()
 
         await api.close()
 
         mock_session.close.assert_awaited_once()
-        mock_client.close.assert_awaited_once()
+        connection.close.assert_not_called()
         assert api._session is None
-        assert api._modbus_client is None
+        assert api._modbus_device is None
         assert api._closed is True
 
         # Second close is a no-op
@@ -621,9 +370,7 @@ class TestQvantumAPI:
     async def test_close_waits_for_in_flight_modbus_lock(self):
         """close() must not tear down Modbus while a read holds the lock."""
         api = QvantumAPI("test@example.com", "password", "test-agent", modbus_tcp=True)
-        mock_client = MagicMock()
-        mock_client.close = AsyncMock()
-        api._modbus_client = mock_client
+        connection, _device = attach_mock_modbus(api)
 
         entered = asyncio.Event()
         release = asyncio.Event()
@@ -637,44 +384,33 @@ class TestQvantumAPI:
         await entered.wait()
 
         closer = asyncio.create_task(api.close())
-        # close should block on the lock until the holder finishes
         await asyncio.sleep(0.05)
         assert not closer.done()
-        mock_client.close.assert_not_called()
+        assert api._modbus_device is not None
 
         release.set()
         await closer
         await holder
 
-        mock_client.close.assert_awaited_once()
-        assert api._modbus_client is None
+        assert api._modbus_device is None
         assert api._closed is True
 
     @pytest.mark.asyncio
-    async def test_read_modbus_cancelled_resets_client(self):
-        """Cancelled Modbus execute must reset the client before re-raising."""
+    async def test_read_modbus_cancelled_keeps_shared_unit(self):
+        """Cancelled Modbus updates must not close the shared Home Assistant unit."""
         api = QvantumAPI("test@example.com", "password", "test-agent", modbus_tcp=True)
+        connection, device = attach_mock_modbus(api)
 
-        client = MagicMock()
-        client.connected = True
-        client.close = AsyncMock()
-        client.execute = AsyncMock(side_effect=asyncio.CancelledError())
-        api._modbus_client = client
+        async def cancel_update():
+            raise asyncio.CancelledError()
 
-        with patch(
-            "custom_components.qvantum.api.MODBUS_INPUT_REGISTER_MAP",
-            {"bt1": (0, "int16", 0.1)},
-        ):
-            with pytest.raises(asyncio.CancelledError):
-                await api._read_modbus_registers(
-                    "dev",
-                    ["bt1"],
-                    {"bt1": (0, "int16", 0.1)},
-                    use_input_registers=True,
-                )
+        device.async_update_inputs = cancel_update
 
-        client.close.assert_awaited_once()
-        assert api._modbus_client is None
+        with pytest.raises(asyncio.CancelledError):
+            await api._read_modbus_metrics("dev", ["bt1"])
+
+        assert api._modbus_unit is not None
+        assert api._modbus_device is device
 
     @pytest.mark.asyncio
     async def test_unauthenticate(self):
@@ -1335,60 +1071,28 @@ class TestQvantumAPI:
     @pytest.mark.asyncio
     async def test_get_metrics_modbus_tcp(self, mock_session):
         """Test getting metrics via Modbus TCP."""
-        from unittest.mock import patch, AsyncMock, MagicMock
+        api = QvantumAPI(
+            "test@example.com",
+            "password",
+            "test-agent",
+            session=mock_session,
+            modbus_tcp=True,
+            modbus_host="192.168.1.100",
+            modbus_port=502,
+        )
+        _connection, device = attach_mock_modbus(api)
+        device.unit.input[0] = 256
 
-        with patch(
-            "custom_components.qvantum.api.ReadInputRegistersRequest", MagicMock()
-        ):
-            # Mock Modbus client
-            mock_client = MagicMock()
-            mock_client.connected = False  # Initially not connected
-            mock_client.connect = AsyncMock(
-                side_effect=lambda: setattr(mock_client, "connected", True)
-            )
-            mock_client.execute = AsyncMock(
-                return_value=MagicMock(
-                    isError=MagicMock(return_value=False), registers=[256]
-                )
-            )  # Mock execute for ReadInputRegistersRequest
-            mock_client.close = AsyncMock()
+        result = await api.get_metrics("test_device", enabled_metrics=["bt1"])
 
-            with patch(
-                "custom_components.qvantum.api.AsyncModbusTcpClient",
-                return_value=mock_client,
-            ):
-                api = QvantumAPI(
-                    "test@example.com",
-                    "password",
-                    "test-agent",
-                    session=mock_session,
-                    modbus_tcp=True,
-                    modbus_host="192.168.1.100",
-                    modbus_port=502,
-                )
-
-                # Mock the register map with a test entry
-                api.MODBUS_REGISTER_MAP = {"bt1": (0, "int16", 10.0)}
-
-                result = await api.get_metrics("test_device", enabled_metrics=["bt1"])
-
-                assert "metrics" in result
-                assert result["metrics"]["hpid"] == "test_device"
-                assert "bt1" in result["metrics"]
-                # Verify Modbus client was used
-                mock_client.connect.assert_called_once()
-                mock_client.execute.assert_called_once()
+        assert "metrics" in result
+        assert result["metrics"]["hpid"] == "test_device"
+        assert result["metrics"]["bt1"] == 25.6
+        assert isinstance(result["metrics"]["latency"], int)
 
     @pytest.mark.asyncio
     async def test_get_metrics_modbus_connection_failure(self, mock_session):
         """Test Modbus connection failure falls back to HTTP."""
-        from unittest.mock import patch, AsyncMock, MagicMock
-
-        mock_client = MagicMock()
-        mock_client.connected = False
-        mock_client.connect = AsyncMock(side_effect=Exception("Connection failed"))
-        mock_client.close = AsyncMock()
-
         cm, mock_response = mock_session.make_cm_response(
             status=200,
             json_data={"values": {"bt1": 123}, "total_latency": 10},
@@ -1396,26 +1100,23 @@ class TestQvantumAPI:
         )
         mock_session.get.return_value = cm
 
-        with patch(
-            "custom_components.qvantum.api.AsyncModbusTcpClient",
-            return_value=mock_client,
-        ):
-            api = QvantumAPI(
-                "test@example.com",
-                "password",
-                "test-agent",
-                session=mock_session,
-                modbus_tcp=True,
-            )
-            api._token = "test_token"
-            api._token_expiry = datetime.datetime.now() + datetime.timedelta(hours=1)
+        api = QvantumAPI(
+            "test@example.com",
+            "password",
+            "test-agent",
+            session=mock_session,
+            modbus_tcp=True,
+        )
+        api._token = "test_token"
+        api._token_expiry = datetime.datetime.now() + datetime.timedelta(hours=1)
+        _connection, device = attach_mock_modbus(api)
+        device.unit.fail_requests(ModbusConnectionError())
 
-            result = await api.get_metrics("test_device", enabled_metrics=["bt1"])
+        result = await api.get_metrics("test_device", enabled_metrics=["bt1"])
 
-            assert "metrics" in result
-            assert result["metrics"]["bt1"] == 123
-            assert mock_client.connect.call_count == 1
-            assert mock_session.get.called
+        assert "metrics" in result
+        assert result["metrics"]["bt1"] == 123
+        assert mock_session.get.called
 
     @pytest.mark.asyncio
     async def test_get_settings_modbus(self, mock_session):
@@ -1500,38 +1201,33 @@ class TestQvantumAPI:
         assert result["metrics"]["bt2"] == metrics_data["values"]["bt2"]
         assert result["metrics"]["latency"] == metrics_data["total_latency"]
 
-    @pytest.mark.asyncio
-    async def test_normalize_modbus_value(self, mock_session):
+    def test_ensure_modbus_device_when_enabled(self, mock_session):
         api = QvantumAPI(
-            "test@example.com", "password", "test-agent", session=mock_session
+            "test@example.com",
+            "password",
+            "test-agent",
+            session=mock_session,
+            modbus_tcp=True,
         )
+        _connection, attached = attach_mock_modbus(api)
+        device = api._ensure_modbus_device()
+        assert device is attached
+        assert api._modbus_device is device
 
-        assert api._normalize_modbus_value(123.4, 1.0) == 123
-        assert api._normalize_modbus_value(123.456, 0.1) == 123.46
-
-    def test_init_modbus_client_when_enabled(self, mock_session):
-        with patch(
-            "custom_components.qvantum.api.AsyncModbusTcpClient",
-            return_value=MagicMock(),
-        ) as mock_client_ctor:
-            api = QvantumAPI(
-                "test@example.com",
-                "password",
-                "test-agent",
-                session=mock_session,
-                modbus_tcp=True,
-            )
-            api._init_modbus_client()
-            assert api._modbus_client is not None
-            mock_client_ctor.assert_called_once_with(
-                host=api._modbus_host,
-                port=api._modbus_port,
-                timeout=10.0,
-                retries=3,
-            )
+    def test_ensure_modbus_device_without_unit_returns_none(self, mock_session):
+        api = QvantumAPI(
+            "test@example.com",
+            "password",
+            "test-agent",
+            session=mock_session,
+            modbus_tcp=True,
+        )
+        assert api._ensure_modbus_device() is None
 
     @pytest.mark.asyncio
-    async def test_read_modbus_registers_raises_when_no_client(self, mock_session):
+    async def test_read_modbus_metrics_raises_when_no_client(self, mock_session):
+        from custom_components.qvantum.api import APIConnectionError
+
         api = QvantumAPI(
             "test@example.com",
             "password",
@@ -1540,53 +1236,8 @@ class TestQvantumAPI:
             modbus_tcp=False,
         )
 
-        with pytest.raises(Exception) as exc_info:
-            await api._read_modbus_registers(
-                "test_device",
-                ["bt1"],
-                {"bt1": (0, "int16", 1.0)},
-                use_input_registers=True,
-            )
-
-        assert "Modbus client not initialized" in str(exc_info.value)
-
-    @pytest.mark.asyncio
-    async def test_read_modbus_registers_float32_handling(self, mock_session):
-        from custom_components.qvantum.api import ReadInputRegistersRequest
-
-        api = QvantumAPI(
-            "test@example.com",
-            "password",
-            "test-agent",
-            session=mock_session,
-            modbus_tcp=True,
-        )
-
-        fake_client = MagicMock()
-        fake_client.connected = False
-
-        async def connect():
-            fake_client.connected = True
-
-        class FakeResult:
-            def __init__(self):
-                self.registers = [0, 64]  # float32 big-endian: 2.0? (0x000040)
-
-            def isError(self):
-                return False
-
-        fake_client.connect = AsyncMock(side_effect=connect)
-        fake_client.execute = AsyncMock(return_value=FakeResult())
-        api._modbus_client = fake_client
-
-        result = await api._read_modbus_registers(
-            "test_device",
-            ["f32_metric"],
-            {"f32_metric": (0, "float32", 1.0)},
-            use_input_registers=True,
-        )
-
-        assert result["hpid"] == "test_device"
+        with pytest.raises(APIConnectionError, match="Modbus client not initialized"):
+            await api._read_modbus_metrics("test_device", ["bt1"])
 
     @pytest.mark.asyncio
     async def test_handle_response_rate_limits_and_auth_error(self):
@@ -1623,17 +1274,17 @@ class TestQvantumAPI:
         assert result_on == {"command": {}}
 
     @pytest.mark.asyncio
-    async def test_reset_modbus_client_handles_error(self, mock_session):
+    async def test_reset_modbus_client_drops_device_wrapper(self, mock_session):
         api = QvantumAPI(
             "test@example.com", "password", "test-agent", session=mock_session
         )
-        client = MagicMock()
-        client.close.side_effect = Exception("close fail")
-        api._modbus_client = client
+        api._modbus_device = MagicMock()
+        api._modbus_unit = MagicMock()
 
         await api._reset_modbus_client()
 
-        assert api._modbus_client is None
+        assert api._modbus_device is None
+        assert api._modbus_unit is not None
 
     @pytest.mark.asyncio
     async def test_close_closes_owned_session(self, mock_session):
@@ -1648,69 +1299,35 @@ class TestQvantumAPI:
         mock_session.close.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_read_modbus_registers_execute_returns_none_raises(self, mock_session):
+    async def test_read_modbus_metrics_device_error_raises(self, mock_session):
+        from custom_components.qvantum.api import APIConnectionError
+
         api = QvantumAPI(
-            "test@example.com", "password", "test-agent", session=mock_session, modbus_tcp=True
+            "test@example.com",
+            "password",
+            "test-agent",
+            session=mock_session,
+            modbus_tcp=True,
         )
+        _connection, device = attach_mock_modbus(api)
+        device.unit.fail_requests(ModbusTimeoutError())
 
-        fake_client = MagicMock()
-        fake_client.connected = True
-        fake_client.execute = AsyncMock(return_value=None)
-        api._modbus_client = fake_client
-
-        with pytest.raises(Exception):
-            await api._read_modbus_registers(
-                "test_device",
-                ["bt1"],
-                {"bt1": (0, "int16", 1.0)},
-                use_input_registers=True,
-            )
-
-    @pytest.mark.asyncio
-    async def test_read_modbus_registers_iserror_logs_and_returns_base(self, mock_session):
-        api = QvantumAPI(
-            "test@example.com", "password", "test-agent", session=mock_session, modbus_tcp=True
-        )
-
-        fake_client = MagicMock()
-        fake_client.connected = True
-
-        class ErrorResult:
-            registers = [0]
-            def isError(self):
-                return True
-
-        fake_client.execute = AsyncMock(return_value=ErrorResult())
-        api._modbus_client = fake_client
-
-        result = await api._read_modbus_registers(
-            "test_device",
-            ["bt1"],
-            {"bt1": (0, "int16", 1.0)},
-            use_input_registers=True,
-        )
-
-        assert result["hpid"] == "test_device"
+        with pytest.raises(APIConnectionError, match="Modbus communication failed"):
+            await api._read_modbus_metrics("test_device", ["bt1"])
 
     @pytest.mark.asyncio
     async def test_read_modbus_metrics_ensures_use_adaptive(self, mock_session):
         api = QvantumAPI(
-            "test@example.com", "password", "test-agent", session=mock_session
+            "test@example.com",
+            "password",
+            "test-agent",
+            session=mock_session,
+            modbus_tcp=True,
         )
+        _connection, device = attach_mock_modbus(api)
+        device.unit.input[161] = 1
 
-        with patch.object(
-            QvantumAPI,
-            "_read_modbus_registers",
-            AsyncMock(
-                return_value={
-                    "smart_dhw_mode": 1,
-                    "compressor_power": 20,
-                    "compressor_mwh": 1,
-                    "compressor_kwh": 1,
-                }
-            ),
-        ):
-            result = await api._read_modbus_metrics("test_device", ["smart_dhw_mode"])
+        result = await api._read_modbus_metrics("test_device", ["smart_dhw_mode"])
 
         assert result["metrics"]["use_adaptive"] is True
         assert result["metrics"]["smart_sh_mode"] == 1
@@ -1718,22 +1335,19 @@ class TestQvantumAPI:
     @pytest.mark.asyncio
     async def test_read_modbus_settings_fan_and_extra_tap_water(self, mock_session):
         api = QvantumAPI(
-            "test@example.com", "password", "test-agent", session=mock_session
+            "test@example.com",
+            "password",
+            "test-agent",
+            session=mock_session,
+            modbus_tcp=True,
         )
+        _connection, device = attach_mock_modbus(api)
+        device.unit.holding[53] = 2  # dhw_mode -> extra_tap_water
+        device.unit.holding[68] = 2  # ventilation_state -> fanspeedselector
 
-        with patch.object(
-            QvantumAPI,
-            "_read_modbus_registers",
-            AsyncMock(
-                return_value={
-                    "extra_tap_water": 2,
-                    "fanspeedselector": 2,
-                    "dhw_start_normal": 1,
-                    "dhw_stop_normal": 1,
-                }
-            ),
-        ):
-            result = await api._read_modbus_settings("test_device", ["extra_tap_water", "fanspeedselector"])
+        result = await api._read_modbus_settings(
+            "test_device", ["dhw_mode", "ventilation_state"]
+        )
 
         settings = {item["name"]: item["value"] for item in result["settings"]}
         assert settings["extra_tap_water"] == "on"
@@ -2395,42 +2009,16 @@ class TestWriteHoldingRegister:
             kwargs["session"] = mock_session
         return QvantumAPI("test@example.com", "password", "test-agent", **kwargs)
 
-    def _make_fake_client(self, execute_result=None, connected=True):
-        client = MagicMock()
-        client.connected = connected
-        client.connect = AsyncMock(
-            side_effect=lambda: setattr(client, "connected", True)
-        )
-        if execute_result is None:
-            ok_result = MagicMock()
-            ok_result.isError.return_value = False
-            execute_result = ok_result
-        client.execute = AsyncMock(return_value=execute_result)
-        return client
-
     @pytest.mark.asyncio
     async def test_write_holding_register_success(self, mock_session):
         """Successful write returns APPLIED status dict."""
         api = self._make_api(mock_session)
-        client = self._make_fake_client()
-        api._modbus_client = client
+        _connection, device = attach_mock_modbus(api)
 
         result = await api.write_holding_register("dev1", 59, 75)
 
         assert result == {"status": "APPLIED"}
-        client.execute.assert_awaited_once()
-
-    @pytest.mark.asyncio
-    async def test_write_holding_register_connects_if_disconnected(self, mock_session):
-        """Connects the client if not already connected."""
-        api = self._make_api(mock_session)
-        client = self._make_fake_client(connected=False)
-        api._modbus_client = client
-
-        result = await api.write_holding_register("dev1", 59, 75)
-
-        client.connect.assert_awaited_once()
-        assert result == {"status": "APPLIED"}
+        assert device.unit.holding[59] == 75
 
     @pytest.mark.asyncio
     async def test_write_holding_register_raises_when_no_client(self, mock_session):
@@ -2440,91 +2028,35 @@ class TestWriteHoldingRegister:
         api = QvantumAPI(
             "test@example.com", "password", "test-agent", session=mock_session
         )
-        # modbus_tcp=False so _init_modbus_client leaves _modbus_client as None
 
         with pytest.raises(APIConnectionError, match="Modbus client not initialized"):
             await api.write_holding_register("dev1", 59, 75)
 
     @pytest.mark.asyncio
-    async def test_write_holding_register_raises_on_error_result(self, mock_session):
-        """Raises APIConnectionError when device returns an error response."""
+    async def test_write_holding_register_raises_on_device_error(self, mock_session):
+        """Raises APIConnectionError when the device rejects the write."""
         from custom_components.qvantum.api import APIConnectionError
+        from modbus_connection import IllegalDataValueError
 
         api = self._make_api(mock_session)
-        error_result = MagicMock()
-        error_result.isError.return_value = True
-        client = self._make_fake_client(execute_result=error_result)
-        api._modbus_client = client
-
-        with pytest.raises(APIConnectionError):
-            await api.write_holding_register("dev1", 59, 75)
-
-    @pytest.mark.asyncio
-    async def test_write_holding_register_raises_on_none_response(self, mock_session):
-        """Raises APIConnectionError when execute returns None."""
-        from custom_components.qvantum.api import APIConnectionError
-
-        api = self._make_api(mock_session)
-        client = self._make_fake_client()
-        client.execute = AsyncMock(return_value=None)
-        api._modbus_client = client
-
-        with pytest.raises(APIConnectionError, match="no response received"):
-            await api.write_holding_register("dev1", 59, 75)
-
-    @pytest.mark.asyncio
-    async def test_write_holding_register_resets_client_on_modbus_exception(
-        self, mock_session
-    ):
-        """Resets the Modbus client and raises APIConnectionError on ModbusException."""
-        from custom_components.qvantum.api import APIConnectionError
-        from pymodbus.exceptions import ModbusException
-
-        api = self._make_api(mock_session)
-        client = self._make_fake_client()
-        client.execute = AsyncMock(side_effect=ModbusException("boom"))
-        api._modbus_client = client
+        _connection, device = attach_mock_modbus(api)
+        device.unit.fail_write(59, IllegalDataValueError())
 
         with pytest.raises(APIConnectionError, match="Modbus write failed"):
             await api.write_holding_register("dev1", 59, 75)
-
-        assert api._modbus_client is None
-
-    @pytest.mark.asyncio
-    async def test_write_holding_register_resets_client_on_generic_exception(
-        self, mock_session
-    ):
-        """Resets the Modbus client and raises APIConnectionError on unexpected errors."""
-        from custom_components.qvantum.api import APIConnectionError
-
-        api = self._make_api(mock_session)
-        client = self._make_fake_client()
-        client.execute = AsyncMock(side_effect=RuntimeError("unexpected"))
-        api._modbus_client = client
-
-        with pytest.raises(APIConnectionError, match="Modbus write failed"):
-            await api.write_holding_register("dev1", 59, 75)
-
-        assert api._modbus_client is None
 
     @pytest.mark.asyncio
     async def test_write_holding_register_for_metric_dhw_stop_extra(self, mock_session):
         """write_holding_register_for_metric resolves dhw_stop_extra to register 59."""
         api = self._make_api(mock_session)
-        client = self._make_fake_client()
-        api._modbus_client = client
+        _connection, device = attach_mock_modbus(api)
 
         result = await api.write_holding_register_for_metric(
             "dev1", "dhw_stop_extra", 75
         )
 
         assert result == {"status": "APPLIED"}
-        # Verify the correct register address (59) was written
-        call_args = client.execute.call_args[0][
-            1
-        ]  # second positional arg is the request
-        assert call_args.address == 59
-        assert call_args.registers == [75]
+        assert device.unit.holding[59] == 75
 
     @pytest.mark.asyncio
     async def test_write_holding_register_for_metric_unknown_key_raises(
@@ -2542,18 +2074,14 @@ class TestWriteHoldingRegister:
     async def test_write_holding_register_for_metric_applies_scale(self, mock_session):
         """write_holding_register_for_metric applies inverse scale when scale != 1.0."""
         api = self._make_api(mock_session)
-        client = self._make_fake_client()
-        api._modbus_client = client
+        _connection, device = attach_mock_modbus(api)
 
-        # room_comp_factor maps to holding key "room_compensation" (scale=0.1)
-        # value=2.5 -> raw = int(round(2.5 / 0.1)) = 25
         result = await api.write_holding_register_for_metric(
             "dev1", "room_comp_factor", 2.5
         )
 
         assert result == {"status": "APPLIED"}
-        call_args = client.execute.call_args[0][1]
-        assert call_args.registers == [25]
+        assert device.unit.holding[13] == 25
 
     @pytest.mark.asyncio
     async def test_write_holding_register_for_metric_room_temp_external_scaling(
@@ -2561,16 +2089,11 @@ class TestWriteHoldingRegister:
     ):
         """room_temp_external writes to register 14 and applies inverse 0.1 scale."""
         api = self._make_api(mock_session)
-        client = self._make_fake_client()
-        api._modbus_client = client
+        _connection, device = attach_mock_modbus(api)
 
-        # room_temp_external maps to holding register 14 with scale=0.1
-        # value=21.5 -> raw = int(round(21.5 / 0.1)) = 215
         result = await api.write_holding_register_for_metric(
             "dev1", "room_temp_external", 21.5
         )
 
         assert result == {"status": "APPLIED"}
-        request = client.execute.call_args[0][1]
-        assert request.address == 14
-        assert request.registers == [215]
+        assert device.unit.holding[14] == 215

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -274,7 +274,7 @@ class TestQvantumAPI:
 
     @pytest.mark.asyncio
     async def test_close_owned_session_and_modbus_client(self):
-        """Owned HTTP session and Modbus connection are closed under the lock."""
+        """Owned HTTP session is closed; the borrowed Modbus connection is not."""
         api = QvantumAPI("test@example.com", "password", "test-agent", modbus_tcp=True)
         mock_session = MagicMock()
         mock_session.close = AsyncMock()
@@ -365,6 +365,41 @@ class TestQvantumAPI:
                 await api.get_metrics("test_device_123", enabled_metrics=["bt1"])
 
         mock_session.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_metrics_shared_connection_closed_falls_back_to_http(
+        self, mock_session
+    ):
+        """A closed borrowed Modbus link must still fall back to HTTP."""
+        from modbus_connection import ClientClosedError
+
+        cm, mock_response = mock_session.make_cm_response(
+            status=200,
+            json_data={"values": {"bt1": 123}, "total_latency": 10},
+            headers={"ETag": "etag123"},
+        )
+        mock_session.get.return_value = cm
+
+        api = QvantumAPI(
+            "test@example.com",
+            "password",
+            "test-agent",
+            session=mock_session,
+            modbus_tcp=True,
+        )
+        api._token = "test_token"
+        api._token_expiry = datetime.datetime.now() + datetime.timedelta(hours=1)
+        _connection, device = attach_mock_modbus(api)
+
+        async def closed_update():
+            raise ClientClosedError("connection closed")
+
+        device.async_update_inputs = closed_update
+
+        result = await api.get_metrics("test_device", enabled_metrics=["bt1"])
+
+        assert result["metrics"]["bt1"] == 123
+        assert mock_session.get.called
 
     @pytest.mark.asyncio
     async def test_close_waits_for_in_flight_modbus_lock(self):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,7 @@
 """Tests for Qvantum integration setup."""
 
 import sys
+import types
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -26,12 +27,6 @@ from custom_components.qvantum import (
 class TestSetupDeviceRequirements:
     """Unit tests for setup device-identity helpers."""
 
-    def test_home_assistant_exposes_async_get_unit(self):
-        """The declared HA floor must ship shared Modbus units."""
-        from homeassistant.components.modbus import async_get_unit
-
-        assert callable(async_get_unit)
-
     def test_modbus_link_settings_from_options(self):
         entry = MagicMock()
         entry.options = {
@@ -50,14 +45,15 @@ class TestSetupDeviceRequirements:
         assert _async_modbus_unit(hass, entry) is None
 
     def test_async_modbus_unit_asks_home_assistant_modbus(self, hass):
+        """Borrow a unit via the lazy HA modbus import, without loading serial deps."""
         entry = MagicMock()
         entry.options = {"modbus_tcp": True, "modbus_host": "hp.local"}
         entry.data = {}
         unit = MagicMock()
-        with patch(
-            "homeassistant.components.modbus.async_get_unit",
-            return_value=unit,
-        ) as get_unit:
+        get_unit = MagicMock(return_value=unit)
+        fake_modbus = types.ModuleType("homeassistant.components.modbus")
+        fake_modbus.async_get_unit = get_unit
+        with patch.dict(sys.modules, {"homeassistant.components.modbus": fake_modbus}):
             result = _async_modbus_unit(hass, entry)
         assert result is unit
         assert get_unit.call_args.args[0] is hass

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -26,6 +26,12 @@ from custom_components.qvantum import (
 class TestSetupDeviceRequirements:
     """Unit tests for setup device-identity helpers."""
 
+    def test_home_assistant_exposes_async_get_unit(self):
+        """The declared HA floor must ship shared Modbus units."""
+        from homeassistant.components.modbus import async_get_unit
+
+        assert callable(async_get_unit)
+
     def test_modbus_link_settings_from_options(self):
         entry = MagicMock()
         entry.options = {
@@ -50,7 +56,6 @@ class TestSetupDeviceRequirements:
         unit = MagicMock()
         with patch(
             "homeassistant.components.modbus.async_get_unit",
-            create=True,
             return_value=unit,
         ) as get_unit:
             result = _async_modbus_unit(hass, entry)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -12,9 +12,11 @@ from custom_components.qvantum import (
     async_migrate_entry,
     PLATFORMS,
     _async_update_listener,
+    _async_modbus_unit,
     _coordinator_device,
     _has_required_device,
     _device_sw_version,
+    _modbus_link_settings,
 )
 
 # Mock HA imports after importing real functions
@@ -23,6 +25,39 @@ from custom_components.qvantum import (
 
 class TestSetupDeviceRequirements:
     """Unit tests for setup device-identity helpers."""
+
+    def test_modbus_link_settings_from_options(self):
+        entry = MagicMock()
+        entry.options = {
+            "modbus_tcp": True,
+            "modbus_host": "hp.local",
+            "modbus_port": 1502,
+            "modbus_unit_id": 7,
+        }
+        entry.data = {}
+        assert _modbus_link_settings(entry) == (True, "hp.local", 1502, 7)
+
+    def test_async_modbus_unit_http_mode_skips_shared_connection(self, hass):
+        entry = MagicMock()
+        entry.options = {}
+        entry.data = {}
+        assert _async_modbus_unit(hass, entry) is None
+
+    def test_async_modbus_unit_asks_home_assistant_modbus(self, hass):
+        entry = MagicMock()
+        entry.options = {"modbus_tcp": True, "modbus_host": "hp.local"}
+        entry.data = {}
+        unit = MagicMock()
+        with patch(
+            "homeassistant.components.modbus.async_get_unit",
+            create=True,
+            return_value=unit,
+        ) as get_unit:
+            result = _async_modbus_unit(hass, entry)
+        assert result is unit
+        assert get_unit.call_args.args[0] is hass
+        assert get_unit.call_args.args[1] is entry
+        assert get_unit.call_args.args[3] == 1
 
     def test_has_required_device_http_needs_metadata(self):
         assert _has_required_device({"id": "abc"}, require_metadata=True) is False
@@ -286,6 +321,8 @@ class TestIntegrationSetup:
         mock_api = MagicMock()
         mock_api._modbus_tcp = True
         mock_api._modbus_host = "Qvantum-HP"
+        mock_api._modbus_port = 502
+        mock_api._modbus_unit_id = 1
 
         mock_coordinator = MagicMock()
         mock_coordinator.modbus_enabled = True
@@ -318,6 +355,8 @@ class TestIntegrationSetup:
         mock_api = MagicMock()
         mock_api._modbus_tcp = True
         mock_api._modbus_host = "old-host"
+        mock_api._modbus_port = 502
+        mock_api._modbus_unit_id = 1
 
         mock_coordinator = MagicMock()
         mock_coordinator.modbus_enabled = True
@@ -350,6 +389,8 @@ class TestIntegrationSetup:
         mock_api = MagicMock()
         mock_api._modbus_tcp = False
         mock_api._modbus_host = "Qvantum-HP"
+        mock_api._modbus_port = 502
+        mock_api._modbus_unit_id = 1
 
         mock_coordinator = MagicMock()
         mock_coordinator.modbus_enabled = False
@@ -361,6 +402,40 @@ class TestIntegrationSetup:
         mock_config_entry.options = {
             "modbus_tcp": True,
             "modbus_host": "Qvantum-HP",
+        }
+        mock_config_entry.data = {}
+
+        await _async_update_listener(hass, mock_config_entry)
+
+        hass.config_entries.async_reload.assert_called_once_with(
+            mock_config_entry.entry_id
+        )
+        mock_coordinator.apply_poll_interval.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_update_listener_reloads_on_modbus_port_change(
+        self, hass, mock_config_entry
+    ):
+        """Changing Modbus port still requires a full reload."""
+        hass.config_entries.async_reload = AsyncMock()
+
+        mock_api = MagicMock()
+        mock_api._modbus_tcp = True
+        mock_api._modbus_host = "Qvantum-HP"
+        mock_api._modbus_port = 502
+        mock_api._modbus_unit_id = 1
+
+        mock_coordinator = MagicMock()
+        mock_coordinator.modbus_enabled = True
+        mock_coordinator.api = mock_api
+        mock_coordinator.apply_poll_interval = MagicMock()
+
+        mock_config_entry.runtime_data = MagicMock()
+        mock_config_entry.runtime_data.coordinator = mock_coordinator
+        mock_config_entry.options = {
+            "modbus_tcp": True,
+            "modbus_host": "Qvantum-HP",
+            "modbus_port": 1502,
         }
         mock_config_entry.data = {}
 
@@ -393,6 +468,9 @@ class TestIntegrationSetup:
         mock_firmware_coordinator.async_config_entry_first_refresh = AsyncMock()
 
         with (
+            patch(
+                "custom_components.qvantum._async_modbus_unit", return_value=MagicMock()
+            ),
             patch("custom_components.qvantum.QvantumAPI", return_value=mock_api),
             patch(
                 "custom_components.qvantum.QvantumDataUpdateCoordinator",
@@ -436,6 +514,9 @@ class TestIntegrationSetup:
         )
 
         with (
+            patch(
+                "custom_components.qvantum._async_modbus_unit", return_value=MagicMock()
+            ),
             patch("custom_components.qvantum.QvantumAPI", return_value=mock_api),
             patch(
                 "custom_components.qvantum.QvantumDataUpdateCoordinator",
@@ -476,6 +557,9 @@ class TestIntegrationSetup:
         )
 
         with (
+            patch(
+                "custom_components.qvantum._async_modbus_unit", return_value=MagicMock()
+            ),
             patch("custom_components.qvantum.QvantumAPI", return_value=mock_api),
             patch(
                 "custom_components.qvantum.QvantumDataUpdateCoordinator",
@@ -490,6 +574,67 @@ class TestIntegrationSetup:
             result = await async_setup_entry(hass, mock_config_entry)
 
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_async_setup_entry_requests_shared_modbus_unit(
+        self, hass, mock_config_entry, mock_api, mock_coordinator
+    ):
+        """Modbus setup borrows a unit from Home Assistant instead of opening TCP."""
+        mock_config_entry.options = {
+            "modbus_tcp": True,
+            "modbus_host": "hp.local",
+            "modbus_port": 502,
+            "modbus_unit_id": 1,
+        }
+        mock_coordinator.data = {
+            "device": {"id": "test_device_123", "model": "QE-6", "vendor": "Qvantum"},
+            "values": {},
+        }
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator.async_restore_dhw_state = AsyncMock()
+        mock_config_entry.add_update_listener = MagicMock()
+        unit = MagicMock()
+        mock_firmware_coordinator = MagicMock()
+        mock_firmware_coordinator.async_config_entry_first_refresh = AsyncMock()
+
+        with (
+            patch(
+                "custom_components.qvantum._async_modbus_unit", return_value=unit
+            ) as get_unit,
+            patch("custom_components.qvantum.QvantumAPI", return_value=mock_api) as api_ctor,
+            patch(
+                "custom_components.qvantum.QvantumDataUpdateCoordinator",
+                return_value=mock_coordinator,
+            ),
+            patch(
+                "custom_components.qvantum.QvantumMaintenanceCoordinator",
+                return_value=mock_firmware_coordinator,
+            ),
+            patch("custom_components.qvantum.services.async_setup_services"),
+        ):
+            result = await async_setup_entry(hass, mock_config_entry)
+
+        assert result is True
+        get_unit.assert_called_once_with(hass, mock_config_entry)
+        assert api_ctor.call_args.kwargs["modbus_unit"] is unit
+        assert api_ctor.call_args.kwargs["modbus_tcp"] is True
+        assert api_ctor.call_args.kwargs["modbus_host"] == "hp.local"
+
+    @pytest.mark.asyncio
+    async def test_async_setup_entry_modbus_conflict_raises_not_ready(
+        self, hass, mock_config_entry
+    ):
+        """Conflicting link settings on a shared Modbus endpoint fail setup."""
+        from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+
+        mock_config_entry.options = {"modbus_tcp": True, "modbus_host": "hp.local"}
+
+        with patch(
+            "custom_components.qvantum._async_modbus_unit",
+            side_effect=HomeAssistantError("already in use"),
+        ):
+            with pytest.raises(ConfigEntryNotReady, match="already in use"):
+                await async_setup_entry(hass, mock_config_entry)
 
     @pytest.mark.asyncio
     async def test_async_setup_entry_http_timeout_raises_not_ready(

--- a/tests/test_modbus_device.py
+++ b/tests/test_modbus_device.py
@@ -1,0 +1,217 @@
+"""Tests for the typed Modbus model and dict adapter."""
+
+import pytest
+from modbus_connection.mock import MockModbusConnection
+
+from custom_components.qvantum.modbus import (
+    MODBUS_HOLDING_REGISTER_MAP,
+    MODBUS_INPUT_REGISTER_MAP,
+    RELAY_BIT_MAP,
+)
+from custom_components.qvantum.modbus_device import (
+    QvantumModbusDevice,
+    build_metrics_payload,
+    build_settings_payload,
+    component_values,
+    holding_field_for_metric,
+)
+from custom_components.qvantum.modbus_model import QvantumInputs, QvantumSettings
+
+
+def _device():
+    connection = MockModbusConnection()
+    unit = connection.for_unit(1)
+    return connection, unit, QvantumModbusDevice(unit)
+
+
+class TestRegisterMapAlignment:
+    def test_input_fields_match_register_map(self):
+        for name, (address, data_type, scale) in MODBUS_INPUT_REGISTER_MAP.items():
+            if name == "relays_bitmask":
+                continue
+            field = QvantumInputs.declared_fields[name]
+            assert field.address == address
+            assert field.signed is (data_type == "int16")
+            assert (field.scale or 1.0) == scale
+
+    def test_relay_bits_use_bitmask_register(self):
+        bitmask_address = MODBUS_INPUT_REGISTER_MAP["relays_bitmask"][0]
+        for name, index in RELAY_BIT_MAP.items():
+            field = QvantumInputs.declared_fields[name]
+            assert field.address == bitmask_address
+            assert field.start == index
+
+    def test_holding_fields_match_register_map(self):
+        for name, (address, data_type, scale) in MODBUS_HOLDING_REGISTER_MAP.items():
+            field = QvantumSettings.declared_fields[name]
+            assert field.address == address
+            assert field.signed is (data_type == "int16")
+            assert (field.scale or 1.0) == scale
+            assert field.writable is True
+
+
+class TestComponentDecode:
+    @pytest.mark.asyncio
+    async def test_decodes_scaled_signed_and_bits(self):
+        _, unit, device = _device()
+        unit.input[0] = 215  # bt1 21.5
+        unit.input[2] = 0xFFD8  # bt2 -4.0 as int16
+        unit.input[33] = 0b0101  # L1 and L3 heat relays
+        unit.input[93] = 420  # compressor_power
+        unit.input[95] = 4
+        unit.input[96] = 8010  # compressor_kwh scale 0.1
+
+        await device.async_update_inputs()
+        values = component_values(device.inputs)
+
+        assert values["bt1"] == 21.5
+        assert values["bt2"] == -4.0
+        assert values["picpin_relay_heat_l1"] == 1
+        assert values["picpin_relay_heat_l2"] == 0
+        assert values["picpin_relay_heat_l3"] == 1
+        assert values["compressor_power"] == 420
+        assert values["compressor_kwh"] == 801.0
+
+    @pytest.mark.asyncio
+    async def test_input_poll_uses_few_block_reads(self):
+        _, unit, device = _device()
+        await device.async_update_inputs()
+        input_reads = [
+            event for event in unit.read_events if event.register_type == "input"
+        ]
+        assert len(input_reads) <= 3
+        assert all(event.count <= 125 for event in input_reads)
+        covered = {
+            addr
+            for event in input_reads
+            for addr in range(event.address, event.address + event.count)
+        }
+        assert not set(range(105, 161)) & covered
+
+    @pytest.mark.asyncio
+    async def test_settings_poll_uses_one_block_read(self):
+        _, unit, device = _device()
+        await device.async_update_settings()
+        holding_reads = [
+            event for event in unit.read_events if event.register_type == "holding"
+        ]
+        assert len(holding_reads) == 1
+        assert holding_reads[0].address == 0
+        assert holding_reads[0].count == 89
+
+    @pytest.mark.asyncio
+    async def test_settings_write_applies_scale(self):
+        _, unit, device = _device()
+        await device.write_metric("room_comp_factor", 2.5)
+        await device.write_metric("room_temp_external", 21.5)
+        await device.write_metric("dhw_stop_extra", 75)
+
+        assert unit.holding[13] == 25
+        assert unit.holding[14] == 215
+        assert unit.holding[59] == 75
+
+    @pytest.mark.asyncio
+    async def test_raw_holding_write(self):
+        _, unit, device = _device()
+        await device.write_holding_register(9, 4)
+        assert unit.holding[9] == 4
+
+
+class TestPayloadAdapter:
+    def test_powertotal_from_relays_and_compressor(self):
+        payload = build_metrics_payload(
+            "dev",
+            {
+                "picpin_relay_heat_l1": 1,
+                "picpin_relay_heat_l2": 1,
+                "picpin_relay_heat_l3": 1,
+                "compressor_power": 100,
+            },
+        )
+        assert payload["metrics"]["powertotal"] == 5260.0
+        assert "compressor_power" not in payload["metrics"]
+        assert payload["metrics"]["hpid"] == "dev"
+
+    def test_compressorenergy_from_mwh_kwh(self):
+        payload = build_metrics_payload(
+            "dev",
+            {"compressor_mwh": 4, "compressor_kwh": 801.0},
+        )
+        assert payload["metrics"]["compressorenergy"] == 4801.0
+        assert "compressor_mwh" not in payload["metrics"]
+        assert "compressor_kwh" not in payload["metrics"]
+
+    def test_skips_energy_if_component_missing(self):
+        payload = build_metrics_payload("dev", {"compressor_mwh": 4})
+        assert "compressorenergy" not in payload["metrics"]
+
+    def test_skips_energy_if_component_non_numeric(self):
+        payload = build_metrics_payload(
+            "dev",
+            {"compressor_mwh": "not-a-number", "compressor_kwh": 1},
+        )
+        assert "compressorenergy" not in payload["metrics"]
+
+    def test_rounds_to_two_decimals(self):
+        payload = build_metrics_payload(
+            "dev",
+            {
+                "picpin_relay_heat_l1": 1,
+                "picpin_relay_heat_l2": 0,
+                "picpin_relay_heat_l3": 0,
+                "compressor_power": 100.12345,
+                "compressor_mwh": 1.2345,
+                "compressor_kwh": 2.3456,
+            },
+        )
+        assert payload["metrics"]["powertotal"] == 2260.12
+        assert payload["metrics"]["compressorenergy"] == 1236.85
+
+    def test_use_adaptive_from_smart_dhw_mode(self):
+        payload = build_metrics_payload("dev", {"smart_dhw_mode": 1})
+        assert payload["metrics"]["use_adaptive"] is True
+        assert payload["metrics"]["smart_sh_mode"] == 1
+
+    def test_filters_to_enabled_metrics_before_derivation(self):
+        payload = build_metrics_payload(
+            "dev",
+            {"bt1": 21.5, "compressor_mwh": 4, "compressor_kwh": 1},
+            enabled_metrics=["bt1"],
+        )
+        assert payload["metrics"]["bt1"] == 21.5
+        assert "compressorenergy" not in payload["metrics"]
+        assert "latency" not in payload["metrics"]
+
+    def test_settings_aliasing_and_hidden_keys(self):
+        payload = build_settings_payload(
+            {
+                "dhw_start_normal": 52,
+                "dhw_stop_normal": 62,
+                "operation_mode": 1,
+            }
+        )
+        settings = {item["name"]: item["value"] for item in payload["settings"]}
+        assert "dhw_start_normal" not in settings
+        assert "dhw_stop_normal" not in settings
+        assert settings["tap_water_start"] == 52
+        assert settings["tap_water_stop"] == 62
+        assert settings["op_mode"] == 1
+        assert "use_adaptive" not in settings
+
+    def test_extra_tap_water_and_fan_mapping(self):
+        payload = build_settings_payload(
+            {"dhw_mode": 2, "ventilation_state": 2}
+        )
+        settings = {item["name"]: item["value"] for item in payload["settings"]}
+        assert settings["extra_tap_water"] == "on"
+        assert settings["fanspeedselector"] == "extra"
+
+    def test_unknown_metric_raises(self):
+        with pytest.raises(
+            ValueError, match="No Modbus holding register mapping found"
+        ):
+            holding_field_for_metric("not_a_real_metric")
+
+    def test_holding_field_for_http_alias(self):
+        assert holding_field_for_metric("room_comp_factor") == "room_compensation"
+        assert holding_field_for_metric("dhw_stop_extra") == "dhw_stop_extra"


### PR DESCRIPTION
## Summary
- Replace the hand-rolled pymodbus TCP client with `modbus-connection` typed `Component`s (`QvantumInputs` / `QvantumSettings`) and a dict adapter so existing entities keep working.
- Borrow a `ModbusUnit` from Home Assistant’s shared `modbus` connection (`async_get_unit`) instead of opening a competing socket. Requires HA **2026.9+** (`hacs.json` floor `2026.9.0b0`).
- Pool register reads at `max_gap=16` with `register_ranges` that skip the refused input **105–160** hole. Live-probed on `Qvantum-HP` (unit 1): documented holes answer; a full poll at gap 1–16 succeeds; spanning 104–161 fails with exception 0x04.
- Tests use the in-memory mock unit; `run-tests.sh` installs `modbus-connection` into the existing venv.

## Test plan
- [x] `./run-tests.sh` — 559 passed
- [x] Live `async_update()` on `Qvantum-HP` after the gap change (`bt1=19.5`, indoor `20.1`)
- [ ] Enable Modbus on HA 2026.9+ and confirm polls stay on the Modbus path (no HTTP fallback in logs)
- [ ] Confirm another integration on the same host:502 serializes instead of fighting for the socket
- [ ] Reload options (interval-only vs host change) still behaves as before