### PR TITLE
feat: Keep Modbus mode fully offline (no HTTP)

### DIFF
--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -152,13 +152,17 @@ class RuntimeData:
 async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) -> bool:
     """Set up Qvantum Heat Pump Integration from a config entry."""
 
-    username = config_entry.data.get(CONF_USERNAME)
-    password = config_entry.data.get(CONF_PASSWORD)
     user_agent = f"Home Assistant/{MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION} Qvantum/{VERSION}"
 
     modbus_enabled, modbus_host, modbus_port, modbus_unit_id = _modbus_link_settings(
         config_entry
     )
+    if modbus_enabled:
+        username = None
+        password = None
+    else:
+        username = config_entry.data[CONF_USERNAME]
+        password = config_entry.data[CONF_PASSWORD]
     try:
         modbus_unit = _async_modbus_unit(hass, config_entry)
     except HomeAssistantError as err:

--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -152,8 +152,8 @@ class RuntimeData:
 async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) -> bool:
     """Set up Qvantum Heat Pump Integration from a config entry."""
 
-    username = config_entry.data[CONF_USERNAME]
-    password = config_entry.data[CONF_PASSWORD]
+    username = config_entry.data.get(CONF_USERNAME)
+    password = config_entry.data.get(CONF_PASSWORD)
     user_agent = f"Home Assistant/{MAJOR_VERSION}.{MINOR_VERSION}.{PATCH_VERSION} Qvantum/{VERSION}"
 
     modbus_enabled, modbus_host, modbus_port, modbus_unit_id = _modbus_link_settings(
@@ -168,8 +168,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) ->
         ) from err
 
     hass.data[DOMAIN] = QvantumAPI(
-        username=username,
-        password=password,
+        username=None if modbus_enabled else username,
+        password=None if modbus_enabled else password,
         user_agent=user_agent,
         modbus_tcp=modbus_enabled,
         modbus_host=modbus_host,
@@ -211,7 +211,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) ->
         translation_key="qvantum_flvp",
         name="Qvantum",
         serial_number=device_data.get("serial"),
-        sw_version=_device_sw_version(device_metadata),
+        sw_version=device_data.get("sw_version")
+        or _device_sw_version(device_metadata),
     )
 
     # Only register the service if it hasn't been registered yet
@@ -222,22 +223,18 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) ->
     maintenance_coordinator = QvantumMaintenanceCoordinator(
         hass, config_entry, coordinator
     )
-    try:
-        await asyncio.wait_for(
-            maintenance_coordinator.async_config_entry_first_refresh(),
-            timeout=HTTP_CLOUD_LOOKUP_TIMEOUT,
-        )
-    except (ConfigEntryNotReady, asyncio.TimeoutError) as err:
-        if not modbus_enabled:
+    if not modbus_enabled:
+        try:
+            await asyncio.wait_for(
+                maintenance_coordinator.async_config_entry_first_refresh(),
+                timeout=HTTP_CLOUD_LOOKUP_TIMEOUT,
+            )
+        except (ConfigEntryNotReady, asyncio.TimeoutError) as err:
             if isinstance(err, asyncio.TimeoutError):
                 raise ConfigEntryNotReady(
                     "Firmware/access check timed out"
                 ) from err
             raise
-        _LOGGER.warning(
-            "Cloud API unavailable during firmware/access check; continuing with local Modbus: %s",
-            err,
-        )
 
     remove_listener = config_entry.add_update_listener(_async_update_listener)
     config_entry.async_on_unload(remove_listener)

--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -15,7 +15,11 @@ from .const import (
     TAP_WATER_CAPACITY_MAPPINGS,
 )
 from .modbus import MODBUS_HOLDING_REGISTER_MAP, MODBUS_HOLDING_TO_SETTINGS_MAP
-from .modbus_device import QvantumModbusDevice, holding_field_for_metric
+from .modbus_device import (
+    IdentityProbeError,
+    QvantumModbusDevice,
+    holding_field_for_metric,
+)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,9 +45,9 @@ class QvantumAPI:
 
     def __init__(
         self,
-        username: str,
-        password: str,
-        user_agent: str,
+        username: str | None = None,
+        password: str | None = None,
+        user_agent: str = "",
         session: Optional[aiohttp.ClientSession] = None,
         modbus_tcp: bool = False,
         modbus_host: str = "qvantum-hp",
@@ -67,12 +71,12 @@ class QvantumAPI:
         self._modbus_device: QvantumModbusDevice | None = None
         self._modbus_lock = asyncio.Lock()
         self._closed = False
-        # Accept an optional aiohttp session for easier testing. If not provided,
-        # create one and mark it as owned so we can close it when `close()` is called.
+        # Modbus-only mode never opens an HTTP session. Cloud mode owns one
+        # unless a test injects a session.
         if session is not None:
             self._session = session
             self._session_owner = False
-        else:
+        elif not modbus_tcp:
             self._session = aiohttp.ClientSession(
                 headers={
                     "Content-Type": "application/json",
@@ -80,6 +84,9 @@ class QvantumAPI:
                 }
             )
             self._session_owner = True
+        else:
+            self._session = None
+            self._session_owner = False
         self._reset_state()
 
     def _reset_state(self):
@@ -170,7 +177,7 @@ class QvantumAPI:
             except ModbusError as err:
                 _LOGGER.error("Modbus error %s: %s", error_label, err)
                 raise APIConnectionError(None, f"{failure_prefix}: {err}") from err
-            except (APIConnectionError, ValueError):
+            except (APIConnectionError, ValueError, IdentityProbeError):
                 raise
             except Exception as err:
                 _LOGGER.error(
@@ -244,6 +251,7 @@ class QvantumAPI:
     async def authenticate(self):
         """Authenticate with the API using username and password to retrieve a token."""
         self._ensure_open()
+        self._ensure_http()
         payload = {
             "returnSecureToken": "true",
             "email": self._username,
@@ -303,9 +311,34 @@ class QvantumAPI:
                     _LOGGER.error("Token refresh failed: %s", response.status)
                     # Don't raise exception here, let _ensure_valid_token handle it
 
+    def _ensure_http(self) -> None:
+        """Raise if this client has no HTTP session (Modbus-only mode)."""
+        if self._session is None:
+            raise APIConnectionError(
+                None, "HTTP API is not available in Modbus mode"
+            )
+
+    async def async_probe_identity(self) -> dict[str, Any]:
+        """Read serial and firmware from the heat pump over Modbus."""
+
+        async def _probe(device: QvantumModbusDevice):
+            await device.async_update_identity()
+            serial = device.serial_number
+            if not serial:
+                raise IdentityProbeError("Heat pump did not return a serial number")
+            return {
+                "id": serial,
+                "serial": serial,
+                "vendor": "Qvantum",
+                "sw_version": device.sw_version,
+            }
+
+        return await self._run_modbus(_probe, error_label="probing identity")
+
     async def _ensure_valid_token(self):
         """Ensure a valid token is available, refreshing if expired."""
         self._ensure_open()
+        self._ensure_http()
         if not self._token or datetime.now() >= self._token_expiry:
             try:
                 await self._refresh_authentication_token()
@@ -718,38 +751,19 @@ class QvantumAPI:
         )
 
         if self._modbus_tcp:
-            # Try Modbus first, then fall back to HTTP if Modbus is unavailable.
-            try:
-                modbus_start = asyncio.get_running_loop().time()
-                self._metrics_data = await self._read_modbus_metrics(device_id, names)
-                modbus_latency = int(
-                    (asyncio.get_running_loop().time() - modbus_start) * 1000
-                )
-                if (
-                    isinstance(self._metrics_data, dict)
-                    and "metrics" in self._metrics_data
-                ):
-                    self._metrics_data["metrics"]["latency"] = modbus_latency
-                return self._metrics_data
-            except (asyncio.CancelledError, APIConnectionError) as e:
-                # Do not HTTP-fallback when the client is closing/closed or the
-                # poll task was cancelled (config reload). Falling back would race
-                # unload and hit a None aiohttp session.
-                if isinstance(e, asyncio.CancelledError) or self._closed:
-                    raise
-                if "API client is closed" in str(e):
-                    raise
-                _LOGGER.warning(
-                    "Failed to read metrics via Modbus, falling back to HTTP: %s",
-                    e,
-                )
-            except Exception as e:
-                _LOGGER.warning(
-                    "Failed to read metrics via Modbus, falling back to HTTP: %s",
-                    e,
-                )
+            modbus_start = asyncio.get_running_loop().time()
+            self._metrics_data = await self._read_modbus_metrics(device_id, names)
+            modbus_latency = int(
+                (asyncio.get_running_loop().time() - modbus_start) * 1000
+            )
+            if (
+                isinstance(self._metrics_data, dict)
+                and "metrics" in self._metrics_data
+            ):
+                self._metrics_data["metrics"]["latency"] = modbus_latency
+            return self._metrics_data
 
-        # Fall back to HTTP API if Modbus is not available or fails.
+        # HTTP cloud mode.
         http_values, etag, total_latency = await self._get_http_values(
             device_id, names, etag_header=self._metrics_etag
         )
@@ -834,31 +848,14 @@ class QvantumAPI:
         self._ensure_open()
 
         if self._modbus_tcp:
-            # Read settings from Modbus holding registers
-            try:
-                # Read all settings that have a corresponding holding register
-                settings_to_read = [
-                    setting_key
-                    for setting_key in MODBUS_HOLDING_TO_SETTINGS_MAP.keys()
-                    if setting_key in MODBUS_HOLDING_REGISTER_MAP
-                ]
-                result = await self._read_modbus_settings(device_id, settings_to_read)
-                return result
-            except (asyncio.CancelledError, APIConnectionError) as e:
-                if isinstance(e, asyncio.CancelledError) or self._closed:
-                    raise
-                if "API client is closed" in str(e):
-                    raise
-                _LOGGER.warning(
-                    "Failed to read settings via Modbus, falling back to HTTP: %s", e
-                )
-            except Exception as e:
-                _LOGGER.warning(
-                    "Failed to read settings via Modbus, falling back to HTTP: %s", e
-                )
-                # Fall through to HTTP logic below
+            settings_to_read = [
+                setting_key
+                for setting_key in MODBUS_HOLDING_TO_SETTINGS_MAP.keys()
+                if setting_key in MODBUS_HOLDING_REGISTER_MAP
+            ]
+            return await self._read_modbus_settings(device_id, settings_to_read)
 
-        # Original HTTP logic
+        # HTTP cloud mode.
         await self._ensure_valid_token()
         headers = self._request_headers()
         if self._settings_etag:

--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -71,12 +71,15 @@ class QvantumAPI:
         self._modbus_device: QvantumModbusDevice | None = None
         self._modbus_lock = asyncio.Lock()
         self._closed = False
-        # Modbus-only mode never opens an HTTP session. Cloud mode owns one
-        # unless a test injects a session.
-        if session is not None:
+        # Modbus-only mode never opens an HTTP session, even if a caller
+        # injects one. Cloud mode owns a session unless a test injects it.
+        if modbus_tcp:
+            self._session = None
+            self._session_owner = False
+        elif session is not None:
             self._session = session
             self._session_owner = False
-        elif not modbus_tcp:
+        else:
             self._session = aiohttp.ClientSession(
                 headers={
                     "Content-Type": "application/json",
@@ -84,9 +87,6 @@ class QvantumAPI:
                 }
             )
             self._session_owner = True
-        else:
-            self._session = None
-            self._session_owner = False
         self._reset_state()
 
     def _reset_state(self):

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -12,7 +12,6 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt as dt_util
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.storage import Store
 
@@ -136,8 +135,6 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         self.api = hass.data[DOMAIN]
         self._config_entry = config_entry
         self._device = None
-        self._last_tap_stop_fetch: datetime | None = None
-        self._cached_tap_stop: Any = None
         self._last_heatingenergy: float | None = None
         self._last_heatingenergy_time: datetime | None = None
         self._last_dhwenergy: float | None = None
@@ -301,13 +298,12 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         """Persist device identity so Modbus can start without the HTTP API."""
         if not isinstance(self._device, dict) or not self._device.get("id"):
             return
+        payload: dict[str, Any] = {"device": self._device}
         username = self._current_username()
-        if not username:
-            return
+        if username:
+            payload["username"] = username
         try:
-            await self._device_store.async_save(
-                {"username": username, "device": self._device}
-            )
+            await self._device_store.async_save(payload)
         except Exception:
             _LOGGER.debug("Failed to persist device info", exc_info=True)
 
@@ -361,10 +357,10 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         return None
 
     async def _ensure_device(self) -> None:
-        """Populate device identity from cache, HTTP, or the device registry.
+        """Populate device identity from cache, Modbus probe, HTTP, or registry.
 
-        Cached identity is preferred so Modbus mode can start while the cloud
-        API is down. HTTP is only contacted when no cache is available.
+        Modbus mode never contacts the cloud. Cached identity is preferred so
+        existing unique IDs stay stable; otherwise the pump is probed.
         """
         if self._device is None:
             cached = await self._load_cached_device()
@@ -377,7 +373,31 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         if self._device is not None:
             return
 
-        http_error: Exception | None = None
+        if self.modbus_enabled:
+            try:
+                probed = await self.api.async_probe_identity()
+            except Exception as err:
+                _LOGGER.warning("Failed to probe Modbus identity: %s", err)
+                probed = None
+            if isinstance(probed, dict) and probed.get("id"):
+                self._device = probed
+                await self._persist_device_state()
+                return
+            if not self._store_account_mismatch:
+                from_registry = self._device_from_registry()
+                if from_registry:
+                    self._device = from_registry
+                    await self._persist_device_state()
+                    _LOGGER.warning(
+                        "Using device registry for local Modbus startup"
+                    )
+                    return
+            if self._store_account_mismatch:
+                _LOGGER.warning(
+                    "Skipping device registry recovery; cached identity is bound to a different account"
+                )
+            raise UpdateFailed("No device identity from Modbus or device registry")
+
         try:
             device = await asyncio.wait_for(
                 self.api.get_primary_device(),
@@ -388,27 +408,10 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
                 await self._persist_device_state()
                 return
         except Exception as err:
-            http_error = err
             _LOGGER.warning(
                 "Failed to fetch device info from HTTP API: %s", err
             )
-
-        if self.modbus_enabled and not self._store_account_mismatch:
-            from_registry = self._device_from_registry()
-            if from_registry:
-                self._device = from_registry
-                await self._persist_device_state()
-                _LOGGER.warning(
-                    "HTTP API unavailable; using device registry for local Modbus startup"
-                )
-                return
-        if self._store_account_mismatch:
-            _LOGGER.warning(
-                "Skipping device registry recovery; cached identity is bound to a different account"
-            )
-
-        if http_error is not None:
-            raise http_error
+            raise
 
     def _persist_dhw_state(self) -> None:
         """Save DHW EMA snapshot via a debounced write so it survives a restart.
@@ -580,41 +583,6 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         _LOGGER.debug("Processed %d settings", len(settings_dict))
         return settings_dict
 
-    async def _fetch_tap_stop_modbus(self, device_id: str, values: dict) -> None:
-        """Poll tap_stop via HTTP in Modbus mode when extra_tap_water is active.
-
-        tap_stop is HTTP-only; it is fetched at the DEFAULT HTTP scan interval
-        and cached between fetches.
-        """
-        now = dt_util.utcnow()
-        elapsed = (
-            (now - self._last_tap_stop_fetch).total_seconds()
-            if self._last_tap_stop_fetch is not None
-            else float("inf")
-        )
-        if elapsed > DEFAULT_SCAN_INTERVAL:
-            try:
-                _LOGGER.debug(
-                    "Fetching tap_stop via HTTP for device %s due to active extra_tap_water and elapsed time %.1f seconds",
-                    device_id,
-                    elapsed,
-                )
-                http_data = await self.api.get_http_metrics(device_id, ["tap_stop"])
-                tap_stop = http_data.get("metrics", {}).get("tap_stop")
-                if tap_stop is not None:
-                    self._cached_tap_stop = tap_stop
-                    values["tap_stop"] = tap_stop
-            except Exception as exc:
-                _LOGGER.warning(
-                    "Failed to fetch tap_stop via HTTP in Modbus mode for device %s: %s",
-                    device_id,
-                    exc,
-                )
-            finally:
-                self._last_tap_stop_fetch = now
-        elif self._cached_tap_stop is not None:
-            values["tap_stop"] = self._cached_tap_stop
-
     def _derive_tap_water_capacity(self, values: dict) -> None:
         """Derive tap_water_capacity_target from tap_water_start/stop when absent.
 
@@ -714,11 +682,6 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
             # Merge metrics and settings into unified values structure
             # Settings take precedence over metrics in case of conflicts
             values = {**metrics_dict, **settings_dict}
-
-            # In Modbus mode, tap_stop is HTTP-only. Poll it at the DEFAULT HTTP
-            # scan interval whenever extra_tap_water is active.
-            if self.modbus_enabled and values.get("extra_tap_water") == "on":
-                await self._fetch_tap_stop_modbus(device_id, values)
 
             self._derive_tap_water_capacity(values)
 

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -376,6 +376,8 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         if self.modbus_enabled:
             try:
                 probed = await self.api.async_probe_identity()
+            except asyncio.CancelledError:
+                raise
             except Exception as err:
                 _LOGGER.warning("Failed to probe Modbus identity: %s", err)
                 probed = None
@@ -407,6 +409,8 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
                 self._device = device
                 await self._persist_device_state()
                 return
+        except asyncio.CancelledError:
+            raise
         except Exception as err:
             _LOGGER.warning(
                 "Failed to fetch device info from HTTP API: %s", err

--- a/custom_components/qvantum/maintenance_coordinator.py
+++ b/custom_components/qvantum/maintenance_coordinator.py
@@ -46,6 +46,8 @@ class QvantumMaintenanceCoordinator(DataUpdateCoordinator):
 
     async def async_check_firmware_updates(self):
         """Check for firmware updates by fetching device metadata and comparing versions."""
+        if getattr(self.main_coordinator, "modbus_enabled", False):
+            return {}
         try:
             # Get the device from the main coordinator
             device = self.main_coordinator._device

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -114,8 +114,10 @@ class TestQvantumAPI:
         assert result["metrics"]["latency"] == metrics_data["total_latency"]
 
     @pytest.mark.asyncio
-    async def test_get_metrics_modbus_tcp_failure_fallback_http(self, mock_session):
-        """Modbus TCP failures should fall back to HTTP when explicitly enabled."""
+    async def test_get_metrics_modbus_tcp_failure_does_not_use_http(self, mock_session):
+        """Modbus TCP failures must not fall back to HTTP."""
+        from custom_components.qvantum.api import APIConnectionError
+
         api = QvantumAPI(
             "test@example.com",
             "password",
@@ -123,26 +125,16 @@ class TestQvantumAPI:
             session=mock_session,
             modbus_tcp=True,
         )
-        api._token = "test_token"
-        api._token_expiry = datetime.datetime.now() + datetime.timedelta(hours=1)
-
-        cm, mock_response = mock_session.make_cm_response(
-            status=200,
-            json_data={"values": {"bt1": 123}, "total_latency": 10},
-            headers={"ETag": "etag123"},
-        )
-        mock_session.get.return_value = cm
 
         with patch.object(
             QvantumAPI,
             "_read_modbus_metrics",
-            AsyncMock(side_effect=Exception("modbus not reachable")),
+            AsyncMock(side_effect=APIConnectionError(None, "modbus not reachable")),
         ):
-            result = await api.get_metrics("test_device_123", enabled_metrics=["bt1"])
+            with pytest.raises(APIConnectionError, match="modbus not reachable"):
+                await api.get_metrics("test_device_123", enabled_metrics=["bt1"])
 
-        assert "metrics" in result
-        assert result["metrics"]["bt1"] == 123
-        assert mock_session.get.called
+        mock_session.get.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_metrics_modbus_sets_latency_ms(self, mock_session):
@@ -317,6 +309,33 @@ class TestQvantumAPI:
         mock_session.post.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_modbus_mode_does_not_open_http_session(self):
+        """Modbus-only clients must not construct an aiohttp session."""
+        with patch("aiohttp.ClientSession") as mock_session_class:
+            api = QvantumAPI(modbus_tcp=True, user_agent="test-agent")
+        mock_session_class.assert_not_called()
+        assert api._session is None
+
+    @pytest.mark.asyncio
+    async def test_async_probe_identity(self):
+        api = QvantumAPI(modbus_tcp=True, user_agent="test-agent")
+        _connection, device = attach_mock_modbus(api)
+        api._modbus_unit.input[180] = 12
+        api._modbus_unit.input[181] = 3
+        api._modbus_unit.input[182] = 45
+        api._modbus_unit.input[183] = 6
+        api._modbus_unit.input[184] = 7
+        api._modbus_unit.input[191] = 1
+        api._modbus_unit.input[192] = 7
+        api._modbus_unit.input[193] = 22
+
+        result = await api.async_probe_identity()
+        assert result["id"] == "12003045006007"
+        assert result["serial"] == "12003045006007"
+        assert result["vendor"] == "Qvantum"
+        assert result["sw_version"] == "1.7.22"
+
+    @pytest.mark.asyncio
     async def test_get_metrics_modbus_cancel_does_not_http_fallback(self, mock_session):
         """Cancelled Modbus polls must not fall back to HTTP (reload race)."""
         api = QvantumAPI(
@@ -367,18 +386,12 @@ class TestQvantumAPI:
         mock_session.get.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_get_metrics_shared_connection_closed_falls_back_to_http(
+    async def test_get_metrics_shared_connection_closed_does_not_use_http(
         self, mock_session
     ):
-        """A closed borrowed Modbus link must still fall back to HTTP."""
+        """A closed borrowed Modbus link must not fall back to HTTP."""
+        from custom_components.qvantum.api import APIConnectionError
         from modbus_connection import ClientClosedError
-
-        cm, mock_response = mock_session.make_cm_response(
-            status=200,
-            json_data={"values": {"bt1": 123}, "total_latency": 10},
-            headers={"ETag": "etag123"},
-        )
-        mock_session.get.return_value = cm
 
         api = QvantumAPI(
             "test@example.com",
@@ -387,8 +400,6 @@ class TestQvantumAPI:
             session=mock_session,
             modbus_tcp=True,
         )
-        api._token = "test_token"
-        api._token_expiry = datetime.datetime.now() + datetime.timedelta(hours=1)
         _connection, device = attach_mock_modbus(api)
 
         async def closed_update():
@@ -396,10 +407,10 @@ class TestQvantumAPI:
 
         device.async_update_inputs = closed_update
 
-        result = await api.get_metrics("test_device", enabled_metrics=["bt1"])
+        with pytest.raises(APIConnectionError, match="Modbus communication failed"):
+            await api.get_metrics("test_device", enabled_metrics=["bt1"])
 
-        assert result["metrics"]["bt1"] == 123
-        assert mock_session.get.called
+        mock_session.get.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_close_waits_for_in_flight_modbus_lock(self):
@@ -1127,13 +1138,8 @@ class TestQvantumAPI:
 
     @pytest.mark.asyncio
     async def test_get_metrics_modbus_connection_failure(self, mock_session):
-        """Test Modbus connection failure falls back to HTTP."""
-        cm, mock_response = mock_session.make_cm_response(
-            status=200,
-            json_data={"values": {"bt1": 123}, "total_latency": 10},
-            headers={"ETag": "etag123"},
-        )
-        mock_session.get.return_value = cm
+        """Modbus connection failure must not fall back to HTTP."""
+        from custom_components.qvantum.api import APIConnectionError
 
         api = QvantumAPI(
             "test@example.com",
@@ -1142,16 +1148,13 @@ class TestQvantumAPI:
             session=mock_session,
             modbus_tcp=True,
         )
-        api._token = "test_token"
-        api._token_expiry = datetime.datetime.now() + datetime.timedelta(hours=1)
         _connection, device = attach_mock_modbus(api)
         device.unit.fail_requests(ModbusConnectionError())
 
-        result = await api.get_metrics("test_device", enabled_metrics=["bt1"])
+        with pytest.raises(APIConnectionError, match="Modbus communication failed"):
+            await api.get_metrics("test_device", enabled_metrics=["bt1"])
 
-        assert "metrics" in result
-        assert result["metrics"]["bt1"] == 123
-        assert mock_session.get.called
+        mock_session.get.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_get_settings_modbus(self, mock_session):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -317,6 +317,19 @@ class TestQvantumAPI:
         assert api._session is None
 
     @pytest.mark.asyncio
+    async def test_modbus_mode_discards_injected_http_session(self, mock_session):
+        """An injected aiohttp session must not be kept in Modbus-only mode."""
+        api = QvantumAPI(
+            "test@example.com",
+            "password",
+            "test-agent",
+            session=mock_session,
+            modbus_tcp=True,
+        )
+        assert api._session is None
+        assert api._session_owner is False
+
+    @pytest.mark.asyncio
     async def test_async_probe_identity(self):
         api = QvantumAPI(modbus_tcp=True, user_agent="test-agent")
         _connection, device = attach_mock_modbus(api)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,5 +1,6 @@
 """Tests for Qvantum coordinator functions."""
 
+import asyncio
 import pytest
 from datetime import datetime, timezone, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -3364,7 +3365,7 @@ class TestDeviceLookupWhenHttpDown:
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     @pytest.mark.asyncio
     async def test_load_cached_device_swallows_store_errors(self, mock_super_init):
-        """A corrupted device store must not prevent an HTTP lookup."""
+        """A corrupted device store must not prevent a Modbus-only update."""
         coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
         coordinator._device_store.async_load = AsyncMock(side_effect=OSError("disk"))
         mock_api.get_metrics = AsyncMock(return_value={"metrics": {}})
@@ -3377,7 +3378,8 @@ class TestDeviceLookupWhenHttpDown:
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     @pytest.mark.asyncio
-    async def test_persist_device_skips_without_username_or_id(self, mock_super_init):
+    async def test_persist_device_saves_unbound_payload_without_username(self, mock_super_init):
+        """Missing username still persists device identity without an account binding."""
         coordinator, _ = self._make_coordinator(mock_super_init, modbus=True)
         coordinator._device = {}
         await coordinator._persist_device_state()
@@ -3389,6 +3391,18 @@ class TestDeviceLookupWhenHttpDown:
         coordinator._device_store.async_save.assert_awaited_once_with(
             {"device": {"id": "test_device_123"}}
         )
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_modbus_identity_probe_propagates_cancellation(self, mock_super_init):
+        """Task cancellation during identity probe must abort the update."""
+        coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
+        mock_api.async_probe_identity = AsyncMock(side_effect=asyncio.CancelledError())
+
+        with pytest.raises(asyncio.CancelledError):
+            await coordinator._ensure_device()
+
+        mock_api.get_primary_device.assert_not_called()
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     @pytest.mark.asyncio

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -548,7 +548,9 @@ class TestQvantumDataUpdateCoordinator:
         mock_super_init.return_value = None
 
         mock_api = MagicMock()
-        mock_api.get_primary_device = AsyncMock(return_value={"id": "test_device_123"})
+        mock_api.async_probe_identity = AsyncMock(
+            return_value={"id": "test_device_123"}
+        )
         mock_api.get_metrics = AsyncMock(
             return_value={
                 "metrics": {
@@ -596,19 +598,16 @@ class TestQvantumDataUpdateCoordinator:
 
         assert result == {"a": 1}
 
-    @patch("custom_components.qvantum.coordinator.dt_util.utcnow")
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     @pytest.mark.asyncio
-    async def test_modbus_fetches_tap_stop_when_extra_tap_water_on(
-        self, mock_super_init, mock_utcnow
-    ):
-        """Test that tap_stop is fetched via HTTP when extra_tap_water is on in Modbus mode."""
+    async def test_modbus_never_fetches_tap_stop_via_http(self, mock_super_init):
+        """Modbus mode must not poll tap_stop over HTTP."""
         mock_super_init.return_value = None
-        fixed_now = datetime(2026, 4, 4, 12, 0, 0, tzinfo=timezone.utc)
-        mock_utcnow.return_value = fixed_now
 
         mock_api = MagicMock()
-        mock_api.get_primary_device = AsyncMock(return_value={"id": "test_device_123"})
+        mock_api.async_probe_identity = AsyncMock(
+            return_value={"id": "test_device_123"}
+        )
         mock_api.get_metrics = AsyncMock(
             return_value={"metrics": {"hpid": "test_device_123"}}
         )
@@ -637,110 +636,8 @@ class TestQvantumDataUpdateCoordinator:
 
         result = await coordinator.async_update_data()
 
-        mock_api.get_http_metrics.assert_called_once_with(
-            "test_device_123", ["tap_stop"]
-        )
-        assert result["values"]["tap_stop"] == 9999
-        assert coordinator._last_tap_stop_fetch == fixed_now
-
-    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
-    @pytest.mark.asyncio
-    async def test_modbus_uses_cached_tap_stop_within_poll_interval(
-        self, mock_super_init
-    ):
-        """Test that the cached tap_stop value is returned when within the poll interval."""
-        mock_super_init.return_value = None
-
-        mock_api = MagicMock()
-        mock_api.get_primary_device = AsyncMock(return_value={"id": "test_device_123"})
-        mock_api.get_metrics = AsyncMock(
-            return_value={"metrics": {"hpid": "test_device_123"}}
-        )
-        mock_api.get_settings = AsyncMock(
-            return_value={"settings": [{"name": "extra_tap_water", "value": "on"}]}
-        )
-        mock_api.get_http_metrics = AsyncMock(
-            return_value={"metrics": {"tap_stop": 9999}}
-        )
-
-        mock_hass = MagicMock()
-        mock_hass.data = {
-            DOMAIN: mock_api,
-            "device_registry": MagicMock(),
-            "entity_registry": MagicMock(),
-        }
-
-        mock_config_entry = MagicMock()
-        mock_config_entry.options.get.side_effect = _modbus_options_get
-        mock_config_entry.data = {}
-        mock_config_entry.unique_id = "test_device_123"
-
-        coordinator = QvantumDataUpdateCoordinator(mock_hass, mock_config_entry)
-        coordinator.api = mock_api
-        coordinator.hass = mock_hass
-
-        # First call: fetches from HTTP and caches
-        result1 = await coordinator.async_update_data()
-        assert result1["values"]["tap_stop"] == 9999
-        mock_api.get_http_metrics.assert_called_once()
-
-        # Second call within interval: should NOT fetch again but still return cached value
-        result2 = await coordinator.async_update_data()
-        assert result2["values"]["tap_stop"] == 9999
-        mock_api.get_http_metrics.assert_called_once()  # still only one call total
-
-    @patch("custom_components.qvantum.coordinator.dt_util.utcnow")
-    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
-    @pytest.mark.asyncio
-    async def test_modbus_refetches_tap_stop_after_interval_elapsed(
-        self, mock_super_init, mock_utcnow
-    ):
-        """Test that tap_stop is re-fetched after DEFAULT_SCAN_INTERVAL seconds have elapsed."""
-        mock_super_init.return_value = None
-        fixed_now = datetime(2026, 4, 4, 12, 0, 0, tzinfo=timezone.utc)
-        mock_utcnow.return_value = fixed_now
-
-        mock_api = MagicMock()
-        mock_api.get_primary_device = AsyncMock(return_value={"id": "test_device_123"})
-        mock_api.get_metrics = AsyncMock(
-            return_value={"metrics": {"hpid": "test_device_123"}}
-        )
-        mock_api.get_settings = AsyncMock(
-            return_value={"settings": [{"name": "extra_tap_water", "value": "on"}]}
-        )
-        mock_api.get_http_metrics = AsyncMock(
-            return_value={"metrics": {"tap_stop": 7777}}
-        )
-
-        mock_hass = MagicMock()
-        mock_hass.data = {
-            DOMAIN: mock_api,
-            "device_registry": MagicMock(),
-            "entity_registry": MagicMock(),
-        }
-
-        mock_config_entry = MagicMock()
-        mock_config_entry.options.get.side_effect = _modbus_options_get
-        mock_config_entry.data = {}
-        mock_config_entry.unique_id = "test_device_123"
-
-        coordinator = QvantumDataUpdateCoordinator(mock_hass, mock_config_entry)
-        coordinator.api = mock_api
-        coordinator.hass = mock_hass
-
-        # Simulate a previous fetch older than DEFAULT_SCAN_INTERVAL
-        coordinator._last_tap_stop_fetch = fixed_now - timedelta(
-            seconds=DEFAULT_SCAN_INTERVAL + 1
-        )
-        coordinator._cached_tap_stop = 1234  # stale cached value
-
-        result = await coordinator.async_update_data()
-
-        mock_api.get_http_metrics.assert_called_once_with(
-            "test_device_123", ["tap_stop"]
-        )
-        assert result["values"]["tap_stop"] == 7777
-        assert coordinator._last_tap_stop_fetch == fixed_now
+        mock_api.get_http_metrics.assert_not_called()
+        assert "tap_stop" not in result["values"]
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     @pytest.mark.asyncio
@@ -751,7 +648,9 @@ class TestQvantumDataUpdateCoordinator:
         mock_super_init.return_value = None
 
         mock_api = MagicMock()
-        mock_api.get_primary_device = AsyncMock(return_value={"id": "test_device_123"})
+        mock_api.async_probe_identity = AsyncMock(
+            return_value={"id": "test_device_123"}
+        )
         mock_api.get_metrics = AsyncMock(
             return_value={"metrics": {"hpid": "test_device_123"}}
         )
@@ -789,7 +688,9 @@ class TestQvantumDataUpdateCoordinator:
         mock_super_init.return_value = None
 
         mock_api = MagicMock()
-        mock_api.get_primary_device = AsyncMock(return_value={"id": "test_device_123"})
+        mock_api.async_probe_identity = AsyncMock(
+            return_value={"id": "test_device_123"}
+        )
         mock_api.get_metrics = AsyncMock(
             return_value={"metrics": {"hpid": "test_device_123"}}
         )
@@ -824,6 +725,9 @@ class TestHpStatusPostProcessing:
         mock_super_init.return_value = None
 
         mock_api = MagicMock()
+        mock_api.async_probe_identity = AsyncMock(
+            return_value={"id": "test_device_123"}
+        )
         mock_api.get_primary_device = AsyncMock(return_value={"id": "test_device_123"})
         mock_api.get_metrics = AsyncMock(return_value={"metrics": metrics})
         mock_api.get_settings = AsyncMock(return_value={"settings": []})
@@ -3177,6 +3081,14 @@ class TestDeviceLookupWhenHttpDown:
     def _make_coordinator(self, mock_super_init, *, modbus: bool):
         mock_super_init.return_value = None
         mock_api = MagicMock()
+        mock_api.async_probe_identity = AsyncMock(
+            return_value={
+                "id": "test_device_123",
+                "serial": "test_device_123",
+                "vendor": "Qvantum",
+            }
+        )
+        mock_api.get_primary_device = AsyncMock()
         mock_hass = MagicMock()
         mock_hass.data = {
             DOMAIN: mock_api,
@@ -3229,7 +3141,7 @@ class TestDeviceLookupWhenHttpDown:
     async def test_uses_device_registry_when_http_down(self, mock_super_init):
         """After a restart with no store file, fall back to the device registry."""
         coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
-        mock_api.get_primary_device = AsyncMock(side_effect=Exception("HTTP API down"))
+        mock_api.async_probe_identity = AsyncMock(side_effect=Exception("probe failed"))
         mock_api.get_metrics = AsyncMock(
             return_value={"metrics": {"hpid": "test_device_123"}}
         )
@@ -3254,7 +3166,7 @@ class TestDeviceLookupWhenHttpDown:
 
         assert result["device"]["id"] == "test_device_123"
         assert result["device"]["device_metadata"]["display_fw_version"] == "1.3.6"
-        mock_api.get_primary_device.assert_awaited()
+        mock_api.get_primary_device.assert_not_called()
         coordinator._device_store.async_save.assert_awaited()
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
@@ -3273,21 +3185,22 @@ class TestDeviceLookupWhenHttpDown:
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     @pytest.mark.asyncio
-    async def test_persists_device_after_successful_http_lookup(self, mock_super_init):
-        """A successful HTTP lookup is stored for later Modbus-only startups."""
+    async def test_persists_device_after_successful_probe(self, mock_super_init):
+        """A successful Modbus identity probe is stored for later startups."""
         coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
         device = {
-            "id": "test_device_123",
+            "id": "12003045006007",
+            "serial": "12003045006007",
             "vendor": "Qvantum",
-            "model": "QE-6",
-            "device_metadata": {"display_fw_version": "1.3.6"},
+            "sw_version": "1.7.22",
         }
-        mock_api.get_primary_device = AsyncMock(return_value=device)
+        mock_api.async_probe_identity = AsyncMock(return_value=device)
         mock_api.get_metrics = AsyncMock(return_value={"metrics": {}})
         mock_api.get_settings = AsyncMock(return_value={"settings": []})
 
         await coordinator.async_update_data()
 
+        mock_api.get_primary_device.assert_not_called()
         coordinator._device_store.async_save.assert_awaited_once_with(
             {"username": "test@example.com", "device": device}
         )
@@ -3362,17 +3275,17 @@ class TestDeviceLookupWhenHttpDown:
         )
         device = {
             "id": "new_device",
+            "serial": "new_device",
             "vendor": "Qvantum",
-            "model": "QE-6",
-            "device_metadata": {"display_fw_version": "1.3.6"},
         }
-        mock_api.get_primary_device = AsyncMock(return_value=device)
+        mock_api.async_probe_identity = AsyncMock(return_value=device)
         mock_api.get_metrics = AsyncMock(return_value={"metrics": {}})
         mock_api.get_settings = AsyncMock(return_value={"settings": []})
 
         result = await coordinator.async_update_data()
 
-        mock_api.get_primary_device.assert_awaited()
+        mock_api.get_primary_device.assert_not_called()
+        mock_api.async_probe_identity.assert_awaited()
         assert result["device"]["id"] == "new_device"
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
@@ -3390,7 +3303,7 @@ class TestDeviceLookupWhenHttpDown:
                 "device": {"id": "old_device", "model": "QE-6"},
             }
         )
-        mock_api.get_primary_device = AsyncMock(side_effect=Exception("HTTP API down"))
+        mock_api.async_probe_identity = AsyncMock(side_effect=Exception("probe failed"))
 
         ha_device = MagicMock()
         ha_device.config_entries = {"test_entry_id"}
@@ -3424,7 +3337,7 @@ class TestDeviceLookupWhenHttpDown:
         coordinator._device_store.async_load = AsyncMock(
             return_value={"id": "test_device_123", "model": "QE-6"}
         )
-        mock_api.get_primary_device = AsyncMock(side_effect=Exception("HTTP API down"))
+        mock_api.async_probe_identity = AsyncMock(side_effect=Exception("probe failed"))
         mock_api.get_metrics = AsyncMock(return_value={"metrics": {}})
         mock_api.get_settings = AsyncMock(return_value={"settings": []})
 
@@ -3454,13 +3367,12 @@ class TestDeviceLookupWhenHttpDown:
         """A corrupted device store must not prevent an HTTP lookup."""
         coordinator, mock_api = self._make_coordinator(mock_super_init, modbus=True)
         coordinator._device_store.async_load = AsyncMock(side_effect=OSError("disk"))
-        device = {"id": "test_device_123", "device_metadata": {"display_fw_version": "1"}}
-        mock_api.get_primary_device = AsyncMock(return_value=device)
         mock_api.get_metrics = AsyncMock(return_value={"metrics": {}})
         mock_api.get_settings = AsyncMock(return_value={"settings": []})
 
         result = await coordinator.async_update_data()
 
+        mock_api.get_primary_device.assert_not_called()
         assert result["device"]["id"] == "test_device_123"
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
@@ -3474,7 +3386,9 @@ class TestDeviceLookupWhenHttpDown:
         coordinator._device = {"id": "test_device_123"}
         coordinator._config_entry.data = {"username": ""}
         await coordinator._persist_device_state()
-        coordinator._device_store.async_save.assert_not_called()
+        coordinator._device_store.async_save.assert_awaited_once_with(
+            {"device": {"id": "test_device_123"}}
+        )
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     @pytest.mark.asyncio

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -97,6 +97,16 @@ class TestIntegrationSetup:
     """Test the integration setup functions."""
 
     @pytest.mark.asyncio
+    async def test_async_setup_entry_cloud_requires_credentials(
+        self, hass, mock_config_entry
+    ):
+        """Cloud setup must fail fast when username or password is missing."""
+        mock_config_entry.data = {}
+        mock_config_entry.options = {}
+        with pytest.raises(KeyError):
+            await async_setup_entry(hass, mock_config_entry)
+
+    @pytest.mark.asyncio
     async def test_async_setup_entry_success(
         self, hass, mock_config_entry, mock_api, mock_coordinator
     ):

--- a/tests/test_maintenance_coordinator.py
+++ b/tests/test_maintenance_coordinator.py
@@ -100,6 +100,21 @@ class TestQvantumMaintenanceCoordinator:
         assert result == {}
 
     @pytest.mark.asyncio
+    async def test_async_check_firmware_updates_skips_cloud_in_modbus_mode(
+        self, maintenance_coordinator, mock_main_coordinator
+    ):
+        """Modbus mode must not call the cloud firmware/access APIs."""
+        mock_main_coordinator.modbus_enabled = True
+        maintenance_coordinator.api.get_device_metadata = AsyncMock()
+        maintenance_coordinator.api.get_access_level = AsyncMock()
+
+        result = await maintenance_coordinator.async_check_firmware_updates()
+
+        assert result == {}
+        maintenance_coordinator.api.get_device_metadata.assert_not_called()
+        maintenance_coordinator.api.get_access_level.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_async_check_firmware_updates_initial_versions(
         self, maintenance_coordinator, mock_main_coordinator
     ):
@@ -220,32 +235,31 @@ class TestQvantumMaintenanceCoordinator:
 
         result = await maintenance_coordinator.async_check_firmware_updates()
 
-        assert "access_level" not in result
+        assert result == {}
+        maintenance_coordinator.api.get_device_metadata.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_async_check_firmware_updates_http_down_clears_stale_access(
         self, maintenance_coordinator, mock_main_coordinator
     ):
-        """A later outage must not keep a previous access_level in effect."""
+        """Modbus mode does not keep cloud access_level; it never fetches it."""
         mock_main_coordinator.modbus_enabled = True
         maintenance_coordinator.data = {
             "firmware_versions": {"display_fw_version": "1.3.6"},
             "access_level": {"writeAccessLevel": 20},
         }
-        maintenance_coordinator.api.get_device_metadata = AsyncMock(
-            side_effect=Exception("HTTP API down")
-        )
+        maintenance_coordinator.api.get_device_metadata = AsyncMock()
 
         result = await maintenance_coordinator.async_check_firmware_updates()
 
-        assert "access_level" not in result
-        assert result["firmware_versions"]["display_fw_version"] == "1.3.6"
+        assert result == {}
+        maintenance_coordinator.api.get_device_metadata.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_async_check_firmware_updates_auth_error_modbus_clears_access(
         self, maintenance_coordinator, mock_main_coordinator
     ):
-        """Auth failures in Modbus mode must not keep a previous access_level."""
+        """Modbus mode does not call the cloud, so auth errors cannot occur."""
         mock_main_coordinator.modbus_enabled = True
         maintenance_coordinator.data = {
             "firmware_versions": {"display_fw_version": "1.3.6"},
@@ -257,8 +271,8 @@ class TestQvantumMaintenanceCoordinator:
 
         result = await maintenance_coordinator.async_check_firmware_updates()
 
-        assert "access_level" not in result
-        assert result["firmware_versions"]["display_fw_version"] == "1.3.6"
+        assert result == {}
+        maintenance_coordinator.api.get_device_metadata.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_async_check_firmware_updates_auth_error_http_still_fails(


### PR DESCRIPTION
When Modbus TCP is on, skip the aiohttp session, inventory lookup, metrics/settings HTTP fallback, `tap_stop` HTTP poll, and maintenance cloud checks.

Identity comes from cache, a serial/firmware probe, or the device registry.

Depends on the identity-probe PR. This is 2/5 of the local-Modbus stack.