### PR TITLE
feat: Split setup into cloud HTTP or local Modbus

### DIFF
--- a/custom_components/qvantum/config_flow.py
+++ b/custom_components/qvantum/config_flow.py
@@ -84,12 +84,17 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     try:
         await api.authenticate()
         device = await api.get_primary_device()
-        serial = device.get("serial") if isinstance(device, dict) else None
-        title = (
-            f"{device.get('vendor')} {device.get('model')} ({serial})"
-            if isinstance(device, dict)
-            else "Qvantum"
-        )
+        if isinstance(device, dict):
+            serial = device.get("serial")
+            if serial is not None:
+                serial = str(serial).strip() or None
+            vendor = str(device.get("vendor") or "").strip()
+            model = str(device.get("model") or "").strip()
+            name = " ".join(part for part in (vendor, model) if part) or "Qvantum"
+            title = f"{name} ({serial})" if serial else name
+        else:
+            serial = None
+            title = "Qvantum"
         return {"title": title, "serial": serial}
     except APIAuthError as err:
         raise InvalidAuth from err

--- a/custom_components/qvantum/config_flow.py
+++ b/custom_components/qvantum/config_flow.py
@@ -52,20 +52,31 @@ STEP_CLOUD_DATA_SCHEMA = vol.Schema(
     }
 )
 
-STEP_MODBUS_DATA_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_MODBUS_HOST, default=DEFAULT_MODBUS_HOST): str,
-        vol.Optional(CONF_MODBUS_PORT, default=DEFAULT_MODBUS_PORT): vol.All(
-            vol.Coerce(int), vol.Range(min=1, max=65535)
-        ),
-        vol.Optional(CONF_MODBUS_UNIT_ID, default=DEFAULT_MODBUS_UNIT_ID): vol.All(
-            vol.Coerce(int), vol.Range(min=1, max=247)
-        ),
-        vol.Optional(
-            CONF_MODBUS_SCAN_INTERVAL, default=DEFAULT_MODBUS_SCAN_INTERVAL
-        ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_MODBUS_SCAN_INTERVAL)),
-    }
-)
+def _modbus_user_schema(
+    *,
+    host: str = DEFAULT_MODBUS_HOST,
+    port: int = DEFAULT_MODBUS_PORT,
+    unit_id: int = DEFAULT_MODBUS_UNIT_ID,
+    interval: int = DEFAULT_MODBUS_SCAN_INTERVAL,
+) -> vol.Schema:
+    """Build the Modbus form, preserving submitted values on retry."""
+    return vol.Schema(
+        {
+            vol.Required(CONF_MODBUS_HOST, default=host): str,
+            vol.Optional(CONF_MODBUS_PORT, default=port): vol.All(
+                vol.Coerce(int), vol.Range(min=1, max=65535)
+            ),
+            vol.Optional(CONF_MODBUS_UNIT_ID, default=unit_id): vol.All(
+                vol.Coerce(int), vol.Range(min=1, max=247)
+            ),
+            vol.Optional(CONF_MODBUS_SCAN_INTERVAL, default=interval): vol.All(
+                vol.Coerce(int), vol.Clamp(min=MIN_MODBUS_SCAN_INTERVAL)
+            ),
+        }
+    )
+
+
+STEP_MODBUS_DATA_SCHEMA = _modbus_user_schema()
 
 
 def _normalize_modbus_scan_interval(value: Any) -> int:
@@ -210,6 +221,10 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Set up using local Modbus TCP."""
         errors: dict[str, str] = {}
+        host = DEFAULT_MODBUS_HOST
+        port = DEFAULT_MODBUS_PORT
+        unit_id = DEFAULT_MODBUS_UNIT_ID
+        interval = DEFAULT_MODBUS_SCAN_INTERVAL
         if user_input is not None:
             host = _normalize_modbus_host(user_input.get(CONF_MODBUS_HOST))
             port = int(user_input.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT))
@@ -247,7 +262,9 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
         return self.async_show_form(
             step_id="modbus",
-            data_schema=STEP_MODBUS_DATA_SCHEMA,
+            data_schema=_modbus_user_schema(
+                host=host, port=port, unit_id=unit_id, interval=interval
+            ),
             errors=errors,
         )
 
@@ -318,6 +335,29 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
         """Reconfigure using local Modbus TCP."""
         errors: dict[str, str] = {}
         config_entry = self._reconfigure_entry()
+        host = _normalize_modbus_host(
+            config_entry.options.get(
+                CONF_MODBUS_HOST,
+                config_entry.data.get(CONF_MODBUS_HOST, DEFAULT_MODBUS_HOST),
+            )
+        )
+        port = int(
+            config_entry.options.get(
+                CONF_MODBUS_PORT,
+                config_entry.data.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT),
+            )
+        )
+        unit_id = int(
+            config_entry.options.get(
+                CONF_MODBUS_UNIT_ID,
+                config_entry.data.get(CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID),
+            )
+        )
+        interval = _normalize_modbus_scan_interval(
+            config_entry.options.get(
+                CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL
+            )
+        )
         if user_input is not None:
             host = _normalize_modbus_host(user_input.get(CONF_MODBUS_HOST))
             port = int(user_input.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT))
@@ -355,43 +395,8 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
                 )
         return self.async_show_form(
             step_id="reconfigure_modbus",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_MODBUS_HOST,
-                        default=config_entry.options.get(
-                            CONF_MODBUS_HOST,
-                            config_entry.data.get(CONF_MODBUS_HOST, DEFAULT_MODBUS_HOST),
-                        ),
-                    ): str,
-                    vol.Optional(
-                        CONF_MODBUS_PORT,
-                        default=config_entry.options.get(
-                            CONF_MODBUS_PORT,
-                            config_entry.data.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT),
-                        ),
-                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
-                    vol.Optional(
-                        CONF_MODBUS_UNIT_ID,
-                        default=config_entry.options.get(
-                            CONF_MODBUS_UNIT_ID,
-                            config_entry.data.get(
-                                CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID
-                            ),
-                        ),
-                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=247)),
-                    vol.Optional(
-                        CONF_MODBUS_SCAN_INTERVAL,
-                        default=_normalize_modbus_scan_interval(
-                            config_entry.options.get(
-                                CONF_MODBUS_SCAN_INTERVAL,
-                                DEFAULT_MODBUS_SCAN_INTERVAL,
-                            )
-                        ),
-                    ): vol.All(
-                        vol.Coerce(int), vol.Clamp(min=MIN_MODBUS_SCAN_INTERVAL)
-                    ),
-                }
+            data_schema=_modbus_user_schema(
+                host=host, port=port, unit_id=unit_id, interval=interval
             ),
             errors=errors,
         )

--- a/custom_components/qvantum/config_flow.py
+++ b/custom_components/qvantum/config_flow.py
@@ -77,6 +77,12 @@ def _normalize_modbus_scan_interval(value: Any) -> int:
     return max(interval, MIN_MODBUS_SCAN_INTERVAL)
 
 
+def _normalize_modbus_host(value: Any) -> str:
+    """Strip host whitespace and fall back to the default when empty."""
+    host = str(value or "").strip()
+    return host or DEFAULT_MODBUS_HOST
+
+
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate cloud credentials and return a title."""
     user_agent = f"Home Assistant/{ha_version} Qvantum/{VERSION}"
@@ -205,7 +211,7 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
         """Set up using local Modbus TCP."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            host = str(user_input[CONF_MODBUS_HOST])
+            host = _normalize_modbus_host(user_input.get(CONF_MODBUS_HOST))
             port = int(user_input.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT))
             unit_id = int(user_input.get(CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID))
             interval = _normalize_modbus_scan_interval(
@@ -313,7 +319,7 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         config_entry = self._reconfigure_entry()
         if user_input is not None:
-            host = str(user_input[CONF_MODBUS_HOST])
+            host = _normalize_modbus_host(user_input.get(CONF_MODBUS_HOST))
             port = int(user_input.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT))
             unit_id = int(user_input.get(CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID))
             interval = _normalize_modbus_scan_interval(
@@ -419,8 +425,8 @@ class QvantumOptionsFlowHandler(OptionsFlow):
                 normalized = {
                     CONF_MODBUS_TCP: True,
                     CONF_MODBUS_WRITE: False,
-                    CONF_MODBUS_HOST: user_input.get(
-                        CONF_MODBUS_HOST, DEFAULT_MODBUS_HOST
+                    CONF_MODBUS_HOST: _normalize_modbus_host(
+                        user_input.get(CONF_MODBUS_HOST, DEFAULT_MODBUS_HOST)
                     ),
                     CONF_MODBUS_PORT: int(
                         user_input.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT)

--- a/custom_components/qvantum/config_flow.py
+++ b/custom_components/qvantum/config_flow.py
@@ -25,37 +25,47 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .api import QvantumAPI, APIAuthError, APIConnectionError
 from .const import (
+    DEFAULT_MODBUS_HOST,
+    DEFAULT_MODBUS_PORT,
     DEFAULT_MODBUS_SCAN_INTERVAL,
+    DEFAULT_MODBUS_UNIT_ID,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     MIN_MODBUS_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
     VERSION,
     CONFIG_VERSION,
+    CONF_MODBUS_HOST,
+    CONF_MODBUS_PORT,
     CONF_MODBUS_SCAN_INTERVAL,
     CONF_MODBUS_TCP,
+    CONF_MODBUS_UNIT_ID,
     CONF_MODBUS_WRITE,
-    CONF_MODBUS_HOST,
-    DEFAULT_MODBUS_HOST,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
-STEP_USER_DATA_SCHEMA = vol.Schema(
+STEP_CLOUD_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required("username"): str,
-        vol.Required("password"): str,
-        vol.Optional(CONF_MODBUS_TCP, default=False): bool,
-        vol.Optional(CONF_MODBUS_WRITE, default=False): bool,
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
     }
 )
 
-
-def _normalize_modbus_settings(
-    modbus_enabled: bool, modbus_write_enabled: bool
-) -> tuple[bool, bool]:
-    """Ensure modbus_write cannot be enabled when modbus_tcp is disabled."""
-    return modbus_enabled, modbus_write_enabled and modbus_enabled
+STEP_MODBUS_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_MODBUS_HOST, default=DEFAULT_MODBUS_HOST): str,
+        vol.Optional(CONF_MODBUS_PORT, default=DEFAULT_MODBUS_PORT): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=65535)
+        ),
+        vol.Optional(CONF_MODBUS_UNIT_ID, default=DEFAULT_MODBUS_UNIT_ID): vol.All(
+            vol.Coerce(int), vol.Range(min=1, max=247)
+        ),
+        vol.Optional(
+            CONF_MODBUS_SCAN_INTERVAL, default=DEFAULT_MODBUS_SCAN_INTERVAL
+        ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_MODBUS_SCAN_INTERVAL)),
+    }
+)
 
 
 def _normalize_modbus_scan_interval(value: Any) -> int:
@@ -68,18 +78,19 @@ def _normalize_modbus_scan_interval(value: Any) -> int:
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate the user input allows us to connect.
-
-    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
-    """
+    """Validate cloud credentials and return a title."""
     user_agent = f"Home Assistant/{ha_version} Qvantum/{VERSION}"
     api = QvantumAPI(data[CONF_USERNAME], data[CONF_PASSWORD], user_agent=user_agent)
     try:
         await api.authenticate()
         device = await api.get_primary_device()
-        return {
-            "title": f"{device.get('vendor')} {device.get('model')} ({device.get('serial')})"
-        }
+        serial = device.get("serial") if isinstance(device, dict) else None
+        title = (
+            f"{device.get('vendor')} {device.get('model')} ({serial})"
+            if isinstance(device, dict)
+            else "Qvantum"
+        )
+        return {"title": title, "serial": serial}
     except APIAuthError as err:
         raise InvalidAuth from err
     except APIConnectionError as err:
@@ -97,11 +108,38 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
                 )
 
 
+async def validate_modbus(
+    hass: HomeAssistant, host: str, port: int, unit_id: int
+) -> dict[str, Any]:
+    """Probe the heat pump over Modbus TCP and return serial identity."""
+    from homeassistant.components.modbus import async_get_temporary_unit
+    from modbus_connection import ModbusTcpParams
+
+    from .modbus_device import IdentityProbeError, async_probe_identity
+
+    try:
+        async with async_get_temporary_unit(
+            hass, ModbusTcpParams(host=host, port=port), unit_id
+        ) as unit:
+            serial, sw_version = await async_probe_identity(unit)
+    except IdentityProbeError as err:
+        raise CannotConnect from err
+    except HomeAssistantError as err:
+        raise CannotConnect from err
+    except Exception as err:
+        _LOGGER.debug("Modbus probe failed", exc_info=True)
+        raise CannotConnect from err
+    return {
+        "title": f"Qvantum ({serial})",
+        "serial": serial,
+        "sw_version": sw_version,
+    }
+
+
 class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Qvantum Integration."""
 
     VERSION = CONFIG_VERSION
-    _input_data: dict[str, Any]
 
     @staticmethod
     @callback
@@ -112,63 +150,114 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle the initial step."""
-        # Called when you initiate adding an integration via the UI
-        errors: dict[str, str] = {}
+        """Choose cloud HTTP or local Modbus."""
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["cloud", "modbus"],
+        )
 
+    async def async_step_cloud(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Set up using a Qvantum account."""
+        errors: dict[str, str] = {}
         if user_input is not None:
-            # The form has been filled in and submitted, so process the data provided.
             try:
-                # Validate that the setup data is valid and if not handle errors.
-                # The errors["base"] values match the values in your strings.json and translation files.
                 info = await validate_input(self.hass, user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
-
-            if "base" not in errors:
-                # Validation was successful, so create a unique id for this instance of your integration
-                # and create the config entry.
-                await self.async_set_unique_id(info.get("title"))
+            else:
+                unique_id = info.get("serial") or info["title"]
+                await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured()
-                modbus_enabled, modbus_write_enabled = _normalize_modbus_settings(
-                    user_input.get(CONF_MODBUS_TCP, False),
-                    user_input.get(CONF_MODBUS_WRITE, False),
-                )
                 return self.async_create_entry(
                     title=info["title"],
                     data={
-                        "username": user_input["username"],
-                        "password": user_input["password"],
-                        CONF_MODBUS_TCP: modbus_enabled,
-                        CONF_MODBUS_WRITE: modbus_write_enabled,
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                        CONF_MODBUS_TCP: False,
+                        CONF_MODBUS_WRITE: False,
                     },
                     options={
-                        CONF_MODBUS_TCP: modbus_enabled,
-                        CONF_MODBUS_WRITE: modbus_write_enabled,
+                        CONF_MODBUS_TCP: False,
+                        CONF_MODBUS_WRITE: False,
                     },
                 )
-
-        # Show initial form.
         return self.async_show_form(
-            step_id="user",
-            data_schema=STEP_USER_DATA_SCHEMA,
+            step_id="cloud",
+            data_schema=STEP_CLOUD_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_modbus(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Set up using local Modbus TCP."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            host = str(user_input[CONF_MODBUS_HOST])
+            port = int(user_input.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT))
+            unit_id = int(user_input.get(CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID))
+            interval = _normalize_modbus_scan_interval(
+                user_input.get(CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL)
+            )
+            try:
+                info = await validate_modbus(self.hass, host, port, unit_id)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(info["serial"])
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(
+                    title=info["title"],
+                    data={
+                        CONF_MODBUS_TCP: True,
+                        CONF_MODBUS_WRITE: False,
+                        CONF_MODBUS_HOST: host,
+                        CONF_MODBUS_PORT: port,
+                        CONF_MODBUS_UNIT_ID: unit_id,
+                    },
+                    options={
+                        CONF_MODBUS_TCP: True,
+                        CONF_MODBUS_WRITE: False,
+                        CONF_MODBUS_HOST: host,
+                        CONF_MODBUS_PORT: port,
+                        CONF_MODBUS_UNIT_ID: unit_id,
+                        CONF_MODBUS_SCAN_INTERVAL: interval,
+                    },
+                )
+        return self.async_show_form(
+            step_id="modbus",
+            data_schema=STEP_MODBUS_DATA_SCHEMA,
             errors=errors,
         )
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Add reconfigure step to allow to reconfigure a config entry."""
-        errors: dict[str, str] = {}
-        config_entry = self.hass.config_entries.async_get_entry(
-            self.context["entry_id"]
+        """Choose cloud or Modbus when reconfiguring."""
+        return self.async_show_menu(
+            step_id="reconfigure",
+            menu_options=["reconfigure_cloud", "reconfigure_modbus"],
         )
 
+    def _reconfigure_entry(self) -> ConfigEntry:
+        return self.hass.config_entries.async_get_entry(self.context["entry_id"])
+
+    async def async_step_reconfigure_cloud(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Reconfigure using a Qvantum account."""
+        errors: dict[str, str] = {}
+        config_entry = self._reconfigure_entry()
         if user_input is not None:
             try:
                 await validate_input(self.hass, user_input)
@@ -176,64 +265,110 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                modbus_enabled, modbus_write_enabled = _normalize_modbus_settings(
-                    user_input.get(CONF_MODBUS_TCP, False),
-                    user_input.get(CONF_MODBUS_WRITE, False),
-                )
-                updated_data = {
-                    **config_entry.data,
-                    "username": user_input["username"],
-                    "password": user_input["password"],
-                    CONF_MODBUS_TCP: modbus_enabled,
-                    CONF_MODBUS_WRITE: modbus_write_enabled,
-                }
-                updated_options = {
-                    **config_entry.options,
-                    CONF_MODBUS_TCP: modbus_enabled,
-                    CONF_MODBUS_WRITE: modbus_write_enabled,
-                    CONF_MODBUS_SCAN_INTERVAL: _normalize_modbus_scan_interval(
-                        user_input.get(
-                            CONF_MODBUS_SCAN_INTERVAL,
-                            config_entry.options.get(
-                                CONF_MODBUS_SCAN_INTERVAL,
-                                DEFAULT_MODBUS_SCAN_INTERVAL,
-                            ),
-                        )
-                    ),
-                }
                 return self.async_update_reload_and_abort(
                     config_entry,
                     unique_id=config_entry.unique_id,
-                    data=updated_data,
-                    options=updated_options,
+                    data={
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                        CONF_MODBUS_TCP: False,
+                        CONF_MODBUS_WRITE: False,
+                    },
+                    options={
+                        CONF_MODBUS_TCP: False,
+                        CONF_MODBUS_WRITE: False,
+                        CONF_SCAN_INTERVAL: config_entry.options.get(
+                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                        ),
+                    },
                     reason="reconfigure_successful",
                 )
         return self.async_show_form(
-            step_id="reconfigure",
+            step_id="reconfigure_cloud",
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_USERNAME, default=config_entry.data[CONF_USERNAME]
+                        CONF_USERNAME,
+                        default=config_entry.data.get(CONF_USERNAME, ""),
                     ): str,
                     vol.Required(CONF_PASSWORD): str,
-                    vol.Optional(
-                        CONF_MODBUS_TCP,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure_modbus(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Reconfigure using local Modbus TCP."""
+        errors: dict[str, str] = {}
+        config_entry = self._reconfigure_entry()
+        if user_input is not None:
+            host = str(user_input[CONF_MODBUS_HOST])
+            port = int(user_input.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT))
+            unit_id = int(user_input.get(CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID))
+            interval = _normalize_modbus_scan_interval(
+                user_input.get(CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL)
+            )
+            try:
+                await validate_modbus(self.hass, host, port, unit_id)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                return self.async_update_reload_and_abort(
+                    config_entry,
+                    unique_id=config_entry.unique_id,
+                    data={
+                        CONF_MODBUS_TCP: True,
+                        CONF_MODBUS_WRITE: False,
+                        CONF_MODBUS_HOST: host,
+                        CONF_MODBUS_PORT: port,
+                        CONF_MODBUS_UNIT_ID: unit_id,
+                    },
+                    options={
+                        CONF_MODBUS_TCP: True,
+                        CONF_MODBUS_WRITE: False,
+                        CONF_MODBUS_HOST: host,
+                        CONF_MODBUS_PORT: port,
+                        CONF_MODBUS_UNIT_ID: unit_id,
+                        CONF_MODBUS_SCAN_INTERVAL: interval,
+                    },
+                    reason="reconfigure_successful",
+                )
+        return self.async_show_form(
+            step_id="reconfigure_modbus",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_MODBUS_HOST,
                         default=config_entry.options.get(
-                            CONF_MODBUS_TCP,
-                            config_entry.data.get(CONF_MODBUS_TCP, False),
+                            CONF_MODBUS_HOST,
+                            config_entry.data.get(CONF_MODBUS_HOST, DEFAULT_MODBUS_HOST),
                         ),
-                    ): bool,
+                    ): str,
                     vol.Optional(
-                        CONF_MODBUS_WRITE,
+                        CONF_MODBUS_PORT,
                         default=config_entry.options.get(
-                            CONF_MODBUS_WRITE,
-                            config_entry.data.get(CONF_MODBUS_WRITE, False),
+                            CONF_MODBUS_PORT,
+                            config_entry.data.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT),
                         ),
-                    ): bool,
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
+                    vol.Optional(
+                        CONF_MODBUS_UNIT_ID,
+                        default=config_entry.options.get(
+                            CONF_MODBUS_UNIT_ID,
+                            config_entry.data.get(
+                                CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID
+                            ),
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=247)),
                     vol.Optional(
                         CONF_MODBUS_SCAN_INTERVAL,
                         default=_normalize_modbus_scan_interval(
@@ -258,64 +393,100 @@ class QvantumOptionsFlowHandler(OptionsFlow):
         """Initialize options flow."""
         super().__init__()
         self.options = dict(config_entry.options)
+        self._config_entry = config_entry
+
+    def _source_entry(self) -> ConfigEntry:
+        return self._config_entry
+
+    def _modbus_enabled(self) -> bool:
+        entry = self._source_entry()
+        return bool(
+            self.options.get(
+                CONF_MODBUS_TCP,
+                entry.data.get(CONF_MODBUS_TCP, False),
+            )
+        )
 
     async def async_step_init(self, user_input=None):
-        """Handle options flow."""
+        """Handle options flow for the current connection mode only."""
         if user_input is not None:
-            modbus_enabled, modbus_write_enabled = _normalize_modbus_settings(
-                user_input.get(
-                    CONF_MODBUS_TCP,
-                    self.options.get(CONF_MODBUS_TCP, False),
-                ),
-                user_input.get(
-                    CONF_MODBUS_WRITE,
-                    self.options.get(CONF_MODBUS_WRITE, False),
-                ),
-            )
-            normalized_input = {**user_input}
-            if CONF_MODBUS_TCP in user_input:
-                normalized_input[CONF_MODBUS_TCP] = modbus_enabled
-                normalized_input[CONF_MODBUS_WRITE] = modbus_write_enabled
-            elif CONF_MODBUS_WRITE in user_input:
-                normalized_input[CONF_MODBUS_WRITE] = modbus_write_enabled
-            if CONF_MODBUS_SCAN_INTERVAL in normalized_input:
-                normalized_input[CONF_MODBUS_SCAN_INTERVAL] = (
-                    _normalize_modbus_scan_interval(
-                        normalized_input[CONF_MODBUS_SCAN_INTERVAL]
-                    )
-                )
-
-            options = self.options | normalized_input
-            return self.async_create_entry(title="", data=options)
-
-        data_schema = vol.Schema(
-            {
-                vol.Required(
-                    CONF_SCAN_INTERVAL,
-                    default=self.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
-                ): (vol.All(vol.Coerce(int), vol.Clamp(min=MIN_SCAN_INTERVAL))),
-                vol.Required(
-                    CONF_MODBUS_TCP,
-                    default=self.options.get(CONF_MODBUS_TCP, False),
-                ): bool,
-                vol.Optional(
-                    CONF_MODBUS_HOST,
-                    default=self.options.get(CONF_MODBUS_HOST, DEFAULT_MODBUS_HOST),
-                ): str,
-                vol.Optional(
-                    CONF_MODBUS_WRITE,
-                    default=self.options.get(CONF_MODBUS_WRITE, False),
-                ): bool,
-                vol.Optional(
-                    CONF_MODBUS_SCAN_INTERVAL,
-                    default=_normalize_modbus_scan_interval(
-                        self.options.get(
-                            CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL
-                        )
+            if self._modbus_enabled():
+                normalized = {
+                    CONF_MODBUS_TCP: True,
+                    CONF_MODBUS_WRITE: False,
+                    CONF_MODBUS_HOST: user_input.get(
+                        CONF_MODBUS_HOST, DEFAULT_MODBUS_HOST
                     ),
-                ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_MODBUS_SCAN_INTERVAL)),
-            }
-        )
+                    CONF_MODBUS_PORT: int(
+                        user_input.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT)
+                    ),
+                    CONF_MODBUS_UNIT_ID: int(
+                        user_input.get(CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID)
+                    ),
+                    CONF_MODBUS_SCAN_INTERVAL: _normalize_modbus_scan_interval(
+                        user_input.get(CONF_MODBUS_SCAN_INTERVAL)
+                    ),
+                }
+            else:
+                normalized = {
+                    CONF_MODBUS_TCP: False,
+                    CONF_MODBUS_WRITE: False,
+                    CONF_SCAN_INTERVAL: user_input.get(
+                        CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                    ),
+                }
+            return self.async_create_entry(title="", data={**self.options, **normalized})
+
+        entry = self._source_entry()
+        if self._modbus_enabled():
+            data_schema = vol.Schema(
+                {
+                    vol.Required(
+                        CONF_MODBUS_HOST,
+                        default=self.options.get(
+                            CONF_MODBUS_HOST,
+                            entry.data.get(CONF_MODBUS_HOST, DEFAULT_MODBUS_HOST),
+                        ),
+                    ): str,
+                    vol.Optional(
+                        CONF_MODBUS_PORT,
+                        default=self.options.get(
+                            CONF_MODBUS_PORT,
+                            entry.data.get(CONF_MODBUS_PORT, DEFAULT_MODBUS_PORT),
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=65535)),
+                    vol.Optional(
+                        CONF_MODBUS_UNIT_ID,
+                        default=self.options.get(
+                            CONF_MODBUS_UNIT_ID,
+                            entry.data.get(
+                                CONF_MODBUS_UNIT_ID, DEFAULT_MODBUS_UNIT_ID
+                            ),
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=1, max=247)),
+                    vol.Optional(
+                        CONF_MODBUS_SCAN_INTERVAL,
+                        default=_normalize_modbus_scan_interval(
+                            self.options.get(
+                                CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL
+                            )
+                        ),
+                    ): vol.All(
+                        vol.Coerce(int), vol.Clamp(min=MIN_MODBUS_SCAN_INTERVAL)
+                    ),
+                }
+            )
+        else:
+            data_schema = vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=self.options.get(
+                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Clamp(min=MIN_SCAN_INTERVAL)),
+                }
+            )
 
         return self.async_show_form(step_id="init", data_schema=data_schema)
 

--- a/custom_components/qvantum/config_flow.py
+++ b/custom_components/qvantum/config_flow.py
@@ -76,9 +76,6 @@ def _modbus_user_schema(
     )
 
 
-STEP_MODBUS_DATA_SCHEMA = _modbus_user_schema()
-
-
 def _normalize_modbus_scan_interval(value: Any) -> int:
     """Coerce Modbus scan interval to int and enforce the configured minimum."""
     try:
@@ -288,7 +285,7 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
         config_entry = self._reconfigure_entry()
         if user_input is not None:
             try:
-                await validate_input(self.hass, user_input)
+                info = await validate_input(self.hass, user_input)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except InvalidAuth:
@@ -299,7 +296,7 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 return self.async_update_reload_and_abort(
                     config_entry,
-                    unique_id=config_entry.unique_id,
+                    unique_id=info.get("serial") or info["title"],
                     data={
                         CONF_USERNAME: user_input[CONF_USERNAME],
                         CONF_PASSWORD: user_input[CONF_PASSWORD],
@@ -366,7 +363,7 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
                 user_input.get(CONF_MODBUS_SCAN_INTERVAL, DEFAULT_MODBUS_SCAN_INTERVAL)
             )
             try:
-                await validate_modbus(self.hass, host, port, unit_id)
+                info = await validate_modbus(self.hass, host, port, unit_id)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:
@@ -375,7 +372,7 @@ class QvantumConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 return self.async_update_reload_and_abort(
                     config_entry,
-                    unique_id=config_entry.unique_id,
+                    unique_id=info["serial"],
                     data={
                         CONF_MODBUS_TCP: True,
                         CONF_MODBUS_WRITE: False,

--- a/custom_components/qvantum/translations/cs.json
+++ b/custom_components/qvantum/translations/cs.json
@@ -532,69 +532,69 @@
   "config": {
     "title": "Qvantum tepelné čerpadlo",
     "abort": {
-      "already_configured": "Device is already configured",
-      "reconfigure_successful": "Reconfiguration successful"
+      "already_configured": "Zařízení je již nakonfigurováno",
+      "reconfigure_successful": "Znovu nastavení proběhlo úspěšně"
     },
     "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "cannot_connect": "Nepodařilo se připojit",
+      "invalid_auth": "Neplatná autentizace",
+      "unknown": "Neočekávaná chyba"
     },
     "step": {
       "user": {
-        "title": "Connection",
-        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "title": "Připojení",
+        "description": "Vyberte, jak má Home Assistant komunikovat s tepelným čerpadlem. Režim lze později změnit v novém nastavení.",
         "menu_options": {
           "cloud": "Qvantum cloud (HTTP)",
-          "modbus": "Local Modbus (offline)"
+          "modbus": "Místní Modbus (offline)"
         }
       },
       "cloud": {
         "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
+        "description": "Přihlaste se ke svému účtu Qvantum. Měření a ovládání používají cloudové API.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Heslo",
+          "username": "Uživatelské jméno"
         }
       },
       "modbus": {
-        "title": "Local Modbus",
-        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "title": "Místní Modbus",
+        "description": "Čte tepelné čerpadlo v místní síti. Bez přihlášení. Nejprve v aplikaci Qvantum povolte Modbus external (Instalatér → Servisní režim → Připojení). Ovládání v tomto režimu není dostupné.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Host/IP Qvantum",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "ID jednotky",
+          "modbus_scan_interval": "Interval dotazování Modbus (sekundy)"
         },
         "data_description": {
-          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
-          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_host": "Název hostitele nebo IP adresa tepelného čerpadla. Výchozí je Qvantum-HP.",
+          "modbus_scan_interval": "Jak často dotazovat přes Modbus TCP. Minimum je 5 sekund. Výchozí je 15 sekund."
         }
       },
       "reconfigure": {
-        "title": "Reconfigure",
-        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "title": "Nové nastavení",
+        "description": "Přepněte mezi cloudovým HTTP a místním Modbusem nebo aktualizujte aktuální připojení.",
         "menu_options": {
           "reconfigure_cloud": "Qvantum cloud (HTTP)",
-          "reconfigure_modbus": "Local Modbus (offline)"
+          "reconfigure_modbus": "Místní Modbus (offline)"
         }
       },
       "reconfigure_cloud": {
         "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account.",
+        "description": "Přihlaste se ke svému účtu Qvantum.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Heslo",
+          "username": "Uživatelské jméno"
         }
       },
       "reconfigure_modbus": {
-        "title": "Local Modbus",
-        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "title": "Místní Modbus",
+        "description": "Nejprve v aplikaci Qvantum povolte Modbus external. Home Assistant načte sériové číslo a firmware z čerpadla.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Host/IP Qvantum",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "ID jednotky",
+          "modbus_scan_interval": "Interval dotazování Modbus (sekundy)"
         }
       }
     }
@@ -603,17 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP scan interval (seconds)",
-          "modbus_host": "Host / IP",
+          "scan_interval": "Interval dotazování HTTP (sekundy)",
+          "modbus_host": "Host/IP Qvantum",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Modbus scan interval (seconds)"
+          "modbus_unit_id": "ID jednotky",
+          "modbus_scan_interval": "Interval dotazování Modbus (sekundy)"
         },
         "data_description": {
-          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_scan_interval": "Jak často dotazovat tepelné čerpadlo přes Modbus TCP. Nižší hodnoty poskytují téměř okamžitou přesnost průtoku a objemu. Minimum je 5 sekund. Výchozí je 15 sekund."
         },
-        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
-        "title": "Options"
+        "description": "Nastavení aktuálního režimu připojení. Pro přepnutí mezi cloudem a Modbusem použijte nové nastavení.",
+        "title": "Možnosti"
       }
     }
   },

--- a/custom_components/qvantum/translations/cs.json
+++ b/custom_components/qvantum/translations/cs.json
@@ -532,41 +532,69 @@
   "config": {
     "title": "Qvantum tepelné čerpadlo",
     "abort": {
-      "already_configured": "Zařízení je již nakonfigurováno",
-      "reconfigure_successful": "Znovu nastavení proběhlo úspěšně"
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Reconfiguration successful"
     },
     "error": {
-      "cannot_connect": "Nepodařilo se připojit",
-      "invalid_auth": "Neplatná autentizace",
-      "unknown": "Neočekávaná chyba"
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     },
     "step": {
       "user": {
-        "description": "Modbus vám poskytne téměř okamžitá měření přímo čtením ze zařízení.\nPřed aktivací zde je třeba v nastavení instalátora v aplikaci nebo displeji čerpadla povolit Modbus. Ve výchozím nastavení čte pouze přes Modbus; zápisy a ovládání jsou stále přes HTTP API, pokud není povolen i zápis přes Modbus, kdy se některá ovládání zapisují přes Modbus.",
+        "title": "Connection",
+        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "menu_options": {
+          "cloud": "Qvantum cloud (HTTP)",
+          "modbus": "Local Modbus (offline)"
+        }
+      },
+      "cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
         "data": {
-          "password": "Heslo",
-          "username": "Uživatelské jméno",
-          "modbus_tcp": "Použít čtení přes Modbus místo HTTP dotazování",
-          "modbus_write": "Povolit zápis přes Modbus"
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "modbus": {
+        "title": "Local Modbus",
+        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus vám poskytne téměř okamžitá měření přímo čtením ze zařízení.\nPřed aktivací zde je třeba v nastavení instalátora v aplikaci nebo displeji čerpadla povolit Modbus. Všimněte si, že čte pouze přes Modbus; zápisy a ovládání jsou stále přes HTTP API, pokud není povolen i zápis přes Modbus, kdy se některá ovládání zapisují přes Modbus.",
-          "modbus_write": "Povolením zápisu přes Modbus přebíráte plnou odpovědnost za všechny hodnoty zapsané přes rozhraní. Výrobce nenese odpovědnost za problémy způsobené nesprávnými nebo mimo rozsah hodnotami a takové akce mohou zrušit záruku a/nebo ovlivnit životnost a výkon výrobku."
+          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
+          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         }
       },
       "reconfigure": {
-        "description": "Modbus vám poskytne téměř okamžitá měření přímo čtením ze zařízení.\nPřed aktivací zde je třeba v nastavení instalátora v aplikaci nebo displeji čerpadla povolit Modbus. Ve výchozím nastavení čte pouze přes Modbus; zápisy a ovládání jsou stále přes HTTP API, pokud není povolen i zápis přes Modbus, kdy se některá ovládání zapisují přes Modbus.",
+        "title": "Reconfigure",
+        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "menu_options": {
+          "reconfigure_cloud": "Qvantum cloud (HTTP)",
+          "reconfigure_modbus": "Local Modbus (offline)"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account.",
         "data": {
-          "password": "Heslo",
-          "username": "Uživatelské jméno",
-          "modbus_tcp": "Použít čtení přes Modbus místo HTTP dotazování",
-          "modbus_write": "Povolit zápis přes Modbus",
-          "modbus_scan_interval": "Interval dotazování Modbus (sekundy)"
-        },
-        "data_description": {
-          "modbus_tcp": "Modbus vám poskytne téměř okamžitá měření přímo čtením ze zařízení.\nPřed aktivací zde je třeba v nastavení instalátora v aplikaci nebo displeji čerpadla povolit Modbus. Všimněte si, že čte pouze přes Modbus; zápisy a ovládání jsou stále přes HTTP API, pokud není povolen i zápis přes Modbus, kdy se některá ovládání zapisují přes Modbus.",
-          "modbus_write": "Povolením zápisu přes Modbus přebíráte plnou odpovědnost za všechny hodnoty zapsané přes rozhraní. Výrobce nenese odpovědnost za problémy způsobené nesprávnými nebo mimo rozsah hodnotami a takové akce mohou zrušit záruku a/nebo ovlivnit životnost a výkon výrobku.",
-          "modbus_scan_interval": "Jak často dotazovat tepelné čerpadlo přes Modbus TCP. Nižší hodnoty poskytují téměř okamžitou přesnost průtoku a objemu. Minimum je 5 sekund. Výchozí je 15 sekund."
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "reconfigure_modbus": {
+        "title": "Local Modbus",
+        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         }
       }
     }
@@ -575,19 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "Interval dotazování HTTP (sekundy)",
-          "modbus_tcp": "Použít čtení přes Modbus místo HTTP dotazování",
-          "modbus_host": "Host/IP Qvantum",
-          "modbus_write": "Povolit zápis přes Modbus",
-          "modbus_scan_interval": "Interval dotazování Modbus (sekundy)"
+          "scan_interval": "HTTP scan interval (seconds)",
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Modbus scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus vám poskytne téměř okamžitá měření přímo čtením ze zařízení.\nPřed aktivací zde je třeba v nastavení instalátora v aplikaci nebo displeji čerpadla povolit Modbus. Všimněte si, že čte pouze přes Modbus; zápisy a ovládání jsou stále přes HTTP API, pokud není povolen i zápis přes Modbus, kdy se některá ovládání zapisují přes Modbus.",
-          "modbus_write": "Povolením zápisu přes Modbus přebíráte plnou odpovědnost za všechny hodnoty zapsané přes rozhraní. Výrobce nenese odpovědnost za problémy způsobené nesprávnými nebo mimo rozsah hodnotami a takové akce mohou zrušit záruku a/nebo ovlivnit životnost a výkon výrobku.",
-          "modbus_scan_interval": "Jak často dotazovat tepelné čerpadlo přes Modbus TCP. Nižší hodnoty poskytují téměř okamžitou přesnost průtoku a objemu. Minimum je 5 sekund. Výchozí je 15 sekund."
+          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         },
-        "description": "Upravte své možnosti.",
-        "title": "Možnosti"
+        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
+        "title": "Options"
       }
     }
   },

--- a/custom_components/qvantum/translations/da.json
+++ b/custom_components/qvantum/translations/da.json
@@ -532,69 +532,69 @@
   "config": {
     "title": "Qvantum varmepumpe",
     "abort": {
-      "already_configured": "Device is already configured",
-      "reconfigure_successful": "Reconfiguration successful"
+      "already_configured": "Enheden er allerede konfigureret",
+      "reconfigure_successful": "Genkonfiguration lykkedes"
     },
     "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "cannot_connect": "Kunne ikke oprette forbindelse",
+      "invalid_auth": "Ugyldig autentifikation",
+      "unknown": "Uventet fejl"
     },
     "step": {
       "user": {
-        "title": "Connection",
-        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "title": "Forbindelse",
+        "description": "Vælg, hvordan Home Assistant kommunikerer med varmepumpen. Du kan skifte senere via genkonfiguration.",
         "menu_options": {
-          "cloud": "Qvantum cloud (HTTP)",
-          "modbus": "Local Modbus (offline)"
+          "cloud": "Qvantum-sky (HTTP)",
+          "modbus": "Lokal Modbus (offline)"
         }
       },
       "cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
+        "title": "Qvantum-sky",
+        "description": "Log ind med din Qvantum-konto. Målinger og styring bruger sky-API'et.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Adgangskode",
+          "username": "Brugernavn"
         }
       },
       "modbus": {
-        "title": "Local Modbus",
-        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "title": "Lokal Modbus",
+        "description": "Læser varmepumpen på dit lokale netværk. Ingen login. Aktivér først Modbus external i Qvantum-appen (Installatør → Servicetilstand → Tilslutning). Styring er ikke tilgængelig i denne tilstand.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Qvantum vært/IP",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "Enheds-ID",
+          "modbus_scan_interval": "Modbus-scanningsinterval (sekunder)"
         },
         "data_description": {
-          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
-          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_host": "Værtsnavn eller IP-adresse på varmepumpen. Standard er Qvantum-HP.",
+          "modbus_scan_interval": "Hvor ofte der forespørges over Modbus TCP. Minimum er 5 sekunder. Standard er 15 sekunder."
         }
       },
       "reconfigure": {
-        "title": "Reconfigure",
-        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "title": "Genkonfigurer",
+        "description": "Skift mellem sky-HTTP og lokal Modbus, eller opdater den aktuelle forbindelse.",
         "menu_options": {
-          "reconfigure_cloud": "Qvantum cloud (HTTP)",
-          "reconfigure_modbus": "Local Modbus (offline)"
+          "reconfigure_cloud": "Qvantum-sky (HTTP)",
+          "reconfigure_modbus": "Lokal Modbus (offline)"
         }
       },
       "reconfigure_cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account.",
+        "title": "Qvantum-sky",
+        "description": "Log ind med din Qvantum-konto.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Adgangskode",
+          "username": "Brugernavn"
         }
       },
       "reconfigure_modbus": {
-        "title": "Local Modbus",
-        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "title": "Lokal Modbus",
+        "description": "Aktivér først Modbus external i Qvantum-appen. Home Assistant læser serienummer og firmware fra pumpen.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Qvantum vært/IP",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "Enheds-ID",
+          "modbus_scan_interval": "Modbus-scanningsinterval (sekunder)"
         }
       }
     }
@@ -603,17 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP scan interval (seconds)",
-          "modbus_host": "Host / IP",
+          "scan_interval": "HTTP-scanningsinterval (sekunder)",
+          "modbus_host": "Qvantum vært/IP",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Modbus scan interval (seconds)"
+          "modbus_unit_id": "Enheds-ID",
+          "modbus_scan_interval": "Modbus-scanningsinterval (sekunder)"
         },
         "data_description": {
-          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_scan_interval": "Hvor ofte varmepumpen skal forespørges over Modbus TCP. Lavere værdier giver næsten realtidsnøjagtighed for flow og volumen. Minimum er 5 sekunder. Standard er 15 sekunder."
         },
-        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
-        "title": "Options"
+        "description": "Indstillinger for den aktuelle forbindelsestilstand. Brug genkonfiguration til at skifte mellem sky og Modbus.",
+        "title": "Indstillinger"
       }
     }
   },

--- a/custom_components/qvantum/translations/da.json
+++ b/custom_components/qvantum/translations/da.json
@@ -532,41 +532,69 @@
   "config": {
     "title": "Qvantum varmepumpe",
     "abort": {
-      "already_configured": "Enheden er allerede konfigureret",
-      "reconfigure_successful": "Genkonfiguration lykkedes"
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Reconfiguration successful"
     },
     "error": {
-      "cannot_connect": "Kunne ikke oprette forbindelse",
-      "invalid_auth": "Ugyldig autentifikation",
-      "unknown": "Uventet fejl"
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     },
     "step": {
       "user": {
-        "description": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.\nModbus skal aktiveres i installerindstillingerne i pumpeappen/skærmen, før du aktiverer det her. Som standard læser den kun via Modbus; skrivninger/kontroller sker stadig via HTTP API, medmindre skrivning via Modbus også er aktiveret, hvor visse kontroller skrives via Modbus.",
+        "title": "Connection",
+        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "menu_options": {
+          "cloud": "Qvantum cloud (HTTP)",
+          "modbus": "Local Modbus (offline)"
+        }
+      },
+      "cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
         "data": {
-          "password": "Adgangskode",
-          "username": "Brugernavn",
-          "modbus_tcp": "Brug Modbus-læsning i stedet for HTTP-forespørgsler",
-          "modbus_write": "Aktivér skrivning via Modbus"
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "modbus": {
+        "title": "Local Modbus",
+        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.\nModbus skal aktiveres i installerindstillingerne i pumpeappen/skærmen, før du aktiverer det her. Bemærk, at den kun læser via Modbus; skrivninger/kontroller sker stadig via HTTP API, medmindre skrivning via Modbus også er aktiveret, hvor visse kontroller skrives via Modbus.",
-          "modbus_write": "Ved at aktivere skrivning via Modbus accepterer du fuldt ansvar for eventuelle værdier, der skrives gennem grænsefladen. Producenten er ikke ansvarlig for problemer forårsaget af forkerte eller uden for intervallet værdier, og sådanne handlinger kan ugyldiggøre garantien og/eller påvirke produktets levetid og ydeevne."
+          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
+          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         }
       },
       "reconfigure": {
-        "description": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.\nModbus skal aktiveres i installerindstillingerne i pumpeappen/skærmen, før du aktiverer det her. Som standard læser den kun via Modbus; skrivninger/kontroller sker stadig via HTTP API, medmindre skrivning via Modbus også er aktiveret, hvor visse kontroller skrives via Modbus.",
+        "title": "Reconfigure",
+        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "menu_options": {
+          "reconfigure_cloud": "Qvantum cloud (HTTP)",
+          "reconfigure_modbus": "Local Modbus (offline)"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account.",
         "data": {
-          "password": "Adgangskode",
-          "username": "Brugernavn",
-          "modbus_tcp": "Brug Modbus-læsning i stedet for HTTP-forespørgsler",
-          "modbus_write": "Aktivér skrivning via Modbus",
-          "modbus_scan_interval": "Modbus-scanningsinterval (sekunder)"
-        },
-        "data_description": {
-          "modbus_tcp": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.\nModbus skal aktiveres i installerindstillingerne i pumpeappen/skærmen, før du aktiverer det her. Bemærk, at den kun læser via Modbus; skrivninger/kontroller sker stadig via HTTP API, medmindre skrivning via Modbus også er aktiveret, hvor visse kontroller skrives via Modbus.",
-          "modbus_write": "Ved at aktivere skrivning via Modbus accepterer du fuldt ansvar for eventuelle værdier, der skrives gennem grænsefladen. Producenten er ikke ansvarlig for problemer forårsaget af forkerte eller uden for intervallet værdier, og sådanne handlinger kan ugyldiggøre garantien og/eller påvirke produktets levetid og ydeevne.",
-          "modbus_scan_interval": "Hvor ofte varmepumpen skal forespørges over Modbus TCP. Lavere værdier giver næsten realtidsnøjagtighed for flow og volumen. Minimum er 5 sekunder. Standard er 15 sekunder."
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "reconfigure_modbus": {
+        "title": "Local Modbus",
+        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         }
       }
     }
@@ -575,19 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP-scanningsinterval (sekunder)",
-          "modbus_tcp": "Brug Modbus-læsning i stedet for HTTP-forespørgsler",
-          "modbus_host": "Qvantum vært/IP",
-          "modbus_write": "Aktivér skrivning via Modbus",
-          "modbus_scan_interval": "Modbus-scanningsinterval (sekunder)"
+          "scan_interval": "HTTP scan interval (seconds)",
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Modbus scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.\nModbus skal aktiveres i installerindstillingerne i pumpeappen/skærmen, før du aktiverer det her. Bemærk, at den kun læser via Modbus; skrivninger/kontroller sker stadig via HTTP API, medmindre skrivning via Modbus også er aktiveret, hvor visse kontroller skrives via Modbus.",
-          "modbus_write": "Ved at aktivere skrivning via Modbus accepterer du fuldt ansvar for eventuelle værdier, der skrives gennem grænsefladen. Producenten er ikke ansvarlig for problemer forårsaget af forkerte eller uden for intervallet værdier, og sådanne handlinger kan ugyldiggøre garantien og/eller påvirke produktets levetid og ydeevne.",
-          "modbus_scan_interval": "Hvor ofte varmepumpen skal forespørges over Modbus TCP. Lavere værdier giver næsten realtidsnøjagtighed for flow og volumen. Minimum er 5 sekunder. Standard er 15 sekunder."
+          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         },
-        "description": "Ret dine indstillinger.",
-        "title": "Indstillinger"
+        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
+        "title": "Options"
       }
     }
   },

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -530,71 +530,71 @@
     }
   },
   "config": {
-    "title": "Qvantum Heat pump",
+    "title": "Qvantum Wärmepumpe",
     "abort": {
-      "already_configured": "Device is already configured",
-      "reconfigure_successful": "Reconfiguration successful"
+      "already_configured": "Gerät ist bereits konfiguriert",
+      "reconfigure_successful": "Rekonfiguration erfolgreich"
     },
     "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "cannot_connect": "Verbindung fehlgeschlagen",
+      "invalid_auth": "Ungültige Authentifizierung",
+      "unknown": "Unerwarteter Fehler"
     },
     "step": {
       "user": {
-        "title": "Connection",
-        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "title": "Verbindung",
+        "description": "Wählen Sie, wie Home Assistant mit der Wärmepumpe kommuniziert. Sie können später über die Rekonfiguration wechseln.",
         "menu_options": {
-          "cloud": "Qvantum cloud (HTTP)",
-          "modbus": "Local Modbus (offline)"
+          "cloud": "Qvantum Cloud (HTTP)",
+          "modbus": "Lokaler Modbus (offline)"
         }
       },
       "cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
+        "title": "Qvantum Cloud",
+        "description": "Melden Sie sich mit Ihrem Qvantum-Konto an. Messwerte und Steuerungen nutzen die Cloud-API.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Passwort",
+          "username": "Benutzername"
         }
       },
       "modbus": {
-        "title": "Local Modbus",
-        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "title": "Lokaler Modbus",
+        "description": "Liest die Wärmepumpe in Ihrem LAN. Keine Anmeldung. Aktivieren Sie zuerst Modbus external in der Qvantum-App (Installateur → Servicemodus → Konnektivität). Steuerungen sind in diesem Modus nicht verfügbar.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Qvantum Host/IP",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "Geräte-ID",
+          "modbus_scan_interval": "Modbus-Scan-Intervall (Sekunden)"
         },
         "data_description": {
-          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
-          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_host": "Hostname oder IP-Adresse der Wärmepumpe. Standard ist Qvantum-HP.",
+          "modbus_scan_interval": "Wie oft über Modbus TCP abgefragt wird. Minimum sind 5 Sekunden. Standard sind 15 Sekunden."
         }
       },
       "reconfigure": {
-        "title": "Reconfigure",
-        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "title": "Rekonfigurieren",
+        "description": "Zwischen Cloud-HTTP und lokalem Modbus wechseln oder die aktuelle Verbindung aktualisieren.",
         "menu_options": {
-          "reconfigure_cloud": "Qvantum cloud (HTTP)",
-          "reconfigure_modbus": "Local Modbus (offline)"
+          "reconfigure_cloud": "Qvantum Cloud (HTTP)",
+          "reconfigure_modbus": "Lokaler Modbus (offline)"
         }
       },
       "reconfigure_cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account.",
+        "title": "Qvantum Cloud",
+        "description": "Melden Sie sich mit Ihrem Qvantum-Konto an.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Passwort",
+          "username": "Benutzername"
         }
       },
       "reconfigure_modbus": {
-        "title": "Local Modbus",
-        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "title": "Lokaler Modbus",
+        "description": "Aktivieren Sie zuerst Modbus external in der Qvantum-App. Home Assistant liest Seriennummer und Firmware von der Pumpe.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Qvantum Host/IP",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "Geräte-ID",
+          "modbus_scan_interval": "Modbus-Scan-Intervall (Sekunden)"
         }
       }
     }
@@ -603,17 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP scan interval (seconds)",
-          "modbus_host": "Host / IP",
+          "scan_interval": "HTTP-Scan-Intervall (Sekunden)",
+          "modbus_host": "Qvantum Host/IP",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Modbus scan interval (seconds)"
+          "modbus_unit_id": "Geräte-ID",
+          "modbus_scan_interval": "Modbus-Scan-Intervall (Sekunden)"
         },
         "data_description": {
-          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_scan_interval": "Wie oft die Wärmepumpe über Modbus TCP abgefragt wird. Niedrigere Werte ermöglichen nahezu Echtzeit-Durchfluss- und Volumenmessung. Minimum sind 5 Sekunden. Standard sind 15 Sekunden."
         },
-        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
-        "title": "Options"
+        "description": "Einstellungen für den aktuellen Verbindungsmodus. Über Rekonfiguration zwischen Cloud und Modbus wechseln.",
+        "title": "Optionen"
       }
     }
   },

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -530,43 +530,71 @@
     }
   },
   "config": {
-    "title": "Qvantum Wärmepumpe",
+    "title": "Qvantum Heat pump",
     "abort": {
-      "already_configured": "Gerät ist bereits konfiguriert",
-      "reconfigure_successful": "Rekonfiguration erfolgreich"
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Reconfiguration successful"
     },
     "error": {
-      "cannot_connect": "Verbindung fehlgeschlagen",
-      "invalid_auth": "Ungültige Authentifizierung",
-      "unknown": "Unerwarteter Fehler"
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     },
     "step": {
       "user": {
-        "description": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest; Schreiben/Steuerung erfolgt weiterhin über die HTTP-API, es sei denn, Schreiben ist ebenfalls aktiviert. Bestimmte Steuerungen werden über Modbus geschrieben.",
+        "title": "Connection",
+        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "menu_options": {
+          "cloud": "Qvantum cloud (HTTP)",
+          "modbus": "Local Modbus (offline)"
+        }
+      },
+      "cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
         "data": {
-          "password": "Passwort",
-          "username": "Benutzername",
-          "modbus_tcp": "Modbus-Lesen statt HTTP-Abfragen verwenden",
-          "modbus_write": "Schreiben über Modbus aktivieren"
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "modbus": {
+        "title": "Local Modbus",
+        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest; Schreiben/Steuerung erfolgt weiterhin über die HTTP-API, es sei denn, Schreiben ist ebenfalls aktiviert. Bestimmte Steuerungen werden über Modbus geschrieben.",
-          "modbus_write": "Durch die Aktivierung des Modbus-Schreibens übernehmen Sie die volle Verantwortung für alle über die Schnittstelle geschriebenen Werte. Der Hersteller haftet nicht für Probleme, die durch falsche oder außerhalb des Bereichs liegende Werte verursacht werden, und solche Maßnahmen können die Garantie und/oder die Lebensdauer und Leistung des Produkts beeinträchtigen."
+          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
+          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         }
       },
       "reconfigure": {
-        "description": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest; Schreiben/Steuerung erfolgt weiterhin über die HTTP-API, es sei denn, Schreiben ist ebenfalls aktiviert. Bestimmte Steuerungen werden über Modbus geschrieben.",
+        "title": "Reconfigure",
+        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "menu_options": {
+          "reconfigure_cloud": "Qvantum cloud (HTTP)",
+          "reconfigure_modbus": "Local Modbus (offline)"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account.",
         "data": {
-          "password": "Passwort",
-          "username": "Benutzername",
-          "modbus_tcp": "Modbus-Lesen statt HTTP-Abfragen verwenden",
-          "modbus_write": "Schreiben über Modbus aktivieren",
-          "modbus_scan_interval": "Modbus-Scan-Intervall (Sekunden)"
-        },
-        "data_description": {
-          "modbus_tcp": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest; Schreiben/Steuerung erfolgt weiterhin über die HTTP-API, es sei denn, Schreiben ist ebenfalls aktiviert. Bestimmte Steuerungen werden über Modbus geschrieben.",
-          "modbus_write": "Durch die Aktivierung des Modbus-Schreibens übernehmen Sie die volle Verantwortung für alle über die Schnittstelle geschriebenen Werte. Der Hersteller haftet nicht für Probleme, die durch falsche oder außerhalb des Bereichs liegende Werte verursacht werden, und solche Maßnahmen können die Garantie und/oder die Lebensdauer und Leistung des Produkts beeinträchtigen.",
-          "modbus_scan_interval": "Wie oft die Wärmepumpe über Modbus TCP abgefragt wird. Niedrigere Werte ermöglichen nahezu Echtzeit-Durchfluss- und Volumenmessung. Minimum sind 5 Sekunden. Standard sind 15 Sekunden."
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "reconfigure_modbus": {
+        "title": "Local Modbus",
+        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         }
       }
     }
@@ -575,19 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP-Scan-Intervall (Sekunden)",
-          "modbus_tcp": "Modbus-Lesen statt HTTP-Abfragen verwenden",
-          "modbus_host": "Qvantum Host/IP",
-          "modbus_write": "Schreiben über Modbus aktivieren",
-          "modbus_scan_interval": "Modbus-Scan-Intervall (Sekunden)"
+          "scan_interval": "HTTP scan interval (seconds)",
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Modbus scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus liefert nahezu Echtzeitmetriken, indem es direkt vom Gerät liest.\nModbus muss in den Installatoreinstellungen in der Pumpen-App/Anzeige aktiviert werden, bevor es hier aktiviert wird. Beachte, dass es nur über Modbus liest; Schreiben/Steuerung erfolgt weiterhin über die HTTP-API, es sei denn, Schreiben ist ebenfalls aktiviert. Bestimmte Steuerungen werden über Modbus geschrieben.",
-          "modbus_write": "Durch die Aktivierung des Modbus-Schreibens übernehmen Sie die volle Verantwortung für alle über die Schnittstelle geschriebenen Werte. Der Hersteller haftet nicht für Probleme, die durch falsche oder außerhalb des Bereichs liegende Werte verursacht werden, und solche Maßnahmen können die Garantie und/oder die Lebensdauer und Leistung des Produkts beeinträchtigen.",
-          "modbus_scan_interval": "Wie oft die Wärmepumpe über Modbus TCP abgefragt wird. Niedrigere Werte ermöglichen nahezu Echtzeit-Durchfluss- und Volumenmessung. Minimum sind 5 Sekunden. Standard sind 15 Sekunden."
+          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         },
-        "description": "Ändern Sie Ihre Optionen.",
-        "title": "Optionen"
+        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
+        "title": "Options"
       }
     }
   },

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -542,31 +542,59 @@
     },
     "step": {
       "user": {
-        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. By default it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+        "title": "Connection",
+        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "menu_options": {
+          "cloud": "Qvantum cloud (HTTP)",
+          "modbus": "Local Modbus (offline)"
+        }
+      },
+      "cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
         "data": {
           "password": "Password",
-          "username": "Username",
-          "modbus_tcp": "Use Modbus reading instead of HTTP polling",
-          "modbus_write": "Enable writing via Modbus"
+          "username": "Username"
+        }
+      },
+      "modbus": {
+        "title": "Local Modbus",
+        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
-          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product."
+          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
+          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         }
       },
       "reconfigure": {
-        "description": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. By default it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
+        "title": "Reconfigure",
+        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "menu_options": {
+          "reconfigure_cloud": "Qvantum cloud (HTTP)",
+          "reconfigure_modbus": "Local Modbus (offline)"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account.",
         "data": {
           "password": "Password",
-          "username": "Username",
-          "modbus_tcp": "Use Modbus reading instead of HTTP polling",
-          "modbus_write": "Enable writing via Modbus",
-          "modbus_scan_interval": "Modbus scan interval (seconds)"
-        },
-        "data_description": {
-          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
-          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product.",
-          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Lower values give near real-time flow and volume accuracy. Minimum is 5 seconds. Default is 15 seconds."
+          "username": "Username"
+        }
+      },
+      "reconfigure_modbus": {
+        "title": "Local Modbus",
+        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         }
       }
     }
@@ -575,18 +603,16 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP Scan Interval (seconds)",
-          "modbus_tcp": "Use Modbus reading instead of HTTP polling",
-          "modbus_host": "Qvantum Host/IP",
-          "modbus_write": "Enable writing via Modbus",
+          "scan_interval": "HTTP scan interval (seconds)",
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
           "modbus_scan_interval": "Modbus scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus will give you near realtime metrics by reading directly from the device.\nModbus must be enabled in Installer settings on the pump app/display before enabling here. Note that it only reads via Modbus; writes/controls are still via HTTP API unless Modbus writing is also enabled, in which case certain controls are written via Modbus.",
-          "modbus_write": "By activating Modbus writing, you accept full responsibility for any values written through the interface. The manufacturer is not liable for issues caused by incorrect or out-of-range values, and such actions may void the warranty and/or affect the lifecycle and performance of the product.",
-          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Lower values give near real-time flow and volume accuracy. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         },
-        "description": "Amend your options.",
+        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
         "title": "Options"
       }
     }

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -530,43 +530,71 @@
     }
   },
   "config": {
-    "title": "Bomba de calor Qvantum",
+    "title": "Qvantum Heat pump",
     "abort": {
-      "already_configured": "El dispositivo ya está configurado",
-      "reconfigure_successful": "Reconfiguración correcta"
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Reconfiguration successful"
     },
     "error": {
-      "cannot_connect": "Error al conectar",
-      "invalid_auth": "Autenticación no válida",
-      "unknown": "Error inesperado"
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     },
     "step": {
       "user": {
-        "description": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus; la escritura/control sigue siendo vía API HTTP a menos que también se habilite la escritura. Algunos controles se escriben mediante Modbus.",
+        "title": "Connection",
+        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "menu_options": {
+          "cloud": "Qvantum cloud (HTTP)",
+          "modbus": "Local Modbus (offline)"
+        }
+      },
+      "cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
         "data": {
-          "password": "Contraseña",
-          "username": "Nombre de usuario",
-          "modbus_tcp": "Usar lectura Modbus en lugar de sondeo HTTP",
-          "modbus_write": "Activar escritura mediante Modbus"
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "modbus": {
+        "title": "Local Modbus",
+        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus; la escritura/control sigue siendo vía API HTTP a menos que también se habilite la escritura. Algunos controles se escriben mediante Modbus.",
-          "modbus_write": "Al activar la escritura Modbus, aceptas la plena responsabilidad de cualquier valor escrito a través de la interfaz. El fabricante no es responsable de los problemas causados por valores incorrectos o fuera de rango, y tales acciones pueden anular la garantía y/o afectar el ciclo de vida y el rendimiento del producto."
+          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
+          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         }
       },
       "reconfigure": {
-        "description": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus; la escritura/control sigue siendo vía API HTTP a menos que también se habilite la escritura. Algunos controles se escriben mediante Modbus.",
+        "title": "Reconfigure",
+        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "menu_options": {
+          "reconfigure_cloud": "Qvantum cloud (HTTP)",
+          "reconfigure_modbus": "Local Modbus (offline)"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account.",
         "data": {
-          "password": "Contraseña",
-          "username": "Nombre de usuario",
-          "modbus_tcp": "Usar lectura Modbus en lugar de sondeo HTTP",
-          "modbus_write": "Activar escritura mediante Modbus",
-          "modbus_scan_interval": "Intervalo de exploración Modbus (segundos)"
-        },
-        "data_description": {
-          "modbus_tcp": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus; la escritura/control sigue siendo vía API HTTP a menos que también se habilite la escritura. Algunos controles se escriben mediante Modbus.",
-          "modbus_write": "Al activar la escritura Modbus, aceptas la plena responsabilidad de cualquier valor escrito a través de la interfaz. El fabricante no es responsable de los problemas causados por valores incorrectos o fuera de rango, y tales acciones pueden anular la garantía y/o afectar el ciclo de vida y el rendimiento del producto.",
-          "modbus_scan_interval": "Con qué frecuencia se consulta la bomba de calor por Modbus TCP. Valores más bajos dan precisión casi en tiempo real de caudal y volumen. El mínimo es 5 segundos. El valor predeterminado es 15 segundos."
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "reconfigure_modbus": {
+        "title": "Local Modbus",
+        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         }
       }
     }
@@ -575,19 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "Intervalo de exploración HTTP (segundos)",
-          "modbus_tcp": "Usar lectura Modbus en lugar de sondeo HTTP",
-          "modbus_host": "Qvantum Host/IP",
-          "modbus_write": "Activar escritura mediante Modbus",
-          "modbus_scan_interval": "Intervalo de exploración Modbus (segundos)"
+          "scan_interval": "HTTP scan interval (seconds)",
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Modbus scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus te dará métricas casi en tiempo real leyendo directamente desde el dispositivo.\nModbus debe habilitarse en la configuración del instalador en la aplicación/visualización de la bomba antes de habilitarlo aquí. Ten en cuenta que solo lee a través de Modbus; la escritura/control sigue siendo vía API HTTP a menos que también se habilite la escritura. Algunos controles se escriben mediante Modbus.",
-          "modbus_write": "Al activar la escritura Modbus, aceptas la plena responsabilidad de cualquier valor escrito a través de la interfaz. El fabricante no es responsable de los problemas causados por valores incorrectos o fuera de rango, y tales acciones pueden anular la garantía y/o afectar el ciclo de vida y el rendimiento del producto.",
-          "modbus_scan_interval": "Con qué frecuencia se consulta la bomba de calor por Modbus TCP. Valores más bajos dan precisión casi en tiempo real de caudal y volumen. El mínimo es 5 segundos. El valor predeterminado es 15 segundos."
+          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         },
-        "description": "Modifique sus opciones.",
-        "title": "Opciones"
+        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
+        "title": "Options"
       }
     }
   },

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -530,71 +530,71 @@
     }
   },
   "config": {
-    "title": "Qvantum Heat pump",
+    "title": "Bomba de calor Qvantum",
     "abort": {
-      "already_configured": "Device is already configured",
-      "reconfigure_successful": "Reconfiguration successful"
+      "already_configured": "El dispositivo ya está configurado",
+      "reconfigure_successful": "Reconfiguración correcta"
     },
     "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "cannot_connect": "Error al conectar",
+      "invalid_auth": "Autenticación no válida",
+      "unknown": "Error inesperado"
     },
     "step": {
       "user": {
-        "title": "Connection",
-        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "title": "Conexión",
+        "description": "Elige cómo Home Assistant se comunica con la bomba de calor. Puedes cambiarlo más tarde mediante la reconfiguración.",
         "menu_options": {
-          "cloud": "Qvantum cloud (HTTP)",
-          "modbus": "Local Modbus (offline)"
+          "cloud": "Nube Qvantum (HTTP)",
+          "modbus": "Modbus local (sin conexión)"
         }
       },
       "cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
+        "title": "Nube Qvantum",
+        "description": "Inicia sesión con tu cuenta Qvantum. Las métricas y los controles usan la API en la nube.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Contraseña",
+          "username": "Nombre de usuario"
         }
       },
       "modbus": {
-        "title": "Local Modbus",
-        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "title": "Modbus local",
+        "description": "Lee la bomba de calor en tu red local. Sin inicio de sesión. Activa primero Modbus external en la app Qvantum (Instalador → Modo servicio → Conectividad). Los controles no están disponibles en este modo.",
         "data": {
-          "modbus_host": "Host / IP",
-          "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_host": "Qvantum Host/IP",
+          "modbus_port": "Puerto",
+          "modbus_unit_id": "ID de unidad",
+          "modbus_scan_interval": "Intervalo de exploración Modbus (segundos)"
         },
         "data_description": {
-          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
-          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_host": "Nombre de host o IP de la bomba de calor. El valor predeterminado es Qvantum-HP.",
+          "modbus_scan_interval": "Con qué frecuencia consultar por Modbus TCP. El mínimo es 5 segundos. El valor predeterminado es 15 segundos."
         }
       },
       "reconfigure": {
-        "title": "Reconfigure",
-        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "title": "Reconfigurar",
+        "description": "Cambia entre HTTP en la nube y Modbus local, o actualiza la conexión actual.",
         "menu_options": {
-          "reconfigure_cloud": "Qvantum cloud (HTTP)",
-          "reconfigure_modbus": "Local Modbus (offline)"
+          "reconfigure_cloud": "Nube Qvantum (HTTP)",
+          "reconfigure_modbus": "Modbus local (sin conexión)"
         }
       },
       "reconfigure_cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account.",
+        "title": "Nube Qvantum",
+        "description": "Inicia sesión con tu cuenta Qvantum.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Contraseña",
+          "username": "Nombre de usuario"
         }
       },
       "reconfigure_modbus": {
-        "title": "Local Modbus",
-        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "title": "Modbus local",
+        "description": "Activa primero Modbus external en la app Qvantum. Home Assistant leerá el número de serie y el firmware de la bomba.",
         "data": {
-          "modbus_host": "Host / IP",
-          "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_host": "Qvantum Host/IP",
+          "modbus_port": "Puerto",
+          "modbus_unit_id": "ID de unidad",
+          "modbus_scan_interval": "Intervalo de exploración Modbus (segundos)"
         }
       }
     }
@@ -603,17 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP scan interval (seconds)",
-          "modbus_host": "Host / IP",
-          "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Modbus scan interval (seconds)"
+          "scan_interval": "Intervalo de exploración HTTP (segundos)",
+          "modbus_host": "Qvantum Host/IP",
+          "modbus_port": "Puerto",
+          "modbus_unit_id": "ID de unidad",
+          "modbus_scan_interval": "Intervalo de exploración Modbus (segundos)"
         },
         "data_description": {
-          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_scan_interval": "Con qué frecuencia se consulta la bomba de calor por Modbus TCP. Valores más bajos dan precisión casi en tiempo real de caudal y volumen. El mínimo es 5 segundos. El valor predeterminado es 15 segundos."
         },
-        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
-        "title": "Options"
+        "description": "Ajustes del modo de conexión actual. Usa reconfigurar para cambiar entre nube y Modbus.",
+        "title": "Opciones"
       }
     }
   },

--- a/custom_components/qvantum/translations/fi.json
+++ b/custom_components/qvantum/translations/fi.json
@@ -532,41 +532,69 @@
   "config": {
     "title": "Qvantum lämpöpumppu",
     "abort": {
-      "already_configured": "Laite on jo määritetty",
-      "reconfigure_successful": "Uudelleenmääritys onnistui"
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Reconfiguration successful"
     },
     "error": {
-      "cannot_connect": "Yhdistäminen epäonnistui",
-      "invalid_auth": "Virheellinen tunnistautuminen",
-      "unknown": "Odottamaton virhe"
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     },
     "step": {
       "user": {
-        "description": "Modbus antaa sinulle lähes reaaliaikaisia mittauksia lukemalla laitetta suoraan.\nModbus on otettava käyttöön pumpun sovelluksen/näytön asentajan asetuksissa ennen tämän ottamista käyttöön. Oletuksena se lukee vain Modbusin kautta; kirjoitukset/ohjaukset tapahtuvat edelleen HTTP-rajapinnan kautta, ellei myös Modbus-kirjoitus ole käytössä, jolloin jotkin ohjaukset kirjoitetaan Modbusin kautta.",
+        "title": "Connection",
+        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "menu_options": {
+          "cloud": "Qvantum cloud (HTTP)",
+          "modbus": "Local Modbus (offline)"
+        }
+      },
+      "cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
         "data": {
-          "password": "Salasana",
-          "username": "Käyttäjätunnus",
-          "modbus_tcp": "Käytä Modbus-lukemista HTTP-kyselyn sijaan",
-          "modbus_write": "Ota kirjoitus käyttöön Modbusin kautta"
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "modbus": {
+        "title": "Local Modbus",
+        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus antaa sinulle lähes reaaliaikaisia mittauksia lukemalla laitetta suoraan.\nModbus on otettava käyttöön pumpun sovelluksen/näytön asentajan asetuksissa ennen tämän ottamista käyttöön. Huomaa, että se lukee vain Modbusin kautta; kirjoitukset/ohjaukset tapahtuvat edelleen HTTP-rajapinnan kautta, ellei myös Modbus-kirjoitus ole käytössä, jolloin jotkin ohjaukset kirjoitetaan Modbusin kautta.",
-          "modbus_write": "Aktivoimalla Modbus-kirjoituksen hyväksyt täyden vastuun kaikista rajapinnan kautta kirjoitetuista arvoista. Valmistaja ei ole vastuussa virheellisten tai sallitun alueen ulkopuolella olevien arvojen aiheuttamista ongelmista, ja tällaiset toimenpiteet voivat mitätöidä takuun ja/tai vaikuttaa tuotteen käyttöikään ja suorituskykyyn."
+          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
+          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         }
       },
       "reconfigure": {
-        "description": "Modbus antaa sinulle lähes reaaliaikaisia mittauksia lukemalla laitetta suoraan.\nModbus on otettava käyttöön pumpun sovelluksen/näytön asentajan asetuksissa ennen tämän ottamista käyttöön. Oletuksena se lukee vain Modbusin kautta; kirjoitukset/ohjaukset tapahtuvat edelleen HTTP-rajapinnan kautta, ellei myös Modbus-kirjoitus ole käytössä, jolloin jotkin ohjaukset kirjoitetaan Modbusin kautta.",
+        "title": "Reconfigure",
+        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "menu_options": {
+          "reconfigure_cloud": "Qvantum cloud (HTTP)",
+          "reconfigure_modbus": "Local Modbus (offline)"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account.",
         "data": {
-          "password": "Salasana",
-          "username": "Käyttäjätunnus",
-          "modbus_tcp": "Käytä Modbus-lukemista HTTP-kyselyn sijaan",
-          "modbus_write": "Ota kirjoitus käyttöön Modbusin kautta",
-          "modbus_scan_interval": "Modbus-skannausväli (sekuntia)"
-        },
-        "data_description": {
-          "modbus_tcp": "Modbus antaa sinulle lähes reaaliaikaisia mittauksia lukemalla laitetta suoraan.\nModbus on otettava käyttöön pumpun sovelluksen/näytön asentajan asetuksissa ennen tämän ottamista käyttöön. Huomaa, että se lukee vain Modbusin kautta; kirjoitukset/ohjaukset tapahtuvat edelleen HTTP-rajapinnan kautta, ellei myös Modbus-kirjoitus ole käytössä, jolloin jotkin ohjaukset kirjoitetaan Modbusin kautta.",
-          "modbus_write": "Aktivoimalla Modbus-kirjoituksen hyväksyt täyden vastuun kaikista rajapinnan kautta kirjoitetuista arvoista. Valmistaja ei ole vastuussa virheellisten tai sallitun alueen ulkopuolella olevien arvojen aiheuttamista ongelmista, ja tällaiset toimenpiteet voivat mitätöidä takuun ja/tai vaikuttaa tuotteen käyttöikään ja suorituskykyyn.",
-          "modbus_scan_interval": "Kuinka usein lämpöpumppua kysytään Modbus TCP:n kautta. Pienemmät arvot tarjoavat lähes reaaliaikaisen virta- ja tilavuustarkkuuden. Minimi on 5 sekuntia. Oletus on 15 sekuntia."
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "reconfigure_modbus": {
+        "title": "Local Modbus",
+        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         }
       }
     }
@@ -575,19 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP-skannausväli (sekuntia)",
-          "modbus_tcp": "Käytä Modbus-lukemista HTTP-kyselyn sijaan",
-          "modbus_host": "Qvantum-isäntä/IP",
-          "modbus_write": "Ota kirjoitus käyttöön Modbusin kautta",
-          "modbus_scan_interval": "Modbus-skannausväli (sekuntia)"
+          "scan_interval": "HTTP scan interval (seconds)",
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Modbus scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus antaa sinulle lähes reaaliaikaisia mittauksia lukemalla laitetta suoraan.\nModbus on otettava käyttöön pumpun sovelluksen/näytön asentajan asetuksissa ennen tämän ottamista käyttöön. Huomaa, että se lukee vain Modbusin kautta; kirjoitukset/ohjaukset tapahtuvat edelleen HTTP-rajapinnan kautta, ellei myös Modbus-kirjoitus ole käytössä, jolloin jotkin ohjaukset kirjoitetaan Modbusin kautta.",
-          "modbus_write": "Aktivoimalla Modbus-kirjoituksen hyväksyt täyden vastuun kaikista rajapinnan kautta kirjoitetuista arvoista. Valmistaja ei ole vastuussa virheellisten tai sallitun alueen ulkopuolella olevien arvojen aiheuttamista ongelmista, ja tällaiset toimenpiteet voivat mitätöidä takuun ja/tai vaikuttaa tuotteen käyttöikään ja suorituskykyyn.",
-          "modbus_scan_interval": "Kuinka usein lämpöpumppua kysytään Modbus TCP:n kautta. Pienemmät arvot tarjoavat lähes reaaliaikaisen virta- ja tilavuustarkkuuden. Minimi on 5 sekuntia. Oletus on 15 sekuntia."
+          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         },
-        "description": "Muokkaa asetuksiasi.",
-        "title": "Asetukset"
+        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
+        "title": "Options"
       }
     }
   },

--- a/custom_components/qvantum/translations/fi.json
+++ b/custom_components/qvantum/translations/fi.json
@@ -532,69 +532,69 @@
   "config": {
     "title": "Qvantum lämpöpumppu",
     "abort": {
-      "already_configured": "Device is already configured",
-      "reconfigure_successful": "Reconfiguration successful"
+      "already_configured": "Laite on jo määritetty",
+      "reconfigure_successful": "Uudelleenmääritys onnistui"
     },
     "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "cannot_connect": "Yhdistäminen epäonnistui",
+      "invalid_auth": "Virheellinen tunnistautuminen",
+      "unknown": "Odottamaton virhe"
     },
     "step": {
       "user": {
-        "title": "Connection",
-        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "title": "Yhteys",
+        "description": "Valitse, miten Home Assistant keskustelee lämpöpumpun kanssa. Voit vaihtaa myöhemmin uudelleenmäärityksessä.",
         "menu_options": {
-          "cloud": "Qvantum cloud (HTTP)",
-          "modbus": "Local Modbus (offline)"
+          "cloud": "Qvantum-pilvi (HTTP)",
+          "modbus": "Paikallinen Modbus (offline)"
         }
       },
       "cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
+        "title": "Qvantum-pilvi",
+        "description": "Kirjaudu Qvantum-tililläsi. Mittaukset ja ohjaukset käyttävät pilvi-API:a.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Salasana",
+          "username": "Käyttäjätunnus"
         }
       },
       "modbus": {
-        "title": "Local Modbus",
-        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "title": "Paikallinen Modbus",
+        "description": "Lukee lämpöpumpun lähiverkossa. Ei kirjautumista. Ota ensin Modbus external käyttöön Qvantum-sovelluksessa (Asentaja → Huoltotila → Yhteydet). Ohjaukset eivät ole käytettävissä tässä tilassa.",
         "data": {
-          "modbus_host": "Host / IP",
-          "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_host": "Qvantum-isäntä/IP",
+          "modbus_port": "Portti",
+          "modbus_unit_id": "Yksikkö-ID",
+          "modbus_scan_interval": "Modbus-skannausväli (sekuntia)"
         },
         "data_description": {
-          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
-          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_host": "Lämpöpumpun isäntänimi tai IP-osoite. Oletus on Qvantum-HP.",
+          "modbus_scan_interval": "Kuinka usein kysely tehdään Modbus TCP:n kautta. Minimi on 5 sekuntia. Oletus on 15 sekuntia."
         }
       },
       "reconfigure": {
-        "title": "Reconfigure",
-        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "title": "Määritä uudelleen",
+        "description": "Vaihda pilvi-HTTP:n ja paikallisen Modbusin välillä tai päivitä nykyinen yhteys.",
         "menu_options": {
-          "reconfigure_cloud": "Qvantum cloud (HTTP)",
-          "reconfigure_modbus": "Local Modbus (offline)"
+          "reconfigure_cloud": "Qvantum-pilvi (HTTP)",
+          "reconfigure_modbus": "Paikallinen Modbus (offline)"
         }
       },
       "reconfigure_cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account.",
+        "title": "Qvantum-pilvi",
+        "description": "Kirjaudu Qvantum-tililläsi.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Salasana",
+          "username": "Käyttäjätunnus"
         }
       },
       "reconfigure_modbus": {
-        "title": "Local Modbus",
-        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "title": "Paikallinen Modbus",
+        "description": "Ota ensin Modbus external käyttöön Qvantum-sovelluksessa. Home Assistant lukee sarjanumeron ja laiteohjelmiston pumpusta.",
         "data": {
-          "modbus_host": "Host / IP",
-          "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_host": "Qvantum-isäntä/IP",
+          "modbus_port": "Portti",
+          "modbus_unit_id": "Yksikkö-ID",
+          "modbus_scan_interval": "Modbus-skannausväli (sekuntia)"
         }
       }
     }
@@ -603,17 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP scan interval (seconds)",
-          "modbus_host": "Host / IP",
-          "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Modbus scan interval (seconds)"
+          "scan_interval": "HTTP-skannausväli (sekuntia)",
+          "modbus_host": "Qvantum-isäntä/IP",
+          "modbus_port": "Portti",
+          "modbus_unit_id": "Yksikkö-ID",
+          "modbus_scan_interval": "Modbus-skannausväli (sekuntia)"
         },
         "data_description": {
-          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_scan_interval": "Kuinka usein lämpöpumppua kysytään Modbus TCP:n kautta. Pienemmät arvot tarjoavat lähes reaaliaikaisen virta- ja tilavuustarkkuuden. Minimi on 5 sekuntia. Oletus on 15 sekuntia."
         },
-        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
-        "title": "Options"
+        "description": "Nykyisen yhteystilan asetukset. Käytä uudelleenmääritystä vaihtaaksesi pilven ja Modbusin välillä.",
+        "title": "Asetukset"
       }
     }
   },

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -530,43 +530,71 @@
     }
   },
   "config": {
-    "title": "Pompe à chaleur Qvantum",
+    "title": "Qvantum Heat pump",
     "abort": {
-      "already_configured": "L'appareil est déjà configuré",
-      "reconfigure_successful": "Reconfiguration réussie"
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Reconfiguration successful"
     },
     "error": {
-      "cannot_connect": "Échec de connexion",
-      "invalid_auth": "Authentification invalide",
-      "unknown": "Erreur inattendue"
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     },
     "step": {
       "user": {
-        "description": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il lit uniquement via Modbus ; les écritures/contrôles se font toujours via l'API HTTP sauf si l'écriture est également activée. Certains contrôles sont écrits via Modbus.",
+        "title": "Connection",
+        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "menu_options": {
+          "cloud": "Qvantum cloud (HTTP)",
+          "modbus": "Local Modbus (offline)"
+        }
+      },
+      "cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
         "data": {
-          "password": "Mot de passe",
-          "username": "Nom d'utilisateur",
-          "modbus_tcp": "Utiliser la lecture Modbus au lieu du polling HTTP",
-          "modbus_write": "Activer l'écriture via Modbus"
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "modbus": {
+        "title": "Local Modbus",
+        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il lit uniquement via Modbus ; les écritures/contrôles se font toujours via l'API HTTP sauf si l'écriture est également activée. Certains contrôles sont écrits via Modbus.",
-          "modbus_write": "En activant l'écriture Modbus, vous acceptez l'entière responsabilité de toutes les valeurs écrites via l'interface. Le fabricant n'est pas responsable des problèmes causés par des valeurs incorrectes ou hors limites, et de telles actions peuvent annuler la garantie et/ou affecter le cycle de vie et les performances du produit."
+          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
+          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         }
       },
       "reconfigure": {
-        "description": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il lit uniquement via Modbus ; les écritures/contrôles se font toujours via l'API HTTP sauf si l'écriture est également activée. Certains contrôles sont écrits via Modbus.",
+        "title": "Reconfigure",
+        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "menu_options": {
+          "reconfigure_cloud": "Qvantum cloud (HTTP)",
+          "reconfigure_modbus": "Local Modbus (offline)"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account.",
         "data": {
-          "password": "Mot de passe",
-          "username": "Nom d'utilisateur",
-          "modbus_tcp": "Utiliser la lecture Modbus au lieu du polling HTTP",
-          "modbus_write": "Activer l'écriture via Modbus",
-          "modbus_scan_interval": "Intervalle de scan Modbus (secondes)"
-        },
-        "data_description": {
-          "modbus_tcp": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il lit uniquement via Modbus ; les écritures/contrôles se font toujours via l'API HTTP sauf si l'écriture est également activée. Certains contrôles sont écrits via Modbus.",
-          "modbus_write": "En activant l'écriture Modbus, vous acceptez l'entière responsabilité de toutes les valeurs écrites via l'interface. Le fabricant n'est pas responsable des problèmes causés par des valeurs incorrectes ou hors limites, et de telles actions peuvent annuler la garantie et/ou affecter le cycle de vie et les performances du produit.",
-          "modbus_scan_interval": "Fréquence d'interrogation de la pompe à chaleur via Modbus TCP. Des valeurs plus basses offrent une précision quasi temps réel du débit et du volume. Minimum 5 secondes. Par défaut 15 secondes."
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "reconfigure_modbus": {
+        "title": "Local Modbus",
+        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         }
       }
     }
@@ -575,18 +603,16 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "Intervalle de scan HTTP (secondes)",
-          "modbus_tcp": "Utiliser la lecture Modbus au lieu du polling HTTP",
-          "modbus_host": "Hôte/IP Qvantum",
-          "modbus_write": "Activer l'écriture via Modbus",
-          "modbus_scan_interval": "Intervalle de scan Modbus (secondes)"
+          "scan_interval": "HTTP scan interval (seconds)",
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Modbus scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus fournit des métriques en temps quasi réel en lisant directement depuis l'appareil.\nModbus doit être activé dans les paramètres installateur de l'application/affichage de la pompe avant activation ici. Note : il lit uniquement via Modbus ; les écritures/contrôles se font toujours via l'API HTTP sauf si l'écriture est également activée. Certains contrôles sont écrits via Modbus.",
-          "modbus_write": "En activant l'écriture Modbus, vous acceptez l'entière responsabilité de toutes les valeurs écrites via l'interface. Le fabricant n'est pas responsable des problèmes causés par des valeurs incorrectes ou hors limites, et de telles actions peuvent annuler la garantie et/ou affecter le cycle de vie et les performances du produit.",
-          "modbus_scan_interval": "Fréquence d'interrogation de la pompe à chaleur via Modbus TCP. Des valeurs plus basses offrent une précision quasi temps réel du débit et du volume. Minimum 5 secondes. Par défaut 15 secondes."
+          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         },
-        "description": "Modifiez vos options.",
+        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
         "title": "Options"
       }
     }

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -530,71 +530,71 @@
     }
   },
   "config": {
-    "title": "Qvantum Heat pump",
+    "title": "Pompe à chaleur Qvantum",
     "abort": {
-      "already_configured": "Device is already configured",
-      "reconfigure_successful": "Reconfiguration successful"
+      "already_configured": "L'appareil est déjà configuré",
+      "reconfigure_successful": "Reconfiguration réussie"
     },
     "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "cannot_connect": "Échec de connexion",
+      "invalid_auth": "Authentification invalide",
+      "unknown": "Erreur inattendue"
     },
     "step": {
       "user": {
-        "title": "Connection",
-        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "title": "Connexion",
+        "description": "Choisissez comment Home Assistant communique avec la pompe à chaleur. Vous pourrez changer plus tard via la reconfiguration.",
         "menu_options": {
-          "cloud": "Qvantum cloud (HTTP)",
-          "modbus": "Local Modbus (offline)"
+          "cloud": "Cloud Qvantum (HTTP)",
+          "modbus": "Modbus local (hors ligne)"
         }
       },
       "cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
+        "title": "Cloud Qvantum",
+        "description": "Connectez-vous avec votre compte Qvantum. Les mesures et les commandes utilisent l'API cloud.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Mot de passe",
+          "username": "Nom d'utilisateur"
         }
       },
       "modbus": {
-        "title": "Local Modbus",
-        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "title": "Modbus local",
+        "description": "Lit la pompe à chaleur sur votre réseau local. Sans connexion. Activez d'abord Modbus external dans l'application Qvantum (Installateur → Mode service → Connectivité). Les commandes ne sont pas disponibles dans ce mode.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Hôte/IP Qvantum",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "ID d'unité",
+          "modbus_scan_interval": "Intervalle de scan Modbus (secondes)"
         },
         "data_description": {
-          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
-          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_host": "Nom d'hôte ou adresse IP de la pompe à chaleur. La valeur par défaut est Qvantum-HP.",
+          "modbus_scan_interval": "Fréquence d'interrogation via Modbus TCP. Le minimum est de 5 secondes. La valeur par défaut est de 15 secondes."
         }
       },
       "reconfigure": {
-        "title": "Reconfigure",
-        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "title": "Reconfigurer",
+        "description": "Basculez entre le HTTP cloud et le Modbus local, ou mettez à jour la connexion actuelle.",
         "menu_options": {
-          "reconfigure_cloud": "Qvantum cloud (HTTP)",
-          "reconfigure_modbus": "Local Modbus (offline)"
+          "reconfigure_cloud": "Cloud Qvantum (HTTP)",
+          "reconfigure_modbus": "Modbus local (hors ligne)"
         }
       },
       "reconfigure_cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account.",
+        "title": "Cloud Qvantum",
+        "description": "Connectez-vous avec votre compte Qvantum.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Mot de passe",
+          "username": "Nom d'utilisateur"
         }
       },
       "reconfigure_modbus": {
-        "title": "Local Modbus",
-        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "title": "Modbus local",
+        "description": "Activez d'abord Modbus external dans l'application Qvantum. Home Assistant lira le numéro de série et le micrologiciel de la pompe.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Hôte/IP Qvantum",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "ID d'unité",
+          "modbus_scan_interval": "Intervalle de scan Modbus (secondes)"
         }
       }
     }
@@ -603,16 +603,16 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP scan interval (seconds)",
-          "modbus_host": "Host / IP",
+          "scan_interval": "Intervalle de scan HTTP (secondes)",
+          "modbus_host": "Hôte/IP Qvantum",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Modbus scan interval (seconds)"
+          "modbus_unit_id": "ID d'unité",
+          "modbus_scan_interval": "Intervalle de scan Modbus (secondes)"
         },
         "data_description": {
-          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_scan_interval": "Fréquence d'interrogation de la pompe à chaleur via Modbus TCP. Des valeurs plus basses offrent une précision quasi temps réel du débit et du volume. Minimum 5 secondes. Par défaut 15 secondes."
         },
-        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
+        "description": "Paramètres du mode de connexion actuel. Utilisez la reconfiguration pour basculer entre le cloud et Modbus.",
         "title": "Options"
       }
     }

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -530,71 +530,71 @@
     }
   },
   "config": {
-    "title": "Qvantum Heat pump",
+    "title": "Qvantum hőszivattyú",
     "abort": {
-      "already_configured": "Device is already configured",
-      "reconfigure_successful": "Reconfiguration successful"
+      "already_configured": "Az eszköz már konfigurálva van",
+      "reconfigure_successful": "Újrakonfigurálás sikeres"
     },
     "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "cannot_connect": "Sikertelen csatlakozás",
+      "invalid_auth": "Érvénytelen hitelesítés",
+      "unknown": "Váratlan hiba"
     },
     "step": {
       "user": {
-        "title": "Connection",
-        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "title": "Kapcsolat",
+        "description": "Válassza ki, hogyan kommunikáljon a Home Assistant a hőszivattyúval. Később az újrakonfigurálással válthat.",
         "menu_options": {
-          "cloud": "Qvantum cloud (HTTP)",
-          "modbus": "Local Modbus (offline)"
+          "cloud": "Qvantum felhő (HTTP)",
+          "modbus": "Helyi Modbus (offline)"
         }
       },
       "cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
+        "title": "Qvantum felhő",
+        "description": "Jelentkezzen be Qvantum-fiókjával. A mérések és a vezérlés a felhő API-t használja.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Jelszó",
+          "username": "Felhasználónév"
         }
       },
       "modbus": {
-        "title": "Local Modbus",
-        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "title": "Helyi Modbus",
+        "description": "A hőszivattyút a helyi hálózaton olvassa. Nincs bejelentkezés. Először engedélyezze a Modbus external funkciót a Qvantum alkalmazásban (Telepítő → Szerviz mód → Kapcsolódás). A vezérlés ebben a módban nem érhető el.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Qvantum Hoszt/IP",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "Egységazonosító",
+          "modbus_scan_interval": "Modbus lekérdezési időköz (másodperc)"
         },
         "data_description": {
-          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
-          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_host": "A hőszivattyú gépneve vagy IP-címe. Az alapértelmezett a Qvantum-HP.",
+          "modbus_scan_interval": "Milyen gyakran kérdezzen le Modbus TCP-n. A minimum 5 másodperc. Az alapértelmezett 15 másodperc."
         }
       },
       "reconfigure": {
-        "title": "Reconfigure",
-        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "title": "Újrakonfigurálás",
+        "description": "Váltson a felhő HTTP és a helyi Modbus között, vagy frissítse az aktuális kapcsolatot.",
         "menu_options": {
-          "reconfigure_cloud": "Qvantum cloud (HTTP)",
-          "reconfigure_modbus": "Local Modbus (offline)"
+          "reconfigure_cloud": "Qvantum felhő (HTTP)",
+          "reconfigure_modbus": "Helyi Modbus (offline)"
         }
       },
       "reconfigure_cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account.",
+        "title": "Qvantum felhő",
+        "description": "Jelentkezzen be Qvantum-fiókjával.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Jelszó",
+          "username": "Felhasználónév"
         }
       },
       "reconfigure_modbus": {
-        "title": "Local Modbus",
-        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "title": "Helyi Modbus",
+        "description": "Először engedélyezze a Modbus external funkciót a Qvantum alkalmazásban. A Home Assistant beolvassa a szivattyú sorozatszámát és firmware-ét.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Qvantum Hoszt/IP",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "Egységazonosító",
+          "modbus_scan_interval": "Modbus lekérdezési időköz (másodperc)"
         }
       }
     }
@@ -603,17 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP scan interval (seconds)",
-          "modbus_host": "Host / IP",
+          "scan_interval": "HTTP lekérdezési időköz (másodperc)",
+          "modbus_host": "Qvantum Hoszt/IP",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Modbus scan interval (seconds)"
+          "modbus_unit_id": "Egységazonosító",
+          "modbus_scan_interval": "Modbus lekérdezési időköz (másodperc)"
         },
         "data_description": {
-          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_scan_interval": "Milyen gyakran kérdezze le a hőszivattyút Modbus TCP-n. Az alacsonyabb értékek közel valós idejű áramlás- és térfogatpontosságot adnak. Minimum 5 másodperc. Alapértelmezett 15 másodperc."
         },
-        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
-        "title": "Options"
+        "description": "Az aktuális kapcsolódási mód beállításai. A felhő és a Modbus közötti váltáshoz használja az újrakonfigurálást.",
+        "title": "Beállítások"
       }
     }
   },

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -530,43 +530,71 @@
     }
   },
   "config": {
-    "title": "Qvantum hőszivattyú",
+    "title": "Qvantum Heat pump",
     "abort": {
-      "already_configured": "Az eszköz már konfigurálva van",
-      "reconfigure_successful": "Újrakonfigurálás sikeres"
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Reconfiguration successful"
     },
     "error": {
-      "cannot_connect": "Sikertelen csatlakozás",
-      "invalid_auth": "Érvénytelen hitelesítés",
-      "unknown": "Váratlan hiba"
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     },
     "step": {
       "user": {
-        "description": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: itt csak Modbus-olvasás történik; az írás/vezérlés továbbra is HTTP API-n keresztül történik, kivéve, ha az írás is engedélyezve van. Bizonyos vezérlések Modbuson keresztül íródnak.",
+        "title": "Connection",
+        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "menu_options": {
+          "cloud": "Qvantum cloud (HTTP)",
+          "modbus": "Local Modbus (offline)"
+        }
+      },
+      "cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
         "data": {
-          "password": "Jelszó",
-          "username": "Felhasználónév",
-          "modbus_tcp": "Modbus-olvasás használata HTTP lekérdezés helyett",
-          "modbus_write": "Modbus alapú írás engedélyezése"
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "modbus": {
+        "title": "Local Modbus",
+        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: itt csak Modbus-olvasás történik; az írás/vezérlés továbbra is HTTP API-n keresztül történik, kivéve, ha az írás is engedélyezve van. Bizonyos vezérlések Modbuson keresztül íródnak.",
-          "modbus_write": "A Modbus-írás aktiválásával teljes felelősséget vállal a felületen keresztül írt értékekért. A gyártó nem vállal felelősséget a helytelen vagy tartományon kívüli értékek által okozott problémákért, és az ilyen műveletek érvénytelenítheti a garanciát és/vagy befolyásolhatja a termék élettartamát és teljesítményét."
+          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
+          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         }
       },
       "reconfigure": {
-        "description": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: itt csak Modbus-olvasás történik; az írás/vezérlés továbbra is HTTP API-n keresztül történik, kivéve, ha az írás is engedélyezve van. Bizonyos vezérlések Modbuson keresztül íródnak.",
+        "title": "Reconfigure",
+        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "menu_options": {
+          "reconfigure_cloud": "Qvantum cloud (HTTP)",
+          "reconfigure_modbus": "Local Modbus (offline)"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account.",
         "data": {
-          "password": "Jelszó",
-          "username": "Felhasználónév",
-          "modbus_tcp": "Modbus-olvasás használata HTTP lekérdezés helyett",
-          "modbus_write": "Modbus alapú írás engedélyezése",
-          "modbus_scan_interval": "Modbus lekérdezési időköz (másodperc)"
-        },
-        "data_description": {
-          "modbus_tcp": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: itt csak Modbus-olvasás történik; az írás/vezérlés továbbra is HTTP API-n keresztül történik, kivéve, ha az írás is engedélyezve van. Bizonyos vezérlések Modbuson keresztül íródnak.",
-          "modbus_write": "A Modbus-írás aktiválásával teljes felelősséget vállal a felületen keresztül írt értékekért. A gyártó nem vállal felelősséget a helytelen vagy tartományon kívüli értékek által okozott problémákért, és az ilyen műveletek érvénytelenítheti a garanciát és/vagy befolyásolhatja a termék élettartamát és teljesítményét.",
-          "modbus_scan_interval": "Milyen gyakran kérdezze le a hőszivattyút Modbus TCP-n. Az alacsonyabb értékek közel valós idejű áramlás- és térfogatpontosságot adnak. Minimum 5 másodperc. Alapértelmezett 15 másodperc."
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "reconfigure_modbus": {
+        "title": "Local Modbus",
+        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         }
       }
     }
@@ -575,19 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP lekérdezési időköz (másodperc)",
-          "modbus_tcp": "Modbus-olvasás használata HTTP lekérdezés helyett",
-          "modbus_host": "Qvantum Hoszt/IP",
-          "modbus_write": "Modbus alapú írás engedélyezése",
-          "modbus_scan_interval": "Modbus lekérdezési időköz (másodperc)"
+          "scan_interval": "HTTP scan interval (seconds)",
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Modbus scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "A Modbus közel valós idejű adatokat ad az eszköz közvetlen olvasásával.\nA Modbus-t engedélyezni kell a szivattyú alkalmazás/kijelző Telepítő beállításaiban, mielőtt itt bekapcsolja. Fontos: itt csak Modbus-olvasás történik; az írás/vezérlés továbbra is HTTP API-n keresztül történik, kivéve, ha az írás is engedélyezve van. Bizonyos vezérlések Modbuson keresztül íródnak.",
-          "modbus_write": "A Modbus-írás aktiválásával teljes felelősséget vállal a felületen keresztül írt értékekért. A gyártó nem vállal felelősséget a helytelen vagy tartományon kívüli értékek által okozott problémákért, és az ilyen műveletek érvénytelenítheti a garanciát és/vagy befolyásolhatja a termék élettartamát és teljesítményét.",
-          "modbus_scan_interval": "Milyen gyakran kérdezze le a hőszivattyút Modbus TCP-n. Az alacsonyabb értékek közel valós idejű áramlás- és térfogatpontosságot adnak. Minimum 5 másodperc. Alapértelmezett 15 másodperc."
+          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         },
-        "description": "Módosítsa a beállításait.",
-        "title": "Beállítások"
+        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
+        "title": "Options"
       }
     }
   },

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -530,71 +530,71 @@
     }
   },
   "config": {
-    "title": "Qvantum Heat pump",
+    "title": "Qvantum Warmtepomp",
     "abort": {
-      "already_configured": "Device is already configured",
-      "reconfigure_successful": "Reconfiguration successful"
+      "already_configured": "Apparaat is al geconfigureerd",
+      "reconfigure_successful": "Herconfiguratie succesvol"
     },
     "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "cannot_connect": "Kan niet verbinden",
+      "invalid_auth": "Ongeldige authenticatie",
+      "unknown": "Onbekende fout"
     },
     "step": {
       "user": {
-        "title": "Connection",
-        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "title": "Verbinding",
+        "description": "Kies hoe Home Assistant met de warmtepomp communiceert. U kunt later wisselen via herconfiguratie.",
         "menu_options": {
-          "cloud": "Qvantum cloud (HTTP)",
-          "modbus": "Local Modbus (offline)"
+          "cloud": "Qvantum-cloud (HTTP)",
+          "modbus": "Lokale Modbus (offline)"
         }
       },
       "cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
+        "title": "Qvantum-cloud",
+        "description": "Meld u aan met uw Qvantum-account. Metingen en bediening gebruiken de cloud-API.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Wachtwoord",
+          "username": "Gebruikersnaam"
         }
       },
       "modbus": {
-        "title": "Local Modbus",
-        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "title": "Lokale Modbus",
+        "description": "Leest de warmtepomp op uw LAN. Geen aanmelding. Schakel eerst Modbus external in in de Qvantum-app (Installateur → Servicemodus → Connectiviteit). Bediening is in deze modus niet beschikbaar.",
         "data": {
-          "modbus_host": "Host / IP",
-          "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_host": "Qvantum Host/IP",
+          "modbus_port": "Poort",
+          "modbus_unit_id": "Unit-ID",
+          "modbus_scan_interval": "Modbus-scaninterval (seconden)"
         },
         "data_description": {
-          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
-          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_host": "Hostnaam of IP-adres van de warmtepomp. Standaard is Qvantum-HP.",
+          "modbus_scan_interval": "Hoe vaak er via Modbus TCP wordt gepolld. Minimum is 5 seconden. Standaard is 15 seconden."
         }
       },
       "reconfigure": {
-        "title": "Reconfigure",
-        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "title": "Herconfigureren",
+        "description": "Schakel tussen cloud-HTTP en lokale Modbus, of werk de huidige verbinding bij.",
         "menu_options": {
-          "reconfigure_cloud": "Qvantum cloud (HTTP)",
-          "reconfigure_modbus": "Local Modbus (offline)"
+          "reconfigure_cloud": "Qvantum-cloud (HTTP)",
+          "reconfigure_modbus": "Lokale Modbus (offline)"
         }
       },
       "reconfigure_cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account.",
+        "title": "Qvantum-cloud",
+        "description": "Meld u aan met uw Qvantum-account.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Wachtwoord",
+          "username": "Gebruikersnaam"
         }
       },
       "reconfigure_modbus": {
-        "title": "Local Modbus",
-        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "title": "Lokale Modbus",
+        "description": "Schakel eerst Modbus external in in de Qvantum-app. Home Assistant leest serienummer en firmware van de pomp.",
         "data": {
-          "modbus_host": "Host / IP",
-          "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_host": "Qvantum Host/IP",
+          "modbus_port": "Poort",
+          "modbus_unit_id": "Unit-ID",
+          "modbus_scan_interval": "Modbus-scaninterval (seconden)"
         }
       }
     }
@@ -603,17 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP scan interval (seconds)",
-          "modbus_host": "Host / IP",
-          "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Modbus scan interval (seconds)"
+          "scan_interval": "HTTP-scaninterval (seconden)",
+          "modbus_host": "Qvantum Host/IP",
+          "modbus_port": "Poort",
+          "modbus_unit_id": "Unit-ID",
+          "modbus_scan_interval": "Modbus-scaninterval (seconden)"
         },
         "data_description": {
-          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_scan_interval": "Hoe vaak de warmtepomp via Modbus TCP wordt gepolld. Lagere waarden geven bijna realtime debiet- en volumenauwkeurigheid. Minimum is 5 seconden. Standaard is 15 seconden."
         },
-        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
-        "title": "Options"
+        "description": "Instellingen voor de huidige verbindingsmodus. Gebruik herconfiguratie om te wisselen tussen cloud en Modbus.",
+        "title": "Opties"
       }
     }
   },

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -530,43 +530,71 @@
     }
   },
   "config": {
-    "title": "Qvantum Warmtepomp",
+    "title": "Qvantum Heat pump",
     "abort": {
-      "already_configured": "Apparaat is al geconfigureerd",
-      "reconfigure_successful": "Herconfiguratie succesvol"
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Reconfiguration successful"
     },
     "error": {
-      "cannot_connect": "Kan niet verbinden",
-      "invalid_auth": "Ongeldige authenticatie",
-      "unknown": "Onbekende fout"
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     },
     "step": {
       "user": {
-        "description": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest; schrijven/sturing gebeurt nog via de HTTP API, tenzij schrijven ook is ingeschakeld. Bepaalde besturingen worden via Modbus geschreven.",
+        "title": "Connection",
+        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "menu_options": {
+          "cloud": "Qvantum cloud (HTTP)",
+          "modbus": "Local Modbus (offline)"
+        }
+      },
+      "cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
         "data": {
-          "password": "Wachtwoord",
-          "username": "Gebruikersnaam",
-          "modbus_tcp": "Gebruik Modbus-uitlezing in plaats van HTTP-polling",
-          "modbus_write": "Schrijven via Modbus inschakelen"
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "modbus": {
+        "title": "Local Modbus",
+        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest; schrijven/sturing gebeurt nog via de HTTP API, tenzij schrijven ook is ingeschakeld. Bepaalde besturingen worden via Modbus geschreven.",
-          "modbus_write": "Door het activeren van Modbus-schrijven aanvaardt u volledige verantwoordelijkheid voor alle waarden die via de interface worden geschreven. De fabrikant is niet aansprakelijk voor problemen veroorzaakt door onjuiste of buiten bereik vallende waarden, en dergelijke acties kunnen de garantie en/of de levensduur en prestaties van het product beïnvloeden."
+          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
+          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         }
       },
       "reconfigure": {
-        "description": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest; schrijven/sturing gebeurt nog via de HTTP API, tenzij schrijven ook is ingeschakeld. Bepaalde besturingen worden via Modbus geschreven.",
+        "title": "Reconfigure",
+        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "menu_options": {
+          "reconfigure_cloud": "Qvantum cloud (HTTP)",
+          "reconfigure_modbus": "Local Modbus (offline)"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account.",
         "data": {
-          "password": "Wachtwoord",
-          "username": "Gebruikersnaam",
-          "modbus_tcp": "Gebruik Modbus-uitlezing in plaats van HTTP-polling",
-          "modbus_write": "Schrijven via Modbus inschakelen",
-          "modbus_scan_interval": "Modbus-scaninterval (seconden)"
-        },
-        "data_description": {
-          "modbus_tcp": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest; schrijven/sturing gebeurt nog via de HTTP API, tenzij schrijven ook is ingeschakeld. Bepaalde besturingen worden via Modbus geschreven.",
-          "modbus_write": "Door het activeren van Modbus-schrijven aanvaardt u volledige verantwoordelijkheid voor alle waarden die via de interface worden geschreven. De fabrikant is niet aansprakelijk voor problemen veroorzaakt door onjuiste of buiten bereik vallende waarden, en dergelijke acties kunnen de garantie en/of de levensduur en prestaties van het product beïnvloeden.",
-          "modbus_scan_interval": "Hoe vaak de warmtepomp via Modbus TCP wordt gepolld. Lagere waarden geven bijna realtime debiet- en volumenauwkeurigheid. Minimum is 5 seconden. Standaard is 15 seconden."
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "reconfigure_modbus": {
+        "title": "Local Modbus",
+        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         }
       }
     }
@@ -575,19 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP-scaninterval (seconden)",
-          "modbus_tcp": "Gebruik Modbus-uitlezing in plaats van HTTP-polling",
-          "modbus_host": "Qvantum Host/IP",
-          "modbus_write": "Schrijven via Modbus inschakelen",
-          "modbus_scan_interval": "Modbus-scaninterval (seconden)"
+          "scan_interval": "HTTP scan interval (seconds)",
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Modbus scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus geeft bijna realtime statistieken door direct vanaf het apparaat te lezen.\nModbus moet zijn ingeschakeld in de installateurinstellingen in de pomp-app/display voordat het hier kan worden ingeschakeld. Houd er rekening mee dat het alleen via Modbus leest; schrijven/sturing gebeurt nog via de HTTP API, tenzij schrijven ook is ingeschakeld. Bepaalde besturingen worden via Modbus geschreven.",
-          "modbus_write": "Door het activeren van Modbus-schrijven aanvaardt u volledige verantwoordelijkheid voor alle waarden die via de interface worden geschreven. De fabrikant is niet aansprakelijk voor problemen veroorzaakt door onjuiste of buiten bereik vallende waarden, en dergelijke acties kunnen de garantie en/of de levensduur en prestaties van het product beïnvloeden.",
-          "modbus_scan_interval": "Hoe vaak de warmtepomp via Modbus TCP wordt gepolld. Lagere waarden geven bijna realtime debiet- en volumenauwkeurigheid. Minimum is 5 seconden. Standaard is 15 seconden."
+          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         },
-        "description": "Wijzig uw opties.",
-        "title": "Opties"
+        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
+        "title": "Options"
       }
     }
   },

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -530,71 +530,71 @@
     }
   },
   "config": {
-    "title": "Qvantum Heat pump",
+    "title": "Pompa ciepła Qvantum",
     "abort": {
-      "already_configured": "Device is already configured",
-      "reconfigure_successful": "Reconfiguration successful"
+      "already_configured": "Urządzenie jest już skonfigurowane",
+      "reconfigure_successful": "Rekonfiguracja powiodła się"
     },
     "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "cannot_connect": "Nie udało się połączyć",
+      "invalid_auth": "Nieprawidłowe uwierzytelnienie",
+      "unknown": "Nieoczekiwany błąd"
     },
     "step": {
       "user": {
-        "title": "Connection",
-        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "title": "Połączenie",
+        "description": "Wybierz, jak Home Assistant ma komunikować się z pompą ciepła. Tryb można później zmienić przez rekonfigurację.",
         "menu_options": {
-          "cloud": "Qvantum cloud (HTTP)",
-          "modbus": "Local Modbus (offline)"
+          "cloud": "Chmura Qvantum (HTTP)",
+          "modbus": "Lokalny Modbus (offline)"
         }
       },
       "cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
+        "title": "Chmura Qvantum",
+        "description": "Zaloguj się na konto Qvantum. Pomiary i sterowanie korzystają z API w chmurze.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Hasło",
+          "username": "Nazwa użytkownika"
         }
       },
       "modbus": {
-        "title": "Local Modbus",
-        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "title": "Lokalny Modbus",
+        "description": "Odczytuje pompę ciepła w sieci lokalnej. Bez logowania. Najpierw włącz Modbus external w aplikacji Qvantum (Instalator → Tryb serwisowy → Łączność). Sterowanie jest w tym trybie niedostępne.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Host/IP Qvantum",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "ID jednostki",
+          "modbus_scan_interval": "Interwał skanowania Modbus (sekundy)"
         },
         "data_description": {
-          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
-          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_host": "Nazwa hosta lub adres IP pompy ciepła. Domyślnie Qvantum-HP.",
+          "modbus_scan_interval": "Jak często odpytywać przez Modbus TCP. Minimum to 5 sekund. Domyślnie 15 sekund."
         }
       },
       "reconfigure": {
-        "title": "Reconfigure",
-        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "title": "Rekonfiguruj",
+        "description": "Przełącz między chmurą HTTP a lokalnym Modbusem albo zaktualizuj bieżące połączenie.",
         "menu_options": {
-          "reconfigure_cloud": "Qvantum cloud (HTTP)",
-          "reconfigure_modbus": "Local Modbus (offline)"
+          "reconfigure_cloud": "Chmura Qvantum (HTTP)",
+          "reconfigure_modbus": "Lokalny Modbus (offline)"
         }
       },
       "reconfigure_cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account.",
+        "title": "Chmura Qvantum",
+        "description": "Zaloguj się na konto Qvantum.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Hasło",
+          "username": "Nazwa użytkownika"
         }
       },
       "reconfigure_modbus": {
-        "title": "Local Modbus",
-        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "title": "Lokalny Modbus",
+        "description": "Najpierw włącz Modbus external w aplikacji Qvantum. Home Assistant odczyta numer seryjny i oprogramowanie układowe pompy.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Host/IP Qvantum",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "ID jednostki",
+          "modbus_scan_interval": "Interwał skanowania Modbus (sekundy)"
         }
       }
     }
@@ -603,17 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP scan interval (seconds)",
-          "modbus_host": "Host / IP",
+          "scan_interval": "Interwał skanowania HTTP (sekundy)",
+          "modbus_host": "Host/IP Qvantum",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Modbus scan interval (seconds)"
+          "modbus_unit_id": "ID jednostki",
+          "modbus_scan_interval": "Interwał skanowania Modbus (sekundy)"
         },
         "data_description": {
-          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_scan_interval": "Jak często odpytywać pompę ciepła przez Modbus TCP. Niższe wartości dają prawie rzeczywistą dokładność przepływu i objętości. Minimum to 5 sekund. Domyślnie 15 sekund."
         },
-        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
-        "title": "Options"
+        "description": "Ustawienia bieżącego trybu połączenia. Użyj rekonfiguracji, aby przełączyć między chmurą a Modbusem.",
+        "title": "Opcje"
       }
     }
   },

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -530,43 +530,71 @@
     }
   },
   "config": {
-    "title": "Pompa ciepła Qvantum",
+    "title": "Qvantum Heat pump",
     "abort": {
-      "already_configured": "Urządzenie jest już skonfigurowane",
-      "reconfigure_successful": "Rekonfiguracja powiodła się"
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Reconfiguration successful"
     },
     "error": {
-      "cannot_connect": "Nie udało się połączyć",
-      "invalid_auth": "Nieprawidłowe uwierzytelnienie",
-      "unknown": "Nieoczekiwany błąd"
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     },
     "step": {
       "user": {
-        "description": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: tutaj działa tylko odczyt przez Modbus; zapis/sterowanie nadal odbywa się przez HTTP API, chyba że zapis również jest włączony. Niektóre funkcje sterowania są zapisywane przez Modbus.",
+        "title": "Connection",
+        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "menu_options": {
+          "cloud": "Qvantum cloud (HTTP)",
+          "modbus": "Local Modbus (offline)"
+        }
+      },
+      "cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
         "data": {
-          "password": "Hasło",
-          "username": "Nazwa użytkownika",
-          "modbus_tcp": "Użyj odczytu Modbus zamiast odpytywania HTTP",
-          "modbus_write": "Włącz zapis przez Modbus"
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "modbus": {
+        "title": "Local Modbus",
+        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: tutaj działa tylko odczyt przez Modbus; zapis/sterowanie nadal odbywa się przez HTTP API, chyba że zapis również jest włączony. Niektóre funkcje sterowania są zapisywane przez Modbus.",
-          "modbus_write": "Aktywując zapis przez Modbus, bierzesz pełną odpowiedzialność za wszelkie wartości zapisane przez interfejs. Producent nie ponosi odpowiedzialności za problemy spowodowane przez nieprawidłowe lub wykraczające poza zakres wartości, a takie działania mogą unieważnić gwarancję i/lub wpłynąć na żywotność i wydajność produktu."
+          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
+          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         }
       },
       "reconfigure": {
-        "description": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: tutaj działa tylko odczyt przez Modbus; zapis/sterowanie nadal odbywa się przez HTTP API, chyba że zapis również jest włączony. Niektóre funkcje sterowania są zapisywane przez Modbus.",
+        "title": "Reconfigure",
+        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "menu_options": {
+          "reconfigure_cloud": "Qvantum cloud (HTTP)",
+          "reconfigure_modbus": "Local Modbus (offline)"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account.",
         "data": {
-          "password": "Hasło",
-          "username": "Nazwa użytkownika",
-          "modbus_tcp": "Użyj odczytu Modbus zamiast odpytywania HTTP",
-          "modbus_write": "Włącz zapis przez Modbus",
-          "modbus_scan_interval": "Interwał skanowania Modbus (sekundy)"
-        },
-        "data_description": {
-          "modbus_tcp": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: tutaj działa tylko odczyt przez Modbus; zapis/sterowanie nadal odbywa się przez HTTP API, chyba że zapis również jest włączony. Niektóre funkcje sterowania są zapisywane przez Modbus.",
-          "modbus_write": "Aktywując zapis przez Modbus, bierzesz pełną odpowiedzialność za wszelkie wartości zapisane przez interfejs. Producent nie ponosi odpowiedzialności za problemy spowodowane przez nieprawidłowe lub wykraczające poza zakres wartości, a takie działania mogą unieważnić gwarancję i/lub wpłynąć na żywotność i wydajność produktu.",
-          "modbus_scan_interval": "Jak często odpytywać pompę ciepła przez Modbus TCP. Niższe wartości dają prawie rzeczywistą dokładność przepływu i objętości. Minimum to 5 sekund. Domyślnie 15 sekund."
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "reconfigure_modbus": {
+        "title": "Local Modbus",
+        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         }
       }
     }
@@ -575,19 +603,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "Interwał skanowania HTTP (sekundy)",
-          "modbus_tcp": "Użyj odczytu Modbus zamiast odpytywania HTTP",
-          "modbus_host": "Host/IP Qvantum",
-          "modbus_write": "Włącz zapis przez Modbus",
-          "modbus_scan_interval": "Interwał skanowania Modbus (sekundy)"
+          "scan_interval": "HTTP scan interval (seconds)",
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Modbus scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus zapewnia dane w czasie niemal rzeczywistym, czytając bezpośrednio z urządzenia.\nModbus musi być włączony w ustawieniach instalatora w aplikacji/wyświetlaczu pompy przed włączeniem tutaj. Uwaga: tutaj działa tylko odczyt przez Modbus; zapis/sterowanie nadal odbywa się przez HTTP API, chyba że zapis również jest włączony. Niektóre funkcje sterowania są zapisywane przez Modbus.",
-          "modbus_write": "Aktywując zapis przez Modbus, bierzesz pełną odpowiedzialność za wszelkie wartości zapisane przez interfejs. Producent nie ponosi odpowiedzialności za problemy spowodowane przez nieprawidłowe lub wykraczające poza zakres wartości, a takie działania mogą unieważnić gwarancję i/lub wpłynąć na żywotność i wydajność produktu.",
-          "modbus_scan_interval": "Jak często odpytywać pompę ciepła przez Modbus TCP. Niższe wartości dają prawie rzeczywistą dokładność przepływu i objętości. Minimum to 5 sekund. Domyślnie 15 sekund."
+          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         },
-        "description": "Zmień swoje opcje.",
-        "title": "Opcje"
+        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
+        "title": "Options"
       }
     }
   },

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -533,71 +533,71 @@
     }
   },
   "config": {
-    "title": "Qvantum Heat pump",
+    "title": "Qvantum Frånluftsvärmepump",
     "abort": {
-      "already_configured": "Device is already configured",
-      "reconfigure_successful": "Reconfiguration successful"
+      "already_configured": "Enheten är redan konfigurerad",
+      "reconfigure_successful": "Omkonfiguration lyckades"
     },
     "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
+      "cannot_connect": "Kunde inte ansluta",
+      "invalid_auth": "Felaktig autentisiering",
+      "unknown": "Oväntat fel"
     },
     "step": {
       "user": {
-        "title": "Connection",
-        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "title": "Anslutning",
+        "description": "Välj hur Home Assistant kommunicerar med värmepumpen. Du kan byta senare via omkonfiguration.",
         "menu_options": {
-          "cloud": "Qvantum cloud (HTTP)",
-          "modbus": "Local Modbus (offline)"
+          "cloud": "Qvantum-moln (HTTP)",
+          "modbus": "Lokal Modbus (offline)"
         }
       },
       "cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
+        "title": "Qvantum-moln",
+        "description": "Logga in med ditt Qvantum-konto. Mätvärden och styrning använder moln-API:et.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Lösenord",
+          "username": "Användarnamn"
         }
       },
       "modbus": {
-        "title": "Local Modbus",
-        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "title": "Lokal Modbus",
+        "description": "Läser värmepumpen i ditt lokala nätverk. Ingen inloggning. Aktivera Modbus external i Qvantum-appen (Installatör → Serviceläge → Anslutning) först. Styrning är inte tillgänglig i detta läge.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Qvantum Host/IP",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "Enhets-ID",
+          "modbus_scan_interval": "Modbus-skanningsintervall (sekunder)"
         },
         "data_description": {
-          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
-          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_host": "Värdnamn eller IP-adress för värmepumpen. Standard är Qvantum-HP.",
+          "modbus_scan_interval": "Hur ofta enheten pollas via Modbus TCP. Minimum är 5 sekunder. Standard är 15 sekunder."
         }
       },
       "reconfigure": {
-        "title": "Reconfigure",
-        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "title": "Omkonfigurera",
+        "description": "Växla mellan moln-HTTP och lokal Modbus, eller uppdatera den aktuella anslutningen.",
         "menu_options": {
-          "reconfigure_cloud": "Qvantum cloud (HTTP)",
-          "reconfigure_modbus": "Local Modbus (offline)"
+          "reconfigure_cloud": "Qvantum-moln (HTTP)",
+          "reconfigure_modbus": "Lokal Modbus (offline)"
         }
       },
       "reconfigure_cloud": {
-        "title": "Qvantum cloud",
-        "description": "Sign in with your Qvantum account.",
+        "title": "Qvantum-moln",
+        "description": "Logga in med ditt Qvantum-konto.",
         "data": {
-          "password": "Password",
-          "username": "Username"
+          "password": "Lösenord",
+          "username": "Användarnamn"
         }
       },
       "reconfigure_modbus": {
-        "title": "Local Modbus",
-        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "title": "Lokal Modbus",
+        "description": "Aktivera Modbus external i Qvantum-appen först. Home Assistant läser serienummer och firmware från pumpen.",
         "data": {
-          "modbus_host": "Host / IP",
+          "modbus_host": "Qvantum Host/IP",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Scan interval (seconds)"
+          "modbus_unit_id": "Enhets-ID",
+          "modbus_scan_interval": "Modbus-skanningsintervall (sekunder)"
         }
       }
     }
@@ -606,17 +606,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP scan interval (seconds)",
-          "modbus_host": "Host / IP",
+          "scan_interval": "HTTP-skanningsintervall (sekunder)",
+          "modbus_host": "Qvantum Host/IP",
           "modbus_port": "Port",
-          "modbus_unit_id": "Unit ID",
-          "modbus_scan_interval": "Modbus scan interval (seconds)"
+          "modbus_unit_id": "Enhets-ID",
+          "modbus_scan_interval": "Modbus-skanningsintervall (sekunder)"
         },
         "data_description": {
-          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
+          "modbus_scan_interval": "Hur ofta värmepumpen pollas via Modbus TCP. Lägre värden ger nästan realtidsnoggrannhet för flöde och volym. Minimum är 5 sekunder. Standard är 15 sekunder."
         },
-        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
-        "title": "Options"
+        "description": "Inställningar för aktuellt anslutningsläge. Använd omkonfiguration för att växla mellan moln och Modbus.",
+        "title": "Alternativ"
       }
     }
   },

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -533,43 +533,71 @@
     }
   },
   "config": {
-    "title": "Qvantum Frånluftsvärmepump",
+    "title": "Qvantum Heat pump",
     "abort": {
-      "already_configured": "Enheten är redan konfigurerad",
-      "reconfigure_successful": "Omkonfiguration lyckades"
+      "already_configured": "Device is already configured",
+      "reconfigure_successful": "Reconfiguration successful"
     },
     "error": {
-      "cannot_connect": "Kunde inte ansluta",
-      "invalid_auth": "Felaktig autentisiering",
-      "unknown": "Oväntat fel"
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
     },
     "step": {
       "user": {
-        "description": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus; skrivning/kontroller sker fortfarande via HTTP API om inte skrivning också är aktiverad. Vissa kontroller skrivs via Modbus.",
+        "title": "Connection",
+        "description": "Choose how Home Assistant talks to the heat pump. You can switch later via reconfigure.",
+        "menu_options": {
+          "cloud": "Qvantum cloud (HTTP)",
+          "modbus": "Local Modbus (offline)"
+        }
+      },
+      "cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account. Metrics and controls use the cloud API.",
         "data": {
-          "password": "Lösenord",
-          "username": "Användarnamn",
-          "modbus_tcp": "Använd Modbus-avläsning istället för HTTP-förfrågning",
-          "modbus_write": "Aktivera skrivning via Modbus"
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "modbus": {
+        "title": "Local Modbus",
+        "description": "Reads the heat pump on your LAN. No login. Enable Modbus external in the Qvantum app (Installer → Service mode → Connectivity) first. Controls are unavailable in this mode.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus; skrivning/kontroller sker fortfarande via HTTP API om inte skrivning också är aktiverad. Vissa kontroller skrivs via Modbus.",
-          "modbus_write": "Genom att aktivera Modbus-skrivning tar du fullt ansvar för alla värden som skrivs via gränssnittet. Tillverkaren ansvarar inte för problem orsakade av felaktiga eller utanför intervallet liggande värden, och sådana åtgärder kan ogiltigförklara garantin och/eller påverka produktens livslängd och prestanda."
+          "modbus_host": "Hostname or IP of the heat pump. Default is Qvantum-HP.",
+          "modbus_scan_interval": "How often to poll over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         }
       },
       "reconfigure": {
-        "description": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus; skrivning/kontroller sker fortfarande via HTTP API om inte skrivning också är aktiverad. Vissa kontroller skrivs via Modbus.",
+        "title": "Reconfigure",
+        "description": "Switch between cloud HTTP and local Modbus, or update the current connection.",
+        "menu_options": {
+          "reconfigure_cloud": "Qvantum cloud (HTTP)",
+          "reconfigure_modbus": "Local Modbus (offline)"
+        }
+      },
+      "reconfigure_cloud": {
+        "title": "Qvantum cloud",
+        "description": "Sign in with your Qvantum account.",
         "data": {
-          "password": "Lösenord",
-          "username": "Användarnamn",
-          "modbus_tcp": "Använd Modbus-avläsning istället för HTTP-förfrågning",
-          "modbus_write": "Aktivera skrivning via Modbus",
-          "modbus_scan_interval": "Modbus-skanningsintervall (sekunder)"
-        },
-        "data_description": {
-          "modbus_tcp": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus; skrivning/kontroller sker fortfarande via HTTP API om inte skrivning också är aktiverad. Vissa kontroller skrivs via Modbus.",
-          "modbus_write": "Genom att aktivera Modbus-skrivning tar du fullt ansvar för alla värden som skrivs via gränssnittet. Tillverkaren ansvarar inte för problem orsakade av felaktiga eller utanför intervallet liggande värden, och sådana åtgärder kan ogiltigförklara garantin och/eller påverka produktens livslängd och prestanda.",
-          "modbus_scan_interval": "Hur ofta värmepumpen pollas via Modbus TCP. Lägre värden ger nästan realtidsnoggrannhet för flöde och volym. Minimum är 5 sekunder. Standard är 15 sekunder."
+          "password": "Password",
+          "username": "Username"
+        }
+      },
+      "reconfigure_modbus": {
+        "title": "Local Modbus",
+        "description": "Enable Modbus external in the Qvantum app first. Home Assistant will probe serial and firmware on the pump.",
+        "data": {
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Scan interval (seconds)"
         }
       }
     }
@@ -578,19 +606,17 @@
     "step": {
       "init": {
         "data": {
-          "scan_interval": "HTTP-skanningsintervall (sekunder)",
-          "modbus_tcp": "Använd Modbus-avläsning istället för HTTP-förfrågning",
-          "modbus_host": "Qvantum Host/IP",
-          "modbus_write": "Aktivera skrivning via Modbus",
-          "modbus_scan_interval": "Modbus-skanningsintervall (sekunder)"
+          "scan_interval": "HTTP scan interval (seconds)",
+          "modbus_host": "Host / IP",
+          "modbus_port": "Port",
+          "modbus_unit_id": "Unit ID",
+          "modbus_scan_interval": "Modbus scan interval (seconds)"
         },
         "data_description": {
-          "modbus_tcp": "Modbus ger nästan realtidsmetrik genom att läsa direkt från enheten.\nModbus måste vara aktiverat i installatörsinställningarna i pumpens app/display innan det kan aktiveras här. Observera att det bara läser via Modbus; skrivning/kontroller sker fortfarande via HTTP API om inte skrivning också är aktiverad. Vissa kontroller skrivs via Modbus.",
-          "modbus_write": "Genom att aktivera Modbus-skrivning tar du fullt ansvar för alla värden som skrivs via gränssnittet. Tillverkaren ansvarar inte för problem orsakade av felaktiga eller utanför intervallet liggande värden, och sådana åtgärder kan ogiltigförklara garantin och/eller påverka produktens livslängd och prestanda.",
-          "modbus_scan_interval": "Hur ofta värmepumpen pollas via Modbus TCP. Lägre värden ger nästan realtidsnoggrannhet för flöde och volym. Minimum är 5 sekunder. Standard är 15 sekunder."
+          "modbus_scan_interval": "How often to poll the heat pump over Modbus TCP. Minimum is 5 seconds. Default is 15 seconds."
         },
-        "description": "Ändra alternativ.",
-        "title": "Alternativ"
+        "description": "Settings for the current connection mode. Use reconfigure to switch between cloud and Modbus.",
+        "title": "Options"
       }
     }
   },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -234,6 +234,54 @@ class TestQvantumConfigFlow:
         assert created["options"]["modbus_scan_interval"] == 10
 
     @pytest.mark.asyncio
+    async def test_modbus_step_strips_host_whitespace(self, hass, config_flow):
+        """Padded or empty hosts should not be persisted as-is."""
+        from custom_components.qvantum.const import DEFAULT_MODBUS_HOST
+
+        with (
+            patch(
+                "custom_components.qvantum.config_flow.validate_modbus",
+                AsyncMock(
+                    return_value={
+                        "title": "Qvantum (12003)",
+                        "serial": "12003",
+                        "sw_version": "1.7.22",
+                    }
+                ),
+            ) as mock_validate,
+            patch.object(config_flow, "async_set_unique_id"),
+            patch.object(config_flow, "_abort_if_unique_id_configured"),
+            patch.object(config_flow, "async_create_entry") as mock_create_entry,
+        ):
+            mock_create_entry.return_value = {"type": "create_entry"}
+            result = await config_flow.async_step_modbus(
+                {
+                    "modbus_host": "  hp.local  ",
+                    "modbus_port": 502,
+                    "modbus_unit_id": 1,
+                    "modbus_scan_interval": 10,
+                }
+            )
+        assert result == {"type": "create_entry"}
+        assert mock_validate.await_args.args[1] == "hp.local"
+        created = mock_create_entry.call_args.kwargs
+        assert created["data"]["modbus_host"] == "hp.local"
+        assert created["options"]["modbus_host"] == "hp.local"
+
+        mock_create_entry.return_value = {"type": "create_entry"}
+        await config_flow.async_step_modbus(
+            {
+                "modbus_host": "   ",
+                "modbus_port": 502,
+                "modbus_unit_id": 1,
+                "modbus_scan_interval": 10,
+            }
+        )
+        assert mock_validate.await_args.args[1] == DEFAULT_MODBUS_HOST
+        created = mock_create_entry.call_args.kwargs
+        assert created["data"]["modbus_host"] == DEFAULT_MODBUS_HOST
+
+    @pytest.mark.asyncio
     async def test_modbus_step_cannot_connect(self, hass, config_flow):
         with patch(
             "custom_components.qvantum.config_flow.validate_modbus",
@@ -369,4 +417,17 @@ class TestQvantumOptionsFlow:
         assert data["modbus_host"] == "hp.local"
         assert data["modbus_scan_interval"] == MIN_MODBUS_SCAN_INTERVAL
         assert "scan_interval" not in data
+
+        mock_create_entry.reset_mock()
+        mock_create_entry.return_value = {"type": "create_entry"}
+        await flow.async_step_init(
+            {
+                "modbus_host": "  hp.local  ",
+                "modbus_port": 502,
+                "modbus_unit_id": 1,
+                "modbus_scan_interval": MIN_MODBUS_SCAN_INTERVAL,
+            }
+        )
+        data = mock_create_entry.call_args.kwargs["data"]
+        assert data["modbus_host"] == "hp.local"
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -288,10 +288,29 @@ class TestQvantumConfigFlow:
             AsyncMock(side_effect=CannotConnect()),
         ):
             result = await config_flow.async_step_modbus(
-                {"modbus_host": "bad-host"}
+                {
+                    "modbus_host": "bad-host",
+                    "modbus_port": 1502,
+                    "modbus_unit_id": 7,
+                    "modbus_scan_interval": 20,
+                }
             )
         assert result["type"] == "form"
         assert result["errors"]["base"] == "cannot_connect"
+        defaults = {
+            (key.schema if hasattr(key, "schema") else key): key.default
+            for key in result["data_schema"].schema
+            if hasattr(key, "default")
+        }
+
+        def _default(name):
+            value = defaults[name]
+            return value() if callable(value) else value
+
+        assert _default("modbus_host") == "bad-host"
+        assert _default("modbus_port") == 1502
+        assert _default("modbus_unit_id") == 7
+        assert _default("modbus_scan_interval") == 20
 
     @pytest.mark.asyncio
     async def test_reconfigure_shows_mode_menu(self, hass, config_flow):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -38,7 +38,7 @@ class TestValidateInput:
                 hass, {"username": "test@example.com", "password": "testpass"}
             )
 
-            assert result == {"title": "Qvantum QE-6 (12345)"}
+            assert result == {"title": "Qvantum QE-6 (12345)", "serial": "12345"}
             mock_api.authenticate.assert_called_once()
             mock_api.get_primary_device.assert_called_once()
             mock_api.close.assert_called_once()
@@ -101,50 +101,18 @@ class TestQvantumConfigFlow:
 
     def test_config_flow_version(self, config_flow):
         """Test that config flow has correct version."""
-        assert config_flow.VERSION == 7  # From const.py CONFIG_VERSION
+        assert config_flow.VERSION == 7
 
     @pytest.mark.asyncio
-    async def test_user_step_cannot_connect(self, hass, config_flow):
-        """Test user step when connection to the API cannot be established."""
-        # Mock the hass.config_entries.flow property
-        hass.config_entries = MagicMock()
-        hass.config_entries.flow = MagicMock()
-        hass.config_entries.flow.async_progress_by_handler = AsyncMock(return_value=[])
-
-        with patch("custom_components.qvantum.config_flow.validate_input") as mock_validate:
-            mock_validate.side_effect = CannotConnect()
-
-            result = await config_flow.async_step_user({
-                "username": "test@example.com",
-                "password": "testpass"
-            })
-
-            assert result["type"] == "form"
-            assert result["errors"]["base"] == "cannot_connect"
+    async def test_user_step_shows_mode_menu(self, hass, config_flow):
+        result = await config_flow.async_step_user()
+        assert result["type"] == "menu"
+        assert result["step_id"] == "user"
+        assert "cloud" in result["menu_options"]
+        assert "modbus" in result["menu_options"]
 
     @pytest.mark.asyncio
-    async def test_user_step_invalid_auth(self, hass, config_flow):
-        """Test user step with authentication error."""
-        # Mock the hass.config_entries.flow property
-        hass.config_entries = MagicMock()
-        hass.config_entries.flow = MagicMock()
-        hass.config_entries.flow.async_progress_by_handler = AsyncMock(return_value=[])
-
-        with patch("custom_components.qvantum.config_flow.validate_input") as mock_validate:
-            mock_validate.side_effect = InvalidAuth()
-
-            result = await config_flow.async_step_user({
-                "username": "test@example.com",
-                "password": "testpass"
-            })
-
-            assert result["type"] == "form"
-            assert result["errors"]["base"] == "invalid_auth"
-
-    @pytest.mark.asyncio
-    async def test_user_step_success(self, hass, config_flow):
-        """Test user step with successful validation."""
-        # Mock the hass.config_entries.flow property
+    async def test_cloud_step_success(self, hass, config_flow):
         hass.config_entries = MagicMock()
         hass.config_entries.flow = MagicMock()
         hass.config_entries.flow.async_progress_by_handler = AsyncMock(return_value=[])
@@ -154,587 +122,211 @@ class TestQvantumConfigFlow:
                 "custom_components.qvantum.config_flow.validate_input"
             ) as mock_validate,
             patch.object(config_flow, "async_set_unique_id") as mock_set_unique_id,
-            patch.object(config_flow, "_abort_if_unique_id_configured") as mock_abort,
+            patch.object(config_flow, "_abort_if_unique_id_configured"),
             patch.object(config_flow, "async_create_entry") as mock_create_entry,
         ):
-            mock_validate.return_value = {"title": "Test Device"}
+            mock_validate.return_value = {
+                "title": "Qvantum QE-6 (12345)",
+                "serial": "12345",
+            }
             mock_create_entry.return_value = {"type": "create_entry"}
 
-            result = await config_flow.async_step_user(
-                {
-                    "username": "test@example.com",
-                    "password": "testpass",
-                    "modbus_tcp": True,
-                }
-            )
-
-            assert result == {"type": "create_entry"}
-
-            mock_validate.assert_called_once_with(
-                hass,
-                {
-                    "username": "test@example.com",
-                    "password": "testpass",
-                    "modbus_tcp": True,
-                },
-            )
-            mock_set_unique_id.assert_called_once_with("Test Device")
-            mock_abort.assert_called_once()
-            mock_create_entry.assert_called_once_with(
-                title="Test Device",
-                data={
-                    "username": "test@example.com",
-                    "password": "testpass",
-                    "modbus_tcp": True,
-                    "modbus_write": False,
-                },
-                options={
-                    "modbus_tcp": True,
-                    "modbus_write": False,
-                },
-            )
-
-    @pytest.mark.asyncio
-    async def test_user_step_normalizes_modbus_write_without_tcp(
-        self, hass, config_flow
-    ):
-        """Test user step coerces modbus_write to false when modbus_tcp is disabled."""
-        hass.config_entries = MagicMock()
-        hass.config_entries.flow = MagicMock()
-        hass.config_entries.flow.async_progress_by_handler = AsyncMock(return_value=[])
-
-        with (
-            patch(
-                "custom_components.qvantum.config_flow.validate_input"
-            ) as mock_validate,
-            patch.object(config_flow, "async_set_unique_id") as mock_set_unique_id,
-            patch.object(config_flow, "_abort_if_unique_id_configured") as mock_abort,
-            patch.object(config_flow, "async_create_entry") as mock_create_entry,
-        ):
-            mock_validate.return_value = {"title": "Test Device"}
-            mock_create_entry.return_value = {"type": "create_entry"}
-
-            result = await config_flow.async_step_user(
-                {
-                    "username": "test@example.com",
-                    "password": "testpass",
-                    "modbus_tcp": False,
-                    "modbus_write": True,
-                }
-            )
-
-            assert result == {"type": "create_entry"}
-            mock_set_unique_id.assert_called_once_with("Test Device")
-            mock_abort.assert_called_once()
-            mock_create_entry.assert_called_once_with(
-                title="Test Device",
-                data={
-                    "username": "test@example.com",
-                    "password": "testpass",
-                    "modbus_tcp": False,
-                    "modbus_write": False,
-                },
-                options={
-                    "modbus_tcp": False,
-                    "modbus_write": False,
-                },
-            )
-
-    @pytest.mark.asyncio
-    async def test_user_step_unknown_error(self, hass, config_flow):
-        """Test user step with unknown error."""
-        # Mock the hass.config_entries.flow property
-        hass.config_entries = MagicMock()
-        hass.config_entries.flow = MagicMock()
-        hass.config_entries.flow.async_progress_by_handler = AsyncMock(return_value=[])
-
-        with patch(
-            "custom_components.qvantum.config_flow.validate_input"
-        ) as mock_validate:
-            mock_validate.side_effect = Exception("Unknown error")
-
-            result = await config_flow.async_step_user(
+            result = await config_flow.async_step_cloud(
                 {"username": "test@example.com", "password": "testpass"}
             )
 
-            assert result["type"] == "form"
-            assert result["errors"]["base"] == "unknown"
+            assert result == {"type": "create_entry"}
+            mock_set_unique_id.assert_called_once_with("12345")
+            mock_create_entry.assert_called_once_with(
+                title="Qvantum QE-6 (12345)",
+                data={
+                    "username": "test@example.com",
+                    "password": "testpass",
+                    "modbus_tcp": False,
+                    "modbus_write": False,
+                },
+                options={"modbus_tcp": False, "modbus_write": False},
+            )
 
     @pytest.mark.asyncio
-    async def test_user_step_initial_form(self, hass, config_flow):
-        """Test user step showing initial form."""
-        # Mock the hass.config_entries.flow property
-        hass.config_entries = MagicMock()
-        hass.config_entries.flow = MagicMock()
-        hass.config_entries.flow.async_progress_by_handler = AsyncMock(return_value=[])
-
-        result = await config_flow.async_step_user()
-
+    async def test_cloud_step_invalid_auth(self, hass, config_flow):
+        with patch(
+            "custom_components.qvantum.config_flow.validate_input"
+        ) as mock_validate:
+            mock_validate.side_effect = InvalidAuth()
+            result = await config_flow.async_step_cloud(
+                {"username": "test@example.com", "password": "bad"}
+            )
         assert result["type"] == "form"
-        assert result["step_id"] == "user"
-        assert "errors" in result
+        assert result["errors"]["base"] == "invalid_auth"
 
     @pytest.mark.asyncio
-    async def test_step_reconfigure_success(self, hass, config_flow):
-        """Test reconfigure step with successful validation."""
-        # Mock config entry
+    async def test_modbus_step_success(self, hass, config_flow):
+        with (
+            patch(
+                "custom_components.qvantum.config_flow.validate_modbus",
+                AsyncMock(
+                    return_value={
+                        "title": "Qvantum (12003)",
+                        "serial": "12003",
+                        "sw_version": "1.7.22",
+                    }
+                ),
+            ),
+            patch.object(config_flow, "async_set_unique_id") as mock_set_unique_id,
+            patch.object(config_flow, "_abort_if_unique_id_configured"),
+            patch.object(config_flow, "async_create_entry") as mock_create_entry,
+        ):
+            mock_create_entry.return_value = {"type": "create_entry"}
+            result = await config_flow.async_step_modbus(
+                {
+                    "modbus_host": "Qvantum-HP",
+                    "modbus_port": 502,
+                    "modbus_unit_id": 1,
+                    "modbus_scan_interval": 10,
+                }
+            )
+        assert result == {"type": "create_entry"}
+        mock_set_unique_id.assert_called_once_with("12003")
+        created = mock_create_entry.call_args.kwargs
+        assert created["data"]["modbus_tcp"] is True
+        assert "username" not in created["data"]
+        assert created["options"]["modbus_scan_interval"] == 10
+
+    @pytest.mark.asyncio
+    async def test_modbus_step_cannot_connect(self, hass, config_flow):
+        with patch(
+            "custom_components.qvantum.config_flow.validate_modbus",
+            AsyncMock(side_effect=CannotConnect()),
+        ):
+            result = await config_flow.async_step_modbus(
+                {"modbus_host": "bad-host"}
+            )
+        assert result["type"] == "form"
+        assert result["errors"]["base"] == "cannot_connect"
+
+    @pytest.mark.asyncio
+    async def test_reconfigure_shows_mode_menu(self, hass, config_flow):
+        result = await config_flow.async_step_reconfigure()
+        assert result["type"] == "menu"
+        assert "reconfigure_cloud" in result["menu_options"]
+        assert "reconfigure_modbus" in result["menu_options"]
+
+    @pytest.mark.asyncio
+    async def test_reconfigure_cloud_success(self, hass, config_flow):
         config_entry = MagicMock()
         config_entry.data = {"username": "old@example.com", "password": "oldpass"}
         config_entry.options = {}
         config_entry.unique_id = "test_unique_id"
-
         hass.config_entries = MagicMock()
         hass.config_entries.async_get_entry.return_value = config_entry
-
         config_flow.context = {"entry_id": "test_entry_id"}
 
         with (
             patch(
-                "custom_components.qvantum.config_flow.validate_input"
-            ) as mock_validate,
+                "custom_components.qvantum.config_flow.validate_input",
+                AsyncMock(return_value={"title": "Updated", "serial": "12345"}),
+            ),
             patch.object(
                 config_flow, "async_update_reload_and_abort"
-            ) as mock_update_reload,
+            ) as mock_update,
         ):
-            mock_validate.return_value = {"title": "Updated Device"}
-            mock_update_reload.return_value = {"type": "abort"}
-
-            result = await config_flow.async_step_reconfigure(
+            mock_update.return_value = {"type": "abort"}
+            result = await config_flow.async_step_reconfigure_cloud(
                 {"username": "new@example.com", "password": "newpass"}
             )
-
-            assert result == {"type": "abort"}
-
-            mock_validate.assert_called_once_with(
-                hass, {"username": "new@example.com", "password": "newpass"}
-            )
-            mock_update_reload.assert_called_once_with(
-                config_entry,
-                unique_id="test_unique_id",
-                data={
-                    "username": "new@example.com",
-                    "password": "newpass",
-                    "modbus_tcp": False,
-                    "modbus_write": False,
-                },
-                options={
-                    "modbus_tcp": False,
-                    "modbus_write": False,
-                    "modbus_scan_interval": DEFAULT_MODBUS_SCAN_INTERVAL,
-                },
-                reason="reconfigure_successful",
-            )
+        assert result == {"type": "abort"}
+        assert mock_update.call_args.kwargs["data"]["modbus_tcp"] is False
 
     @pytest.mark.asyncio
-    async def test_step_reconfigure_cannot_connect(self, hass, config_flow):
-        """Test reconfigure step with connection error."""
-        # Mock config entry
+    async def test_reconfigure_modbus_success(self, hass, config_flow):
         config_entry = MagicMock()
-        config_entry.data = {"username": "old@example.com", "password": "oldpass"}
-
-        hass.config_entries = MagicMock()
-        hass.config_entries.async_get_entry.return_value = config_entry
-
-        config_flow.context = {"entry_id": "test_entry_id"}
-
-        with patch(
-            "custom_components.qvantum.config_flow.validate_input"
-        ) as mock_validate:
-            mock_validate.side_effect = CannotConnect()
-
-            result = await config_flow.async_step_reconfigure(
-                {"username": "new@example.com", "password": "newpass"}
-            )
-
-            assert result["type"] == "form"
-            assert result["errors"]["base"] == "cannot_connect"
-
-    @pytest.mark.asyncio
-    async def test_step_reconfigure_initial_form(self, hass, config_flow):
-        """Test reconfigure step showing initial form."""
-        # Mock config entry
-        config_entry = MagicMock()
-        config_entry.data = {"username": "old@example.com", "password": "oldpass"}
-
-        hass.config_entries = MagicMock()
-        hass.config_entries.async_get_entry.return_value = config_entry
-
-        config_flow.context = {"entry_id": "test_entry_id"}
-
-        result = await config_flow.async_step_reconfigure()
-
-        assert result["type"] == "form"
-        assert result["step_id"] == "reconfigure"
-        assert "data_schema" in result
-
-    @pytest.mark.asyncio
-    async def test_step_reconfigure_sets_modbus_tcp(self, hass, config_flow):
-        """Test reconfigure updates modbus_tcp in config data and triggers reload."""
-        config_entry = MagicMock()
-        config_entry.data = {"username": "old@example.com", "password": "oldpass"}
-        config_entry.options = {"modbus_tcp": False}
-
-        hass.config_entries = MagicMock()
-        hass.config_entries.async_get_entry.return_value = config_entry
-
-        config_flow.context = {"entry_id": "test_entry_id"}
-
-        with (
-            patch(
-                "custom_components.qvantum.config_flow.validate_input"
-            ) as mock_validate,
-            patch.object(
-                config_flow, "async_update_reload_and_abort"
-            ) as mock_update_reload,
-        ):
-            user_input = {
-                "username": "new@example.com",
-                "password": "newpass",
-                "modbus_tcp": True,
-            }
-            mock_validate.return_value = None
-            mock_update_reload.return_value = {"type": "abort"}
-
-            result = await config_flow.async_step_reconfigure(user_input)
-
-            assert result == {"type": "abort"}
-            mock_update_reload.assert_called_once()
-            assert mock_update_reload.call_args.kwargs["data"]["modbus_tcp"] is True
-            assert mock_update_reload.call_args.kwargs["options"]["modbus_tcp"] is True
-
-    @pytest.mark.asyncio
-    async def test_step_reconfigure_normalizes_modbus_write_without_tcp(
-        self, hass, config_flow
-    ):
-        """Test reconfigure coerces modbus_write to false when modbus_tcp is disabled."""
-        config_entry = MagicMock()
-        config_entry.data = {"username": "old@example.com", "password": "oldpass"}
-        config_entry.options = {"modbus_tcp": True, "modbus_write": True}
+        config_entry.data = {}
+        config_entry.options = {}
         config_entry.unique_id = "test_unique_id"
-
         hass.config_entries = MagicMock()
         hass.config_entries.async_get_entry.return_value = config_entry
-
         config_flow.context = {"entry_id": "test_entry_id"}
 
         with (
             patch(
-                "custom_components.qvantum.config_flow.validate_input"
-            ) as mock_validate,
+                "custom_components.qvantum.config_flow.validate_modbus",
+                AsyncMock(return_value={"title": "Qvantum (1)", "serial": "1"}),
+            ),
             patch.object(
                 config_flow, "async_update_reload_and_abort"
-            ) as mock_update_reload,
+            ) as mock_update,
         ):
-            mock_validate.return_value = None
-            mock_update_reload.return_value = {"type": "abort"}
-
-            result = await config_flow.async_step_reconfigure(
+            mock_update.return_value = {"type": "abort"}
+            result = await config_flow.async_step_reconfigure_modbus(
                 {
-                    "username": "new@example.com",
-                    "password": "newpass",
-                    "modbus_tcp": False,
-                    "modbus_write": True,
-                }
-            )
-
-            assert result == {"type": "abort"}
-            mock_update_reload.assert_called_once()
-            assert mock_update_reload.call_args.kwargs["data"]["modbus_tcp"] is False
-            assert mock_update_reload.call_args.kwargs["data"]["modbus_write"] is False
-            assert mock_update_reload.call_args.kwargs["options"]["modbus_tcp"] is False
-            assert (
-                mock_update_reload.call_args.kwargs["options"]["modbus_write"] is False
-            )
-
-    @pytest.mark.asyncio
-    async def test_step_reconfigure_sets_modbus_scan_interval(self, hass, config_flow):
-        """Test reconfigure stores a custom Modbus poll interval in options."""
-        config_entry = MagicMock()
-        config_entry.data = {"username": "old@example.com", "password": "oldpass"}
-        config_entry.options = {"modbus_tcp": True, "modbus_scan_interval": 15}
-        config_entry.unique_id = "test_unique_id"
-
-        hass.config_entries = MagicMock()
-        hass.config_entries.async_get_entry.return_value = config_entry
-
-        config_flow.context = {"entry_id": "test_entry_id"}
-
-        with (
-            patch(
-                "custom_components.qvantum.config_flow.validate_input"
-            ) as mock_validate,
-            patch.object(
-                config_flow, "async_update_reload_and_abort"
-            ) as mock_update_reload,
-        ):
-            mock_validate.return_value = None
-            mock_update_reload.return_value = {"type": "abort"}
-
-            result = await config_flow.async_step_reconfigure(
-                {
-                    "username": "new@example.com",
-                    "password": "newpass",
-                    "modbus_tcp": True,
-                    "modbus_write": False,
-                    "modbus_scan_interval": MIN_MODBUS_SCAN_INTERVAL,
-                }
-            )
-
-            assert result == {"type": "abort"}
-            mock_update_reload.assert_called_once()
-            assert (
-                mock_update_reload.call_args.kwargs["options"]["modbus_scan_interval"]
-                == MIN_MODBUS_SCAN_INTERVAL
-            )
-            assert mock_update_reload.call_args.kwargs["options"]["modbus_tcp"] is True
-
-    @pytest.mark.asyncio
-    async def test_step_reconfigure_normalizes_invalid_modbus_scan_interval(
-        self, hass, config_flow
-    ):
-        """Test reconfigure coerces invalid Modbus intervals to a valid int."""
-        config_entry = MagicMock()
-        config_entry.data = {"username": "old@example.com", "password": "oldpass"}
-        config_entry.options = {
-            "modbus_tcp": True,
-            "modbus_scan_interval": "not-a-number",
-        }
-        config_entry.unique_id = "test_unique_id"
-
-        hass.config_entries = MagicMock()
-        hass.config_entries.async_get_entry.return_value = config_entry
-
-        config_flow.context = {"entry_id": "test_entry_id"}
-
-        with (
-            patch(
-                "custom_components.qvantum.config_flow.validate_input"
-            ) as mock_validate,
-            patch.object(
-                config_flow, "async_update_reload_and_abort"
-            ) as mock_update_reload,
-        ):
-            mock_validate.return_value = None
-            mock_update_reload.return_value = {"type": "abort"}
-
-            # Missing field falls back to stored invalid value, then normalizes.
-            result = await config_flow.async_step_reconfigure(
-                {
-                    "username": "new@example.com",
-                    "password": "newpass",
-                    "modbus_tcp": True,
-                    "modbus_write": False,
-                }
-            )
-
-            assert result == {"type": "abort"}
-            assert (
-                mock_update_reload.call_args.kwargs["options"]["modbus_scan_interval"]
-                == DEFAULT_MODBUS_SCAN_INTERVAL
-            )
-
-            mock_update_reload.reset_mock()
-            result = await config_flow.async_step_reconfigure(
-                {
-                    "username": "new@example.com",
-                    "password": "newpass",
-                    "modbus_tcp": True,
-                    "modbus_write": False,
-                    "modbus_scan_interval": "3",
-                }
-            )
-
-            assert result == {"type": "abort"}
-            assert (
-                mock_update_reload.call_args.kwargs["options"]["modbus_scan_interval"]
-                == MIN_MODBUS_SCAN_INTERVAL
-            )
-
-    @pytest.mark.asyncio
-    async def test_options_flow_init_success(self, hass):
-        """Test options flow init step with successful update."""
-        from custom_components.qvantum.config_flow import QvantumOptionsFlowHandler
-        from homeassistant.config_entries import ConfigEntry
-
-        config_entry = ConfigEntry(
-            version=1,
-            minor_version=1,
-            domain="qvantum",
-            title="Test",
-            data={},
-            options={"scan_interval": 120},
-            source="user",
-            unique_id="test_unique_id",
-            discovery_keys={},
-            subentries_data={},
-        )
-
-        flow = QvantumOptionsFlowHandler(config_entry)
-
-        with patch.object(flow, "async_create_entry") as mock_create_entry:
-            mock_create_entry.return_value = {"type": "create_entry"}
-
-            result = await flow.async_step_init({"scan_interval": 300})
-
-            assert result == {"type": "create_entry"}
-
-            mock_create_entry.assert_called_once_with(
-                title="", data={"scan_interval": 300}
-            )
-
-    @pytest.mark.asyncio
-    async def test_options_flow_init_initial_form(self, hass):
-        """Test options flow init step showing initial form."""
-        from custom_components.qvantum.config_flow import QvantumOptionsFlowHandler
-        from homeassistant.config_entries import ConfigEntry
-
-        config_entry = ConfigEntry(
-            version=1,
-            minor_version=1,
-            domain="qvantum",
-            title="Test",
-            data={},
-            options={"scan_interval": 120},
-            source="user",
-            unique_id="test_unique_id",
-            discovery_keys={},
-            subentries_data={},
-        )
-
-        flow = QvantumOptionsFlowHandler(config_entry)
-
-        result = await flow.async_step_init()
-
-        assert result["type"] == "form"
-        assert result["step_id"] == "init"
-        assert "data_schema" in result
-
-    @pytest.mark.asyncio
-    async def test_options_flow_init_normalizes_modbus_write_without_tcp(self, hass):
-        """Test options flow coerces modbus_write to false when modbus_tcp is disabled."""
-        from custom_components.qvantum.config_flow import QvantumOptionsFlowHandler
-        from homeassistant.config_entries import ConfigEntry
-
-        config_entry = ConfigEntry(
-            version=1,
-            minor_version=1,
-            domain="qvantum",
-            title="Test",
-            data={},
-            options={"scan_interval": 120},
-            source="user",
-            unique_id="test_unique_id",
-            discovery_keys={},
-            subentries_data={},
-        )
-
-        flow = QvantumOptionsFlowHandler(config_entry)
-
-        with patch.object(flow, "async_create_entry") as mock_create_entry:
-            mock_create_entry.return_value = {"type": "create_entry"}
-
-            result = await flow.async_step_init(
-                {
-                    "scan_interval": 300,
-                    "modbus_tcp": False,
-                    "modbus_write": True,
-                }
-            )
-
-            assert result == {"type": "create_entry"}
-            mock_create_entry.assert_called_once_with(
-                title="",
-                data={
-                    "scan_interval": 300,
-                    "modbus_tcp": False,
-                    "modbus_write": False,
-                },
-            )
-
-    @pytest.mark.asyncio
-    async def test_options_flow_sets_modbus_scan_interval(self, hass):
-        """Test options flow stores a custom Modbus poll interval."""
-        from custom_components.qvantum.config_flow import QvantumOptionsFlowHandler
-        from homeassistant.config_entries import ConfigEntry
-
-        config_entry = ConfigEntry(
-            version=1,
-            minor_version=1,
-            domain="qvantum",
-            title="Test",
-            data={},
-            options={"scan_interval": 120, "modbus_tcp": True},
-            source="user",
-            unique_id="test_unique_id",
-            discovery_keys={},
-            subentries_data={},
-        )
-
-        flow = QvantumOptionsFlowHandler(config_entry)
-
-        with patch.object(flow, "async_create_entry") as mock_create_entry:
-            mock_create_entry.return_value = {"type": "create_entry"}
-
-            result = await flow.async_step_init(
-                {
-                    "scan_interval": 120,
-                    "modbus_tcp": True,
-                    "modbus_write": False,
-                    "modbus_scan_interval": MIN_MODBUS_SCAN_INTERVAL,
-                }
-            )
-
-            assert result == {"type": "create_entry"}
-            mock_create_entry.assert_called_once_with(
-                title="",
-                data={
-                    "scan_interval": 120,
-                    "modbus_tcp": True,
-                    "modbus_write": False,
-                    "modbus_scan_interval": MIN_MODBUS_SCAN_INTERVAL,
-                },
-            )
-
-    @pytest.mark.asyncio
-    async def test_options_flow_normalizes_invalid_modbus_scan_interval(self, hass):
-        """Test options flow coerces invalid Modbus intervals before persisting."""
-        from custom_components.qvantum.config_flow import QvantumOptionsFlowHandler
-        from homeassistant.config_entries import ConfigEntry
-
-        config_entry = ConfigEntry(
-            version=1,
-            minor_version=1,
-            domain="qvantum",
-            title="Test",
-            data={},
-            options={"scan_interval": 120, "modbus_tcp": True},
-            source="user",
-            unique_id="test_unique_id",
-            discovery_keys={},
-            subentries_data={},
-        )
-
-        flow = QvantumOptionsFlowHandler(config_entry)
-
-        with patch.object(flow, "async_create_entry") as mock_create_entry:
-            mock_create_entry.return_value = {"type": "create_entry"}
-
-            result = await flow.async_step_init(
-                {
-                    "scan_interval": 120,
-                    "modbus_tcp": True,
-                    "modbus_write": False,
-                    "modbus_scan_interval": "2",
-                }
-            )
-
-            assert result == {"type": "create_entry"}
-            mock_create_entry.assert_called_once_with(
-                title="",
-                data={
-                    "scan_interval": 120,
-                    "modbus_tcp": True,
-                    "modbus_write": False,
+                    "modbus_host": "hp.local",
+                    "modbus_port": 502,
+                    "modbus_unit_id": 1,
                     "modbus_scan_interval": 5,
-                },
+                }
             )
+        assert result == {"type": "abort"}
+        assert mock_update.call_args.kwargs["data"]["modbus_tcp"] is True
+        assert mock_update.call_args.kwargs["options"]["modbus_host"] == "hp.local"
+
+
+class TestQvantumOptionsFlow:
+    """Options show only fields for the current connection mode."""
+
+    def _entry(self, **options):
+        from homeassistant.config_entries import ConfigEntry
+
+        return ConfigEntry(
+            version=1,
+            minor_version=1,
+            domain="qvantum",
+            title="Test",
+            data={},
+            options=options,
+            source="user",
+            unique_id="test_unique_id",
+            discovery_keys={},
+            subentries_data={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_cloud_options_update_scan_interval(self, hass):
+        from custom_components.qvantum.config_flow import QvantumOptionsFlowHandler
+
+        flow = QvantumOptionsFlowHandler(self._entry(scan_interval=120))
+        with patch.object(flow, "async_create_entry") as mock_create_entry:
+            mock_create_entry.return_value = {"type": "create_entry"}
+            result = await flow.async_step_init({"scan_interval": 300})
+        assert result == {"type": "create_entry"}
+        mock_create_entry.assert_called_once_with(
+            title="",
+            data={
+                "scan_interval": 300,
+                "modbus_tcp": False,
+                "modbus_write": False,
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_modbus_options_update_host_and_interval(self, hass):
+        from custom_components.qvantum.config_flow import QvantumOptionsFlowHandler
+
+        flow = QvantumOptionsFlowHandler(self._entry(modbus_tcp=True))
+        with patch.object(flow, "async_create_entry") as mock_create_entry:
+            mock_create_entry.return_value = {"type": "create_entry"}
+            result = await flow.async_step_init(
+                {
+                    "modbus_host": "hp.local",
+                    "modbus_port": 502,
+                    "modbus_unit_id": 1,
+                    "modbus_scan_interval": MIN_MODBUS_SCAN_INTERVAL,
+                }
+            )
+        assert result == {"type": "create_entry"}
+        data = mock_create_entry.call_args.kwargs["data"]
+        assert data["modbus_tcp"] is True
+        assert data["modbus_host"] == "hp.local"
+        assert data["modbus_scan_interval"] == MIN_MODBUS_SCAN_INTERVAL
+        assert "scan_interval" not in data or True
+

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -262,24 +262,24 @@ class TestQvantumConfigFlow:
                     "modbus_scan_interval": 10,
                 }
             )
-        assert result == {"type": "create_entry"}
-        assert mock_validate.await_args.args[1] == "hp.local"
-        created = mock_create_entry.call_args.kwargs
-        assert created["data"]["modbus_host"] == "hp.local"
-        assert created["options"]["modbus_host"] == "hp.local"
+            assert result == {"type": "create_entry"}
+            assert mock_validate.await_args.args[1] == "hp.local"
+            created = mock_create_entry.call_args.kwargs
+            assert created["data"]["modbus_host"] == "hp.local"
+            assert created["options"]["modbus_host"] == "hp.local"
 
-        mock_create_entry.return_value = {"type": "create_entry"}
-        await config_flow.async_step_modbus(
-            {
-                "modbus_host": "   ",
-                "modbus_port": 502,
-                "modbus_unit_id": 1,
-                "modbus_scan_interval": 10,
-            }
-        )
-        assert mock_validate.await_args.args[1] == DEFAULT_MODBUS_HOST
-        created = mock_create_entry.call_args.kwargs
-        assert created["data"]["modbus_host"] == DEFAULT_MODBUS_HOST
+            mock_create_entry.return_value = {"type": "create_entry"}
+            await config_flow.async_step_modbus(
+                {
+                    "modbus_host": "   ",
+                    "modbus_port": 502,
+                    "modbus_unit_id": 1,
+                    "modbus_scan_interval": 10,
+                }
+            )
+            assert mock_validate.await_args.args[1] == DEFAULT_MODBUS_HOST
+            created = mock_create_entry.call_args.kwargs
+            assert created["data"]["modbus_host"] == DEFAULT_MODBUS_HOST
 
     @pytest.mark.asyncio
     async def test_modbus_step_cannot_connect(self, hass, config_flow):
@@ -405,7 +405,7 @@ class TestQvantumOptionsFlow:
             mock_create_entry.return_value = {"type": "create_entry"}
             result = await flow.async_step_init(
                 {
-                    "modbus_host": "hp.local",
+                    "modbus_host": "  hp.local  ",
                     "modbus_port": 502,
                     "modbus_unit_id": 1,
                     "modbus_scan_interval": MIN_MODBUS_SCAN_INTERVAL,
@@ -417,17 +417,4 @@ class TestQvantumOptionsFlow:
         assert data["modbus_host"] == "hp.local"
         assert data["modbus_scan_interval"] == MIN_MODBUS_SCAN_INTERVAL
         assert "scan_interval" not in data
-
-        mock_create_entry.reset_mock()
-        mock_create_entry.return_value = {"type": "create_entry"}
-        await flow.async_step_init(
-            {
-                "modbus_host": "  hp.local  ",
-                "modbus_port": 502,
-                "modbus_unit_id": 1,
-                "modbus_scan_interval": MIN_MODBUS_SCAN_INTERVAL,
-            }
-        )
-        data = mock_create_entry.call_args.kwargs["data"]
-        assert data["modbus_host"] == "hp.local"
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -44,6 +44,46 @@ class TestValidateInput:
             mock_api.close.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_validate_input_omits_missing_serial_from_title(self, hass):
+        """Title should not include (None) when the device has no serial."""
+        with patch(
+            "custom_components.qvantum.config_flow.QvantumAPI"
+        ) as mock_api_class:
+            mock_api = MagicMock()
+            mock_api_class.return_value = mock_api
+            mock_api.authenticate = AsyncMock()
+            mock_api.get_primary_device = AsyncMock(
+                return_value={"vendor": "Qvantum", "model": "QE-6"}
+            )
+            mock_api.close = AsyncMock()
+
+            result = await validate_input(
+                hass, {"username": "test@example.com", "password": "testpass"}
+            )
+
+            assert result == {"title": "Qvantum QE-6", "serial": None}
+
+    @pytest.mark.asyncio
+    async def test_validate_input_defaults_vendor_model_without_serial(self, hass):
+        """Missing vendor/model/serial should fall back to a plain Qvantum title."""
+        with patch(
+            "custom_components.qvantum.config_flow.QvantumAPI"
+        ) as mock_api_class:
+            mock_api = MagicMock()
+            mock_api_class.return_value = mock_api
+            mock_api.authenticate = AsyncMock()
+            mock_api.get_primary_device = AsyncMock(
+                return_value={"vendor": None, "model": None, "serial": None}
+            )
+            mock_api.close = AsyncMock()
+
+            result = await validate_input(
+                hass, {"username": "test@example.com", "password": "testpass"}
+            )
+
+            assert result == {"title": "Qvantum", "serial": None}
+
+    @pytest.mark.asyncio
     async def test_validate_input_auth_error(self, hass):
         """Test validate_input with authentication error."""
         from custom_components.qvantum.api import APIAuthError
@@ -328,5 +368,5 @@ class TestQvantumOptionsFlow:
         assert data["modbus_tcp"] is True
         assert data["modbus_host"] == "hp.local"
         assert data["modbus_scan_interval"] == MIN_MODBUS_SCAN_INTERVAL
-        assert "scan_interval" not in data or True
+        assert "scan_interval" not in data
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -343,6 +343,7 @@ class TestQvantumConfigFlow:
                 {"username": "new@example.com", "password": "newpass"}
             )
         assert result == {"type": "abort"}
+        assert mock_update.call_args.kwargs["unique_id"] == "12345"
         assert mock_update.call_args.kwargs["data"]["modbus_tcp"] is False
 
     @pytest.mark.asyncio
@@ -374,6 +375,7 @@ class TestQvantumConfigFlow:
                 }
             )
         assert result == {"type": "abort"}
+        assert mock_update.call_args.kwargs["unique_id"] == "1"
         assert mock_update.call_args.kwargs["data"]["modbus_tcp"] is True
         assert mock_update.call_args.kwargs["options"]["modbus_host"] == "hp.local"
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -18,7 +18,6 @@ def test_danish_and_czech_translations_are_available():
             "smart_dhw_control_status": "Smart DHW-styringsstatus",
             "hp_status_name": "Varmepumpestatus",
             "hp_status_defrosting": "Afrimning",
-            "config_description": "Modbus giver dig næsten realtidsmålinger ved direkte læsning fra enheden.",
         },
         "cs": {
             "config_title": "Qvantum tepelné čerpadlo",
@@ -26,7 +25,6 @@ def test_danish_and_czech_translations_are_available():
             "smart_dhw_control_status": "Stav řízení Smart DHW",
             "hp_status_name": "Stav tepelného čerpadla",
             "hp_status_defrosting": "Odmrazování",
-            "config_description": "Modbus vám poskytne téměř okamžitá měření přímo čtením ze zařízení.",
         },
         "fi": {
             "config_title": "Qvantum lämpöpumppu",
@@ -34,7 +32,6 @@ def test_danish_and_czech_translations_are_available():
             "smart_dhw_control_status": "Älykkään käyttöveden ohjaustila",
             "hp_status_name": "Lämpöpumpun tila",
             "hp_status_defrosting": "Sulatus",
-            "config_description": "Modbus antaa sinulle lähes reaaliaikaisia mittauksia lukemalla laitetta suoraan.",
         },
     }
 
@@ -51,4 +48,5 @@ def test_danish_and_czech_translations_are_available():
         )
         assert data["entity"]["sensor"]["hp_status"]["name"] == expected["hp_status_name"]
         assert data["entity"]["sensor"]["hp_status"]["state"]["1"] == expected["hp_status_defrosting"]
-        assert expected["config_description"] in data["config"]["step"]["user"]["description"]
+        assert "cloud" in data["config"]["step"]["user"]["menu_options"]
+        assert "modbus" in data["config"]["step"]["user"]["menu_options"]

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -50,3 +50,21 @@ def test_danish_and_czech_translations_are_available():
         assert data["entity"]["sensor"]["hp_status"]["state"]["1"] == expected["hp_status_defrosting"]
         assert "cloud" in data["config"]["step"]["user"]["menu_options"]
         assert "modbus" in data["config"]["step"]["user"]["menu_options"]
+
+
+def test_config_flow_strings_are_localized():
+    """Non-English locales must keep localized config abort/error/title strings."""
+    en = json.loads((TRANSLATIONS_DIR / "en.json").read_text(encoding="utf-8"))
+    en_abort = en["config"]["abort"]["already_configured"]
+    en_error = en["config"]["error"]["cannot_connect"]
+    en_user_title = en["config"]["step"]["user"]["title"]
+
+    for path in sorted(TRANSLATIONS_DIR.glob("*.json")):
+        if path.name == "en.json":
+            continue
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["config"]["abort"]["already_configured"] != en_abort, path.name
+        assert data["config"]["error"]["cannot_connect"] != en_error, path.name
+        assert data["config"]["step"]["user"]["title"] != en_user_title, path.name
+        assert data["config"]["step"]["user"]["menu_options"]["cloud"]
+        assert data["config"]["step"]["user"]["menu_options"]["modbus"]


### PR DESCRIPTION
Add a connection menu for install, reconfigure, and options so the user picks one mode.

- Cloud still uses the account API.
- Modbus probes serial and firmware on the pump and stores no credentials.

Depends on the offline-runtime PR. This is 3/5 of the local-Modbus stack.