### PR TITLE
feat: Hide cloud-only controls and firmware sensors in Modbus mode

### DIFF
--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -92,30 +92,29 @@ def _modbus_link_settings(config_entry: ConfigEntry) -> tuple[bool, str, int, in
     return enabled, host, port, unit_id
 
 
+def _qvantum_entry_is_active(entry: ConfigEntry) -> bool:
+    """Return True for loaded or in-setup entries (tests may omit state)."""
+    state = getattr(entry, "state", None)
+    if isinstance(state, ConfigEntryState):
+        return state in (
+            ConfigEntryState.LOADED,
+            ConfigEntryState.SETUP_IN_PROGRESS,
+        )
+    return True
+
+
 def _qvantum_entries(hass: HomeAssistant) -> list[ConfigEntry]:
-    """Return loaded Qvantum config entries, or [] in incomplete tests."""
+    """Return active Qvantum config entries, or [] in incomplete tests."""
     config_entries = getattr(hass, "config_entries", None)
     if config_entries is None:
         return []
-    loaded_fn = getattr(config_entries, "async_loaded_entries", None)
-    if callable(loaded_fn):
-        try:
-            entries = loaded_fn(DOMAIN)
-        except TypeError:
-            entries = None
-        if isinstance(entries, (list, tuple)):
-            return list(entries)
     getter = getattr(config_entries, "async_entries", None)
     if getter is None:
         return []
     entries = getter(DOMAIN)
     if not isinstance(entries, (list, tuple)):
         return []
-    return [
-        entry
-        for entry in entries
-        if getattr(entry, "state", None) in (ConfigEntryState.LOADED, None)
-    ]
+    return [entry for entry in entries if _qvantum_entry_is_active(entry)]
 
 
 def _any_cloud_qvantum_entry(

--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -8,7 +8,7 @@ import inspect
 import logging
 import json
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import callback
 from homeassistant.const import MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION
@@ -94,13 +94,28 @@ def _modbus_link_settings(config_entry: ConfigEntry) -> tuple[bool, str, int, in
 
 def _qvantum_entries(hass: HomeAssistant) -> list[ConfigEntry]:
     """Return loaded Qvantum config entries, or [] in incomplete tests."""
-    getter = getattr(hass.config_entries, "async_entries", None)
+    config_entries = getattr(hass, "config_entries", None)
+    if config_entries is None:
+        return []
+    loaded_fn = getattr(config_entries, "async_loaded_entries", None)
+    if callable(loaded_fn):
+        try:
+            entries = loaded_fn(DOMAIN)
+        except TypeError:
+            entries = None
+        if isinstance(entries, (list, tuple)):
+            return list(entries)
+    getter = getattr(config_entries, "async_entries", None)
     if getter is None:
         return []
     entries = getter(DOMAIN)
-    if isinstance(entries, (list, tuple)):
-        return list(entries)
-    return []
+    if not isinstance(entries, (list, tuple)):
+        return []
+    return [
+        entry
+        for entry in entries
+        if getattr(entry, "state", None) in (ConfigEntryState.LOADED, None)
+    ]
 
 
 def _any_cloud_qvantum_entry(

--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -587,9 +587,10 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: MyConfigEntry) -
     unload_ok = await hass.config_entries.async_unload_platforms(
         config_entry, PLATFORMS
     )
-    await _async_sync_extra_hot_water_service(
-        hass, skip_entry_id=config_entry.entry_id
-    )
+    if unload_ok:
+        await _async_sync_extra_hot_water_service(
+            hass, skip_entry_id=config_entry.entry_id
+        )
 
     if hass.data.get(DOMAIN) is not None:
         try:

--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -92,6 +92,42 @@ def _modbus_link_settings(config_entry: ConfigEntry) -> tuple[bool, str, int, in
     return enabled, host, port, unit_id
 
 
+def _qvantum_entries(hass: HomeAssistant) -> list[ConfigEntry]:
+    """Return loaded Qvantum config entries, or [] in incomplete tests."""
+    getter = getattr(hass.config_entries, "async_entries", None)
+    if getter is None:
+        return []
+    entries = getter(DOMAIN)
+    if isinstance(entries, (list, tuple)):
+        return list(entries)
+    return []
+
+
+def _any_cloud_qvantum_entry(
+    hass: HomeAssistant, *, skip_entry_id: str | None = None
+) -> bool:
+    """Return True when any remaining Qvantum entry uses the cloud HTTP API."""
+    for entry in _qvantum_entries(hass):
+        if skip_entry_id and getattr(entry, "entry_id", None) == skip_entry_id:
+            continue
+        if not _modbus_link_settings(entry)[0]:
+            return True
+    return False
+
+
+async def _async_sync_extra_hot_water_service(
+    hass: HomeAssistant, *, skip_entry_id: str | None = None
+) -> None:
+    """Register extra_hot_water for cloud entries; remove it when none remain."""
+    registered = bool(hass.services.has_service(DOMAIN, "extra_hot_water"))
+    if _any_cloud_qvantum_entry(hass, skip_entry_id=skip_entry_id):
+        if not registered:
+            await async_setup_services(hass)
+        return
+    if registered:
+        hass.services.async_remove(DOMAIN, "extra_hot_water")
+
+
 def _async_modbus_unit(hass: HomeAssistant, config_entry: ConfigEntry):
     """Borrow a unit from the shared Home Assistant Modbus connection."""
     enabled, host, port, unit_id = _modbus_link_settings(config_entry)
@@ -219,9 +255,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) ->
         or _device_sw_version(device_metadata),
     )
 
-    # Only register the service if it hasn't been registered yet
-    if not modbus_enabled and not hass.services.has_service(DOMAIN, "extra_hot_water"):
-        await async_setup_services(hass)
+    await _async_sync_extra_hot_water_service(hass)
 
     # Initialize maintenance coordinator (handles firmware updates and maintenance tasks)
     maintenance_coordinator = QvantumMaintenanceCoordinator(
@@ -552,6 +586,9 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: MyConfigEntry) -
 
     unload_ok = await hass.config_entries.async_unload_platforms(
         config_entry, PLATFORMS
+    )
+    await _async_sync_extra_hot_water_service(
+        hass, skip_entry_id=config_entry.entry_id
     )
 
     if hass.data.get(DOMAIN) is not None:

--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -220,7 +220,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) ->
     )
 
     # Only register the service if it hasn't been registered yet
-    if not hass.services.has_service(DOMAIN, "extra_hot_water"):
+    if not modbus_enabled and not hass.services.has_service(DOMAIN, "extra_hot_water"):
         await async_setup_services(hass)
 
     # Initialize maintenance coordinator (handles firmware updates and maintenance tasks)

--- a/custom_components/qvantum/button.py
+++ b/custom_components/qvantum/button.py
@@ -66,6 +66,11 @@ class QvantumButtonEntity(QvantumEntity, ButtonEntity):
         """Handle the button press."""
         match self._metric_key:
             case "extra_tap_water_60min":
+                if getattr(self.coordinator, "modbus_enabled", False):
+                    _LOGGER.debug(
+                        "extra_tap_water_60min has no local write in this mode; ignoring press"
+                    )
+                    return
                 # Activate extra tap water for 60 minutes
                 response = await self.coordinator.api.set_extra_tap_water(
                     self._hpid, 60

--- a/custom_components/qvantum/button.py
+++ b/custom_components/qvantum/button.py
@@ -34,14 +34,20 @@ async def async_setup_entry(
 
     buttons = []
     buttons.append(QvantumButtonEntity(coordinator, "extra_tap_water_60min", device))
-
-    buttons.append(
-        QvantumButtonEntity(
-            coordinator, "elevate_access", device, maintenance_coordinator
+    button_keys = {"extra_tap_water_60min"}
+    if not coordinator.modbus_enabled:
+        buttons.append(
+            QvantumButtonEntity(
+                coordinator, "elevate_access", device, maintenance_coordinator
+            )
         )
-    )
+        button_keys.add("elevate_access")
 
     async_add_entities(buttons)
+
+    from .entity import cleanup_disabled_entities
+
+    cleanup_disabled_entities(hass, coordinator, button_keys, "button")
 
     _LOGGER.debug("Setting up platform BUTTON")
 

--- a/custom_components/qvantum/button.py
+++ b/custom_components/qvantum/button.py
@@ -95,8 +95,7 @@ class QvantumButtonEntity(QvantumEntity, ButtonEntity):
     def available(self):
         """Check if button is available."""
         if self._metric_key == "elevate_access":
-            # Elevate access button is always available
-            return True
+            return not getattr(self.coordinator, "modbus_enabled", False)
         else:
             # Other action buttons require write access
             return self._has_write_access

--- a/custom_components/qvantum/button.py
+++ b/custom_components/qvantum/button.py
@@ -77,6 +77,11 @@ class QvantumButtonEntity(QvantumEntity, ButtonEntity):
                     "Extra tap water activated for 60 minutes via button press"
                 )
             case "elevate_access":
+                if getattr(self.coordinator, "modbus_enabled", False):
+                    _LOGGER.debug(
+                        "elevate_access is cloud-only; ignoring press in Modbus mode"
+                    )
+                    return
                 # Elevate access level for the device
                 response = await self.coordinator.api.elevate_access(self._hpid)
 

--- a/custom_components/qvantum/entity.py
+++ b/custom_components/qvantum/entity.py
@@ -48,6 +48,8 @@ class QvantumAccessMixin:
         try:
             if not isinstance(self.coordinator, QvantumDataUpdateCoordinator):
                 return True  # Maintenance entities always available
+            if getattr(self.coordinator, "modbus_enabled", False):
+                return False
             maintenance_coordinator = (
                 self.coordinator.config_entry.runtime_data.maintenance_coordinator
             )

--- a/custom_components/qvantum/entity.py
+++ b/custom_components/qvantum/entity.py
@@ -44,7 +44,11 @@ class QvantumAccessMixin:
 
     @property
     def _has_write_access(self) -> bool:
-        """Check if the user has write access level >= 20."""
+        """Return whether this entity may write.
+
+        Cloud mode requires writeAccessLevel >= 20. Modbus mode has no local
+        writes in this phase, so access is denied.
+        """
         try:
             if not isinstance(self.coordinator, QvantumDataUpdateCoordinator):
                 return True  # Maintenance entities always available

--- a/custom_components/qvantum/sensor.py
+++ b/custom_components/qvantum/sensor.py
@@ -147,11 +147,18 @@ async def async_setup_entry(
 
     # Clean up disabled entities that are no longer supported in the current mode.
     # Include special sensor keys so they are never removed by cleanup.
-    special_sensor_keys = {
-        "totalenergy", "latency", "hpid", "tap_stop",
-        "expiresAt", "display_fw_version", "cc_fw_version",
-        "inv_fw_version", "firmware_last_check",
-    }
+    special_sensor_keys = {"totalenergy", "latency", "hpid"}
+    if not coordinator.modbus_enabled:
+        special_sensor_keys.update(
+            {
+                "tap_stop",
+                "expiresAt",
+                "display_fw_version",
+                "cc_fw_version",
+                "inv_fw_version",
+                "firmware_last_check",
+            }
+        )
     from .entity import cleanup_disabled_entities
 
     cleanup_disabled_entities(hass, coordinator, possible_metrics | special_sensor_keys, "sensor")

--- a/custom_components/qvantum/sensor.py
+++ b/custom_components/qvantum/sensor.py
@@ -109,31 +109,34 @@ async def async_setup_entry(
     sensors.append(QvantumTotalEnergyEntity(coordinator, "totalenergy", device, True))
     sensors.append(QvantumDiagnosticEntity(coordinator, "latency", device, True))
     sensors.append(QvantumDiagnosticEntity(coordinator, "hpid", device, True))
-    sensors.append(QvantumTimerEntity(coordinator, "tap_stop", device, True))
+    if not coordinator.modbus_enabled:
+        sensors.append(QvantumTimerEntity(coordinator, "tap_stop", device, True))
 
-    # Add maintenance sensors (firmware and access level)
-    maintenance_coordinator = config_entry.runtime_data.maintenance_coordinator
-    sensors.append(
-        QvantumAccessExpireEntity(maintenance_coordinator, "expiresAt", device, True)
-    )
-    sensors.append(
-        QvantumFirmwareSensorEntity(
-            maintenance_coordinator, "display_fw_version", device, True
+        # Cloud-only: firmware and access level from the HTTP API
+        maintenance_coordinator = config_entry.runtime_data.maintenance_coordinator
+        sensors.append(
+            QvantumAccessExpireEntity(maintenance_coordinator, "expiresAt", device, True)
         )
-    )
-    sensors.append(
-        QvantumFirmwareSensorEntity(maintenance_coordinator, "cc_fw_version", device, True)
-    )
-    sensors.append(
-        QvantumFirmwareSensorEntity(
-            maintenance_coordinator, "inv_fw_version", device, True
+        sensors.append(
+            QvantumFirmwareSensorEntity(
+                maintenance_coordinator, "display_fw_version", device, True
+            )
         )
-    )
-    sensors.append(
-        QvantumFirmwareLastCheckSensorEntity(
-            maintenance_coordinator, "firmware_last_check", device, True
+        sensors.append(
+            QvantumFirmwareSensorEntity(
+                maintenance_coordinator, "cc_fw_version", device, True
+            )
         )
-    )
+        sensors.append(
+            QvantumFirmwareSensorEntity(
+                maintenance_coordinator, "inv_fw_version", device, True
+            )
+        )
+        sensors.append(
+            QvantumFirmwareLastCheckSensorEntity(
+                maintenance_coordinator, "firmware_last_check", device, True
+            )
+        )
 
     async_add_entities(sensors)
 

--- a/tests/test_button_working.py
+++ b/tests/test_button_working.py
@@ -25,6 +25,7 @@ def mock_coordinator():
     coordinator.api = MagicMock()
     coordinator.api.set_extra_tap_water = AsyncMock(return_value={"status": "APPLIED"})
     coordinator.api.elevate_access = AsyncMock(return_value={"writeAccessLevel": 30})
+    coordinator.modbus_enabled = False
 
     # Mock config_entry and runtime_data for access level check
     config_entry = MagicMock()
@@ -150,6 +151,25 @@ class TestQvantumButtonEntity:
         assert "Failed to elevate access" in caplog.text
         # Verify maintenance coordinator is not refreshed on failure
         mock_maintenance_coordinator.async_refresh.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_press_elevate_access_noop_in_modbus_mode(
+        self, mock_coordinator, mock_device, mock_maintenance_coordinator
+    ):
+        """Service press of elevate_access must not call HTTP in Modbus mode."""
+        mock_coordinator.modbus_enabled = True
+        button = QvantumButtonEntity(
+            mock_coordinator,
+            "elevate_access",
+            mock_device,
+            mock_maintenance_coordinator,
+        )
+
+        await button.async_press()
+
+        mock_coordinator.api.elevate_access.assert_not_called()
+        mock_maintenance_coordinator.async_refresh.assert_not_called()
+        mock_coordinator.async_refresh.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_async_setup_entry(

--- a/tests/test_button_working.py
+++ b/tests/test_button_working.py
@@ -1,7 +1,7 @@
 """Tests for Qvantum button entities."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant.const import EntityCategory
 from homeassistant.helpers.device_registry import DeviceInfo
 
@@ -203,9 +203,11 @@ class TestQvantumButtonEntity:
 
         async_add_entities = MagicMock()
 
-        await async_setup_entry(hass, mock_config_entry, async_add_entities)
+        with patch(
+            "custom_components.qvantum.entity.cleanup_disabled_entities"
+        ) as cleanup:
+            await async_setup_entry(hass, mock_config_entry, async_add_entities)
 
-        # Check that entities were added
         assert async_add_entities.called
         entities = async_add_entities.call_args[0][0]
         assert len(entities) == 2
@@ -213,3 +215,38 @@ class TestQvantumButtonEntity:
         assert entities[0]._metric_key == "extra_tap_water_60min"
         assert isinstance(entities[1], QvantumButtonEntity)
         assert entities[1]._metric_key == "elevate_access"
+        assert cleanup.call_args.args[2] == {
+            "extra_tap_water_60min",
+            "elevate_access",
+        }
+        assert cleanup.call_args.args[3] == "button"
+
+    @pytest.mark.asyncio
+    async def test_async_setup_entry_modbus_omits_elevate_access(
+        self,
+        hass,
+        mock_config_entry,
+        mock_coordinator,
+        mock_device,
+        mock_maintenance_coordinator,
+    ):
+        """Elevate access is cloud-only and must not be created in Modbus mode."""
+        mock_coordinator.modbus_enabled = True
+        mock_config_entry.runtime_data = RuntimeData(
+            coordinator=mock_coordinator,
+            device=mock_device,
+            maintenance_coordinator=mock_maintenance_coordinator,
+        )
+        async_add_entities = MagicMock()
+
+        with patch(
+            "custom_components.qvantum.entity.cleanup_disabled_entities"
+        ) as cleanup:
+            await async_setup_entry(hass, mock_config_entry, async_add_entities)
+
+        entities = async_add_entities.call_args[0][0]
+        assert [entity._metric_key for entity in entities] == [
+            "extra_tap_water_60min"
+        ]
+        assert "elevate_access" not in cleanup.call_args.args[2]
+        assert cleanup.call_args.args[3] == "button"

--- a/tests/test_button_working.py
+++ b/tests/test_button_working.py
@@ -172,6 +172,20 @@ class TestQvantumButtonEntity:
         mock_coordinator.async_refresh.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_async_press_extra_tap_water_60min_noop_in_modbus_mode(
+        self, mock_coordinator, mock_device
+    ):
+        """Service press of extra_tap_water_60min must not call HTTP in Modbus mode."""
+        mock_coordinator.modbus_enabled = True
+        button = QvantumButtonEntity(
+            mock_coordinator, "extra_tap_water_60min", mock_device
+        )
+
+        await button.async_press()
+
+        mock_coordinator.api.set_extra_tap_water.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_async_setup_entry(
         self,
         hass,

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -65,7 +65,7 @@ def test_has_write_access_denies_http_only_entity_when_cloud_unavailable():
     assert entity._has_write_access is False
 
 
-def test_has_write_access_allows_modbus_metric_when_cloud_unavailable():
+def test_has_write_access_denies_modbus_metric_in_modbus_mode():
     """Holding-register writes are still gated off in Modbus mode for now."""
     from custom_components.qvantum.coordinator import QvantumDataUpdateCoordinator
     from custom_components.qvantum.const import CONF_MODBUS_TCP, CONF_MODBUS_WRITE

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -20,11 +20,12 @@ def test_has_write_access_maintenance_entity():
     assert entity._has_write_access is True
 
 
-def test_has_write_access_allows_modbus_write_when_cloud_unavailable():
-    """Local Modbus writes stay available when the HTTP API cannot be checked."""
+def test_has_write_access_denied_in_modbus_mode():
+    """Modbus mode has no writes in this phase, even if cloud access is missing."""
     from custom_components.qvantum.coordinator import QvantumDataUpdateCoordinator
 
     coordinator = QvantumDataUpdateCoordinator.__new__(QvantumDataUpdateCoordinator)
+    coordinator.modbus_enabled = True
     coordinator.config_entry = MagicMock()
     coordinator.config_entry.runtime_data = MagicMock()
     coordinator.config_entry.runtime_data.maintenance_coordinator = None
@@ -38,7 +39,7 @@ def test_has_write_access_allows_modbus_write_when_cloud_unavailable():
             return True
 
     entity = DummyModbusWriteEntity(coordinator)
-    assert entity._has_write_access is True
+    assert entity._has_write_access is False
 
 
 def test_has_write_access_denies_http_only_entity_when_cloud_unavailable():
@@ -65,7 +66,7 @@ def test_has_write_access_denies_http_only_entity_when_cloud_unavailable():
 
 
 def test_has_write_access_allows_modbus_metric_when_cloud_unavailable():
-    """Entities that write via holding registers stay available offline."""
+    """Holding-register writes are still gated off in Modbus mode for now."""
     from custom_components.qvantum.coordinator import QvantumDataUpdateCoordinator
     from custom_components.qvantum.const import CONF_MODBUS_TCP, CONF_MODBUS_WRITE
 
@@ -78,13 +79,14 @@ def test_has_write_access_allows_modbus_metric_when_cloud_unavailable():
     coordinator.config_entry.data = {}
     coordinator.config_entry.runtime_data = MagicMock()
     coordinator.config_entry.runtime_data.maintenance_coordinator = None
+    coordinator.modbus_enabled = True
 
     entity = QvantumEntity.__new__(QvantumEntity)
     entity.coordinator = coordinator
     entity._write_access_warning_logged = False
     entity._metric_key = "room_temp_external"
 
-    assert entity._has_write_access is True
+    assert entity._has_write_access is False
 
 
 def test_has_write_access_treats_empty_maintenance_data_as_outage():

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -57,6 +57,27 @@ class TestSetupDeviceRequirements:
         hass.services.async_remove.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_sync_extra_hot_water_registers_during_cloud_setup(self, hass):
+        """SETUP_IN_PROGRESS cloud entries must register extra_hot_water."""
+        from homeassistant.config_entries import ConfigEntryState
+
+        cloud = MagicMock()
+        cloud.entry_id = "cloud"
+        cloud.options = {}
+        cloud.data = {}
+        cloud.state = ConfigEntryState.SETUP_IN_PROGRESS
+        hass.config_entries.async_loaded_entries = MagicMock(return_value=[])
+        hass.config_entries.async_entries = MagicMock(return_value=[cloud])
+        hass.services.has_service = MagicMock(return_value=False)
+        hass.services.async_remove = MagicMock()
+        with patch(
+            "custom_components.qvantum.async_setup_services", new_callable=AsyncMock
+        ) as setup:
+            await _async_sync_extra_hot_water_service(hass)
+        setup.assert_awaited_once_with(hass)
+        hass.services.async_remove.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_sync_extra_hot_water_removes_when_only_modbus_remains(self, hass):
         modbus = MagicMock()
         modbus.entry_id = "modbus"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -47,6 +47,7 @@ class TestSetupDeviceRequirements:
         cloud.data = {}
         hass.config_entries.async_entries = MagicMock(return_value=[cloud])
         hass.services.has_service = MagicMock(return_value=False)
+        hass.services.async_remove = MagicMock()
         with patch(
             "custom_components.qvantum.async_setup_services", new_callable=AsyncMock
         ) as setup:
@@ -62,6 +63,7 @@ class TestSetupDeviceRequirements:
         modbus.data = {}
         hass.config_entries.async_entries = MagicMock(return_value=[modbus])
         hass.services.has_service = MagicMock(return_value=True)
+        hass.services.async_remove = MagicMock()
         with patch(
             "custom_components.qvantum.async_setup_services", new_callable=AsyncMock
         ) as setup:
@@ -222,6 +224,21 @@ class TestIntegrationSetup:
         assert result is True
         hass.config_entries.async_unload_platforms.assert_called_once()
         mock_api.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_unload_entry_skips_service_sync_when_unload_fails(
+        self, hass, mock_config_entry
+    ):
+        """Failed platform unload must not drop extra_hot_water."""
+        hass.config_entries.async_unload_platforms = AsyncMock(return_value=False)
+        mock_config_entry.runtime_data = None
+        with patch(
+            "custom_components.qvantum._async_sync_extra_hot_water_service",
+            new_callable=AsyncMock,
+        ) as sync:
+            result = await async_unload_entry(hass, mock_config_entry)
+        assert result is False
+        sync.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_async_unload_entry_shuts_down_coordinators_before_api_close(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -18,6 +18,7 @@ from custom_components.qvantum import (
     _has_required_device,
     _device_sw_version,
     _modbus_link_settings,
+    _async_sync_extra_hot_water_service,
 )
 
 # Mock HA imports after importing real functions
@@ -37,6 +38,36 @@ class TestSetupDeviceRequirements:
         }
         entry.data = {}
         assert _modbus_link_settings(entry) == (True, "hp.local", 1502, 7)
+
+    @pytest.mark.asyncio
+    async def test_sync_extra_hot_water_registers_for_cloud_entry(self, hass):
+        cloud = MagicMock()
+        cloud.entry_id = "cloud"
+        cloud.options = {}
+        cloud.data = {}
+        hass.config_entries.async_entries = MagicMock(return_value=[cloud])
+        hass.services.has_service = MagicMock(return_value=False)
+        with patch(
+            "custom_components.qvantum.async_setup_services", new_callable=AsyncMock
+        ) as setup:
+            await _async_sync_extra_hot_water_service(hass)
+        setup.assert_awaited_once_with(hass)
+        hass.services.async_remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sync_extra_hot_water_removes_when_only_modbus_remains(self, hass):
+        modbus = MagicMock()
+        modbus.entry_id = "modbus"
+        modbus.options = {"modbus_tcp": True}
+        modbus.data = {}
+        hass.config_entries.async_entries = MagicMock(return_value=[modbus])
+        hass.services.has_service = MagicMock(return_value=True)
+        with patch(
+            "custom_components.qvantum.async_setup_services", new_callable=AsyncMock
+        ) as setup:
+            await _async_sync_extra_hot_water_service(hass)
+        setup.assert_not_called()
+        hass.services.async_remove.assert_called_once_with("qvantum", "extra_hot_water")
 
     def test_async_modbus_unit_http_mode_skips_shared_connection(self, hass):
         entry = MagicMock()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -45,6 +45,7 @@ class TestSetupDeviceRequirements:
         cloud.entry_id = "cloud"
         cloud.options = {}
         cloud.data = {}
+        hass.config_entries.async_loaded_entries = MagicMock(return_value=[cloud])
         hass.config_entries.async_entries = MagicMock(return_value=[cloud])
         hass.services.has_service = MagicMock(return_value=False)
         hass.services.async_remove = MagicMock()
@@ -61,6 +62,7 @@ class TestSetupDeviceRequirements:
         modbus.entry_id = "modbus"
         modbus.options = {"modbus_tcp": True}
         modbus.data = {}
+        hass.config_entries.async_loaded_entries = MagicMock(return_value=[modbus])
         hass.config_entries.async_entries = MagicMock(return_value=[modbus])
         hass.services.has_service = MagicMock(return_value=True)
         hass.services.async_remove = MagicMock()
@@ -70,6 +72,27 @@ class TestSetupDeviceRequirements:
             await _async_sync_extra_hot_water_service(hass)
         setup.assert_not_called()
         hass.services.async_remove.assert_called_once_with("qvantum", "extra_hot_water")
+
+    @pytest.mark.asyncio
+    async def test_sync_extra_hot_water_ignores_unloaded_cloud_entry(self, hass):
+        """Disabled/unloaded cloud entries must not keep extra_hot_water registered."""
+        from homeassistant.config_entries import ConfigEntryState
+
+        cloud = MagicMock()
+        cloud.entry_id = "cloud"
+        cloud.options = {}
+        cloud.data = {}
+        cloud.state = ConfigEntryState.NOT_LOADED
+        hass.config_entries.async_loaded_entries = MagicMock(return_value=[])
+        hass.config_entries.async_entries = MagicMock(return_value=[cloud])
+        hass.services.has_service = MagicMock(return_value=False)
+        hass.services.async_remove = MagicMock()
+        with patch(
+            "custom_components.qvantum.async_setup_services", new_callable=AsyncMock
+        ) as setup:
+            await _async_sync_extra_hot_water_service(hass)
+        setup.assert_not_called()
+        hass.services.async_remove.assert_not_called()
 
     def test_async_modbus_unit_http_mode_skips_shared_connection(self, hass):
         entry = MagicMock()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -557,9 +557,12 @@ class TestSensorSetup:
         mock_config_entry.options = {CONF_MODBUS_TCP: True}
         mock_coordinator.modbus_enabled = True
 
-        with patch(
-            "custom_components.qvantum.entity.cleanup_disabled_entities"
-        ) as cleanup:
+        with (
+            patch("custom_components.qvantum.entity.disable_entities_by_default"),
+            patch(
+                "custom_components.qvantum.entity.cleanup_disabled_entities"
+            ) as cleanup,
+        ):
             await async_setup_entry(mock_hass, mock_config_entry, MagicMock())
 
         allowed = cleanup.call_args.args[2]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -74,6 +74,7 @@ def mock_coordinator():
             "tap_stop": 1712232000,
         },
     }
+    coordinator.modbus_enabled = False
     return coordinator
 
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -548,6 +548,29 @@ class TestSensorSetup:
         )
 
     @pytest.mark.asyncio
+    async def test_async_setup_entry_modbus_cleanup_drops_cloud_special_sensors(
+        self, mock_hass, mock_config_entry, mock_coordinator, mock_device
+    ):
+        """HTTP-only special sensors must not be kept when cleaning up Modbus mode."""
+        from custom_components.qvantum.const import CONF_MODBUS_TCP
+
+        mock_config_entry.options = {CONF_MODBUS_TCP: True}
+        mock_coordinator.modbus_enabled = True
+
+        with patch(
+            "custom_components.qvantum.entity.cleanup_disabled_entities"
+        ) as cleanup:
+            await async_setup_entry(mock_hass, mock_config_entry, MagicMock())
+
+        allowed = cleanup.call_args.args[2]
+        assert "totalenergy" in allowed
+        assert "latency" in allowed
+        assert "hpid" in allowed
+        assert "tap_stop" not in allowed
+        assert "expiresAt" not in allowed
+        assert "firmware_last_check" not in allowed
+
+    @pytest.mark.asyncio
     async def test_async_setup_entry_respects_user_enabled_entities(
         self, mock_hass, mock_config_entry, mock_coordinator, mock_device
     ):


### PR DESCRIPTION
Skip firmware/access/`tap_stop` sensors and the extra-hot-water service when running locally.

Write entities stay unavailable until the following write-support PR.

Depends on the setup-menu PR. This is 4/5 of the local-Modbus stack.