### PR TITLE
feat: Persist extra DHW restore timer across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Cloud-only sensors (firmware boards, access expiry, extra-DHW `tap_stop` countdo
 >
 > By enabling Modbus writing you accept full responsibility for values written to the pump. Incorrect or out-of-range values may void the warranty and/or affect lifecycle and performance.
 
-Extra DHW on local Modbus writes DHW mode Extra/Normal. A timed extra (button or `qvantum.extra_hot_water`) is restored by Home Assistant after the interval; it is **not** stored on the pump, so a restart during that window will not write Normal back.
+Extra DHW on local Modbus writes DHW mode Extra/Normal. Use the extra-DHW button (60 minutes) or `qvantum.extra_hot_water` with `minutes` (0–480). Home Assistant restores Normal when the timer ends, including after a restart. The extra-DHW timer entity (`tap_stop`) shows the end time. The extra switch without a duration stays Extra until you turn it off.
 
 Fan extra on local Modbus is a sticky preset. Cloud extra ventilation is a timed boost.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Reads the heat pump on your LAN. No login and no cloud session.
 2. Enter host (default `Qvantum-HP`), port, unit ID, and poll interval (default 15 seconds, minimum 5).
 3. Home Assistant probes serial and firmware from identity registers 180–193.
 
-Cloud-only sensors (firmware boards, access expiry, extra-DHW `tap_stop` countdown) are not created in this mode.
+Cloud-only sensors (firmware boards and access expiry) are not created in this mode. Extra-DHW `tap_stop` is created from the local restore deadline.
 
 ### Features
 

--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -237,6 +237,20 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) ->
         modbus_write=modbus_enabled and _modbus_write_enabled(config_entry),
     )
     hass.data[DOMAIN].hass = hass
+    if modbus_enabled:
+        config_dir = getattr(getattr(hass, "config", None), "config_dir", None)
+        if isinstance(config_dir, str):
+            from homeassistant.helpers.storage import Store
+
+            api = hass.data[DOMAIN]
+            api._extra_dhw_store = Store(
+                hass, 1, f"{DOMAIN}.extra_dhw.{config_entry.entry_id}"
+            )
+            restore = getattr(api, "async_restore_extra_dhw_timer", None)
+            if callable(restore):
+                restore_result = restore()
+                if inspect.isawaitable(restore_result):
+                    await restore_result
 
     coordinator = QvantumDataUpdateCoordinator(hass, config_entry)
     await coordinator.async_restore_dhw_state()
@@ -362,7 +376,7 @@ async def _async_update_listener(hass: HomeAssistant, config_entry: ConfigEntry)
         if getattr(api, "_modbus_write", False) and not write_enabled:
             cancel = getattr(api, "_cancel_extra_dhw_timer", None)
             if callable(cancel):
-                cancel()
+                cancel(clear_store=True)
         api._modbus_write = write_enabled
 
     changed = runtime.coordinator.apply_poll_interval(config_entry)

--- a/custom_components/qvantum/__init__.py
+++ b/custom_components/qvantum/__init__.py
@@ -238,8 +238,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: MyConfigEntry) ->
     )
     hass.data[DOMAIN].hass = hass
     if modbus_enabled:
-        config_dir = getattr(getattr(hass, "config", None), "config_dir", None)
-        if isinstance(config_dir, str):
+        if isinstance(getattr(getattr(hass, "config", None), "config_dir", None), str):
             from homeassistant.helpers.storage import Store
 
             api = hass.data[DOMAIN]

--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -389,10 +389,16 @@ class QvantumAPI:
         store = self._extra_dhw_store
         if store is None:
             return
-        if payload is None:
-            await store.async_remove()
-        else:
-            await store.async_save(payload)
+        try:
+            if payload is None:
+                await store.async_remove()
+            else:
+                await store.async_save(payload)
+        except Exception:
+            if payload is None:
+                _LOGGER.debug("Failed to clear extra DHW timer", exc_info=True)
+            else:
+                _LOGGER.debug("Failed to persist extra DHW timer", exc_info=True)
 
     def _persist_extra_dhw(self, payload: dict | None) -> None:
         """Fire-and-forget persist for sync callers (options listener)."""
@@ -419,7 +425,7 @@ class QvantumAPI:
         """Schedule restore at an absolute UTC epoch; persist when requested."""
         self._cancel_extra_dhw_timer(clear_store=False)
         remaining = restore_at - datetime.now(timezone.utc).timestamp()
-        if not self.hass or remaining <= 0:
+        if not self.hass:
             return
         self._extra_dhw_restore_at = restore_at
         if persist:
@@ -445,7 +451,8 @@ class QvantumAPI:
             except Exception:
                 _LOGGER.debug("Failed to clear extra DHW timer", exc_info=True)
 
-        self._extra_dhw_unsub = async_call_later(self.hass, remaining, _restore)
+        delay = max(remaining, 0)
+        self._extra_dhw_unsub = async_call_later(self.hass, delay, _restore)
 
     async def async_restore_extra_dhw_timer(self) -> None:
         """Resume a persisted extra-DHW restore after Home Assistant restart."""

--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -407,13 +407,11 @@ class QvantumAPI:
             return
         create_task = getattr(hass, "async_create_task", None)
         if callable(create_task):
+            coro = self.async_persist_extra_dhw(payload)
             try:
-                create_task(
-                    self.async_persist_extra_dhw(payload),
-                    name="qvantum_persist_extra_dhw",
-                )
+                create_task(coro, name="qvantum_persist_extra_dhw")
             except TypeError:
-                create_task(self.async_persist_extra_dhw(payload))
+                create_task(coro)
 
     async def _schedule_extra_dhw_restore(self, device_id: str, minutes: int) -> None:
         """After *minutes*, write DHW mode back to Normal."""

--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -2,7 +2,6 @@
 
 import aiohttp
 import asyncio
-import inspect
 import json
 from datetime import datetime, timedelta, timezone
 import logging
@@ -385,26 +384,36 @@ class QvantumAPI:
             self._extra_dhw_restore_at = None
             self._persist_extra_dhw(None)
 
-    def _persist_extra_dhw(self, payload: dict | None) -> None:
+    async def async_persist_extra_dhw(self, payload: dict | None) -> None:
         """Save or clear the extra-DHW restore deadline."""
         store = self._extra_dhw_store
-        hass = self.hass
-        if store is None or hass is None:
+        if store is None:
             return
-        result = store.async_remove() if payload is None else store.async_save(payload)
-        if inspect.isawaitable(result):
-            create_task = getattr(hass, "async_create_task", None)
-            if callable(create_task):
-                create_task(result)
+        if payload is None:
+            await store.async_remove()
+        else:
+            await store.async_save(payload)
 
-    def _schedule_extra_dhw_restore(self, device_id: str, minutes: int) -> None:
+    def _persist_extra_dhw(self, payload: dict | None) -> None:
+        """Fire-and-forget persist for sync callers (options listener)."""
+        hass = self.hass
+        if self._extra_dhw_store is None or hass is None:
+            return
+        create_task = getattr(hass, "async_create_task", None)
+        if callable(create_task):
+            create_task(
+                self.async_persist_extra_dhw(payload),
+                name="qvantum_persist_extra_dhw",
+            )
+
+    async def _schedule_extra_dhw_restore(self, device_id: str, minutes: int) -> None:
         """After *minutes*, write DHW mode back to Normal."""
         if minutes <= 0:
             return
         restore_at = datetime.now(timezone.utc).timestamp() + minutes * 60
-        self._schedule_extra_dhw_at(device_id, restore_at, persist=True)
+        await self._schedule_extra_dhw_at(device_id, restore_at, persist=True)
 
-    def _schedule_extra_dhw_at(
+    async def _schedule_extra_dhw_at(
         self, device_id: str, restore_at: float, *, persist: bool
     ) -> None:
         """Schedule restore at an absolute UTC epoch; persist when requested."""
@@ -414,15 +423,13 @@ class QvantumAPI:
             return
         self._extra_dhw_restore_at = restore_at
         if persist:
-            self._persist_extra_dhw(
+            await self.async_persist_extra_dhw(
                 {"device_id": str(device_id), "restore_at": restore_at}
             )
         from homeassistant.helpers.event import async_call_later
 
         async def _restore(_now) -> None:
             self._extra_dhw_unsub = None
-            self._extra_dhw_restore_at = None
-            self._persist_extra_dhw(None)
             try:
                 await self.write_holding_register_for_metric(
                     device_id, "extra_tap_water", DHW_MODE_NORMAL
@@ -431,6 +438,12 @@ class QvantumAPI:
                 _LOGGER.warning(
                     "Failed to restore DHW mode after extra hot water timer: %s", err
                 )
+                return
+            self._extra_dhw_restore_at = None
+            try:
+                await self.async_persist_extra_dhw(None)
+            except Exception:
+                _LOGGER.debug("Failed to clear extra DHW timer", exc_info=True)
 
         self._extra_dhw_unsub = async_call_later(self.hass, remaining, _restore)
 
@@ -454,11 +467,7 @@ class QvantumAPI:
             return
         remaining = float(restore_at) - datetime.now(timezone.utc).timestamp()
         if remaining <= 0:
-            self._extra_dhw_restore_at = None
-            try:
-                await store.async_remove()
-            except Exception:
-                _LOGGER.debug("Failed to clear extra DHW timer", exc_info=True)
+            self._extra_dhw_restore_at = float(restore_at)
             try:
                 await self.write_holding_register_for_metric(
                     device_id, "extra_tap_water", DHW_MODE_NORMAL
@@ -467,8 +476,14 @@ class QvantumAPI:
                 _LOGGER.warning(
                     "Failed to restore DHW mode after extra hot water timer: %s", err
                 )
+                return
+            self._extra_dhw_restore_at = None
+            try:
+                await self.async_persist_extra_dhw(None)
+            except Exception:
+                _LOGGER.debug("Failed to clear extra DHW timer", exc_info=True)
             return
-        self._schedule_extra_dhw_at(str(device_id), float(restore_at), persist=False)
+        await self._schedule_extra_dhw_at(str(device_id), float(restore_at), persist=False)
 
     def _ensure_modbus_write_allowed(self) -> None:
         """Raise when Modbus TCP is on but holding-register writes are disabled."""
@@ -706,16 +721,25 @@ class QvantumAPI:
     async def set_extra_tap_water(self, device_id: str, minutes: int):
         """Update extra_tap_water setting."""
         if self._modbus_tcp:
-            self._cancel_extra_dhw_timer(clear_store=True)
+            if minutes > 0:
+                result = await self.write_holding_register_for_metric(
+                    device_id, "extra_tap_water", DHW_MODE_EXTRA
+                )
+                await self._schedule_extra_dhw_restore(device_id, minutes)
+                return result
+            # Off or indefinite: write first so a failed write keeps the
+            # persisted timed restore for the next restart.
             if minutes == 0:
-                return await self.write_holding_register_for_metric(
+                result = await self.write_holding_register_for_metric(
                     device_id, "extra_tap_water", DHW_MODE_NORMAL
                 )
-            result = await self.write_holding_register_for_metric(
-                device_id, "extra_tap_water", DHW_MODE_EXTRA
-            )
-            if minutes > 0:
-                self._schedule_extra_dhw_restore(device_id, minutes)
+            else:
+                result = await self.write_holding_register_for_metric(
+                    device_id, "extra_tap_water", DHW_MODE_EXTRA
+                )
+            self._cancel_extra_dhw_timer(clear_store=False)
+            self._extra_dhw_restore_at = None
+            await self.async_persist_extra_dhw(None)
             return result
 
         # Capture current time once to ensure consistency across all code paths

--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -2,6 +2,7 @@
 
 import aiohttp
 import asyncio
+import inspect
 import json
 from datetime import datetime, timedelta, timezone
 import logging
@@ -82,6 +83,8 @@ class QvantumAPI:
         self._modbus_lock = asyncio.Lock()
         self._closed = False
         self._extra_dhw_unsub = None
+        self._extra_dhw_restore_at: float | None = None
+        self._extra_dhw_store = None
         # Modbus-only mode never opens an HTTP session, even if a caller
         # injects one. Cloud mode owns a session unless a test injects it.
         if modbus_tcp:
@@ -372,22 +375,54 @@ class QvantumAPI:
             "Authorization": f"Bearer {self._token}",
         }
 
-    def _cancel_extra_dhw_timer(self) -> None:
+    def _cancel_extra_dhw_timer(self, *, clear_store: bool = False) -> None:
         """Cancel a pending extra-DHW restore callback."""
         unsub = self._extra_dhw_unsub
         self._extra_dhw_unsub = None
         if unsub:
             unsub()
+        if clear_store:
+            self._extra_dhw_restore_at = None
+            self._persist_extra_dhw(None)
+
+    def _persist_extra_dhw(self, payload: dict | None) -> None:
+        """Save or clear the extra-DHW restore deadline."""
+        store = self._extra_dhw_store
+        hass = self.hass
+        if store is None or hass is None:
+            return
+        result = store.async_remove() if payload is None else store.async_save(payload)
+        if inspect.isawaitable(result):
+            create_task = getattr(hass, "async_create_task", None)
+            if callable(create_task):
+                create_task(result)
 
     def _schedule_extra_dhw_restore(self, device_id: str, minutes: int) -> None:
         """After *minutes*, write DHW mode back to Normal."""
-        self._cancel_extra_dhw_timer()
-        if not self.hass or minutes <= 0:
+        if minutes <= 0:
             return
+        restore_at = datetime.now(timezone.utc).timestamp() + minutes * 60
+        self._schedule_extra_dhw_at(device_id, restore_at, persist=True)
+
+    def _schedule_extra_dhw_at(
+        self, device_id: str, restore_at: float, *, persist: bool
+    ) -> None:
+        """Schedule restore at an absolute UTC epoch; persist when requested."""
+        self._cancel_extra_dhw_timer(clear_store=False)
+        remaining = restore_at - datetime.now(timezone.utc).timestamp()
+        if not self.hass or remaining <= 0:
+            return
+        self._extra_dhw_restore_at = restore_at
+        if persist:
+            self._persist_extra_dhw(
+                {"device_id": str(device_id), "restore_at": restore_at}
+            )
         from homeassistant.helpers.event import async_call_later
 
         async def _restore(_now) -> None:
             self._extra_dhw_unsub = None
+            self._extra_dhw_restore_at = None
+            self._persist_extra_dhw(None)
             try:
                 await self.write_holding_register_for_metric(
                     device_id, "extra_tap_water", DHW_MODE_NORMAL
@@ -397,9 +432,43 @@ class QvantumAPI:
                     "Failed to restore DHW mode after extra hot water timer: %s", err
                 )
 
-        self._extra_dhw_unsub = async_call_later(
-            self.hass, minutes * 60, _restore
-        )
+        self._extra_dhw_unsub = async_call_later(self.hass, remaining, _restore)
+
+    async def async_restore_extra_dhw_timer(self) -> None:
+        """Resume a persisted extra-DHW restore after Home Assistant restart."""
+        if not self._modbus_tcp or not self._modbus_write:
+            return
+        store = self._extra_dhw_store
+        if store is None:
+            return
+        try:
+            data = await store.async_load()
+        except Exception:
+            _LOGGER.debug("Failed to load extra DHW timer", exc_info=True)
+            return
+        if not isinstance(data, dict):
+            return
+        device_id = data.get("device_id")
+        restore_at = data.get("restore_at")
+        if not device_id or not isinstance(restore_at, (int, float)):
+            return
+        remaining = float(restore_at) - datetime.now(timezone.utc).timestamp()
+        if remaining <= 0:
+            self._extra_dhw_restore_at = None
+            try:
+                await store.async_remove()
+            except Exception:
+                _LOGGER.debug("Failed to clear extra DHW timer", exc_info=True)
+            try:
+                await self.write_holding_register_for_metric(
+                    device_id, "extra_tap_water", DHW_MODE_NORMAL
+                )
+            except Exception as err:
+                _LOGGER.warning(
+                    "Failed to restore DHW mode after extra hot water timer: %s", err
+                )
+            return
+        self._schedule_extra_dhw_at(str(device_id), float(restore_at), persist=False)
 
     def _ensure_modbus_write_allowed(self) -> None:
         """Raise when Modbus TCP is on but holding-register writes are disabled."""
@@ -637,7 +706,7 @@ class QvantumAPI:
     async def set_extra_tap_water(self, device_id: str, minutes: int):
         """Update extra_tap_water setting."""
         if self._modbus_tcp:
-            self._cancel_extra_dhw_timer()
+            self._cancel_extra_dhw_timer(clear_store=True)
             if minutes == 0:
                 return await self.write_holding_register_for_metric(
                     device_id, "extra_tap_water", DHW_MODE_NORMAL

--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -456,7 +456,11 @@ class QvantumAPI:
 
     async def async_restore_extra_dhw_timer(self) -> None:
         """Resume a persisted extra-DHW restore after Home Assistant restart."""
-        if not self._modbus_tcp or not self._modbus_write:
+        if not self._modbus_tcp:
+            return
+        if not self._modbus_write:
+            # Writes off: do not reschedule, and drop any saved deadline.
+            await self.async_persist_extra_dhw(None)
             return
         store = self._extra_dhw_store
         if store is None:

--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -407,10 +407,13 @@ class QvantumAPI:
             return
         create_task = getattr(hass, "async_create_task", None)
         if callable(create_task):
-            create_task(
-                self.async_persist_extra_dhw(payload),
-                name="qvantum_persist_extra_dhw",
-            )
+            try:
+                create_task(
+                    self.async_persist_extra_dhw(payload),
+                    name="qvantum_persist_extra_dhw",
+                )
+            except TypeError:
+                create_task(self.async_persist_extra_dhw(payload))
 
     async def _schedule_extra_dhw_restore(self, device_id: str, minutes: int) -> None:
         """After *minutes*, write DHW mode back to Normal."""

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -687,6 +687,10 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
             # Settings take precedence over metrics in case of conflicts
             values = {**metrics_dict, **settings_dict}
 
+            restore_at = getattr(self.api, "_extra_dhw_restore_at", None)
+            if self.modbus_enabled and isinstance(restore_at, (int, float)):
+                values["tap_stop"] = int(restore_at)
+
             self._derive_tap_water_capacity(values)
 
             if self.modbus_enabled:

--- a/custom_components/qvantum/sensor.py
+++ b/custom_components/qvantum/sensor.py
@@ -109,9 +109,8 @@ async def async_setup_entry(
     sensors.append(QvantumTotalEnergyEntity(coordinator, "totalenergy", device, True))
     sensors.append(QvantumDiagnosticEntity(coordinator, "latency", device, True))
     sensors.append(QvantumDiagnosticEntity(coordinator, "hpid", device, True))
+    sensors.append(QvantumTimerEntity(coordinator, "tap_stop", device, True))
     if not coordinator.modbus_enabled:
-        sensors.append(QvantumTimerEntity(coordinator, "tap_stop", device, True))
-
         # Cloud-only: firmware and access level from the HTTP API
         maintenance_coordinator = config_entry.runtime_data.maintenance_coordinator
         sensors.append(
@@ -147,11 +146,10 @@ async def async_setup_entry(
 
     # Clean up disabled entities that are no longer supported in the current mode.
     # Include special sensor keys so they are never removed by cleanup.
-    special_sensor_keys = {"totalenergy", "latency", "hpid"}
+    special_sensor_keys = {"totalenergy", "latency", "hpid", "tap_stop"}
     if not coordinator.modbus_enabled:
         special_sensor_keys.update(
             {
-                "tap_stop",
                 "expiresAt",
                 "display_fw_version",
                 "cc_fw_version",

--- a/docs/modbus-feature-gap-analysis.md
+++ b/docs/modbus-feature-gap-analysis.md
@@ -61,12 +61,12 @@ Reinstalling a pump that was on the previous overlay as current local-only **cre
 Gone in current local. Previous Modbus could still show some of these via HTTP fallback:
 
 - `bp1_pressure`, `bp1_temp`, `bp2_pressure`, `bp2_temp`, `fan0_10v`
-- `tap_stop` extra-DHW countdown
+- Cloud extra-DHW countdown (HTTP `tap_stop` epoch from the pump/cloud)
 - Firmware sensors: `display_fw_version`, `cc_fw_version`, `inv_fw_version`, `firmware_last_check`
 - Access: `expiresAt`
 - Default-disabled HTTP metrics with no register, including `calc_suppy_cpr`, `dhw_outl_temp_*`, `guide_*`, `price_region`, `heatingreleased` / `coolingreleased` / `compressorreleased` / `additionreleased`, `inputcurrent1–3`, …
 
-Previous Modbus **still created** `tap_stop`, firmware, and access sensors even when Modbus was on (often stale or empty if the cloud was down). Current local **hides** them and cleans leftovers out of the entity registry.
+Previous Modbus **still created** cloud `tap_stop`, firmware, and access sensors even when Modbus was on (often stale or empty if the cloud was down). Current local **hides** firmware/access and leftover cloud sensors, and cleans those leftovers out of the entity registry. Extra-DHW `tap_stop` is still created locally from the persisted restore epoch (`_extra_dhw_restore_at`), not the cloud countdown.
 
 ### Modbus-only (HTTP never had these as first-class live sensors)
 
@@ -125,7 +125,7 @@ Climate is heat-only. `async_set_hvac_mode` is a no-op in **all** modes. Target-
 | **SmartControl** (`use_adaptive`, `smart_sh_mode`, `smart_dhw_mode`) | Constraint: never write SmartControl locally. Select stays cloud-only. |
 | **`enable_sc_sh` / `enable_sc_dhw`** | Readable as inputs 163–164; no holding in the write map. Switches exist but are unavailable. |
 | **`elevate_access`** | Cloud grant flow. The button is not created in local Modbus mode. |
-| **Timed extra DHW** | Cloud has `stopTime` / indefinite / cancel. Local only flips DHW mode. |
+| **Timed extra DHW** | Cloud has pump-side `stopTime` / indefinite / cancel. Local writes Extra/Normal and Home Assistant restores Normal from a restore timer with a persisted deadline (`tap_stop` from that epoch). |
 | **Timed fan boost** | Cloud extra fan uses a ~120 minute stop timestamp. Local writes 0/1/2 with no restore timer (sticky). |
 
 SmartControl **status** can still be **read** on Modbus (`smart_dhw_mode` 161, `smart_dhw_control_status` 162, `enable_sc_dhw` 163, `enable_sc_sh` 164). `use_adaptive` is derived (`smart_dhw_mode != -1`).
@@ -136,14 +136,14 @@ SmartControl **status** can still be **read** on Modbus (`smart_dhw_mode` 161, `
 
 | | HTTP / previous Modbus | Current local |
 |---|---|---|
-| Mechanism | Cloud command with end epoch | Holding 53 Extra vs Normal |
-| 60-min button | Pump/cloud enforces the window | In-memory `async_call_later` (60 min) |
+| Mechanism | Cloud command with end epoch | Holding 53 Extra vs Normal; HA restore timer for timed extra |
+| 60-min button | Pump/cloud enforces the window | Restore timer with persisted deadline (60 min) |
 | Extra switch ON | HTTP `minutes=-1` (indefinite) | Extra mode, **no timer** |
-| Service `qvantum.extra_hot_water` | Always (uses HTTP); 0–480 min, default 120 | Registered; writes holding if `modbus_write`; same in-memory timer for `minutes > 0` |
-| `tap_stop` sensor | Yes | No |
+| Service `qvantum.extra_hot_water` | Always (uses HTTP); 0–480 min, default 120 | Registered; writes holding if `modbus_write`; persisted restore timer for `minutes > 0` |
+| `tap_stop` sensor | Yes (cloud countdown) | Yes, from `_extra_dhw_restore_at` |
 | HA restart during the hour | Cloud still ends extra | Restore deadline is persisted; Normal is written when it expires |
 
-That restart hole is the leftover note on #181, not a regression vs “local previous” — previous extra DHW simply was not local. Turning `modbus_write` off cancels a pending restore timer.
+Turning `modbus_write` off cancels a pending restore timer.
 
 ---
 
@@ -168,12 +168,12 @@ The holding map includes many registers that are **not** in `MODBUS_HOLDING_TO_S
 ### Current local vs HTTP
 
 - **Gain:** no cloud, faster poll, derived power / DHW capacity, extra relays/state, local writes for the mapped setpoints.
-- **Lose:** SmartControl, elevate access, compressor/inverter/display firmware sensors, `tap_stop`, bp1/bp2, `fan0_10v`, true timed extra DHW / fan boost, any HTTP-only disabled metric, vendor/model from inventory.
+- **Lose:** SmartControl, elevate access, compressor/inverter/display firmware sensors, bp1/bp2, `fan0_10v`, timed fan boost, any HTTP-only disabled metric, vendor/model from inventory. Extra-DHW `tap_stop` remains (local restore epoch, not the cloud countdown).
 
 ### Current local vs previous Modbus
 
 - **Gain:** works with no account and no internet; serial unique id; no refused dual-span HTTP; extra DHW / climate / fan / DHW start-stop / op-mode actually write locally; cloud-only entities are hidden instead of sitting unavailable; write access does not need cloud elevation.
-- **Lose:** HTTP fallback if Modbus drops; cloud-backed extra DHW duration and `tap_stop`; SmartControl and elevate-access while “on Modbus”; bp1/bp2/`fan0_10v` via fallback; write access via cloud when `modbus_write` is off; stable cloud `hpid` in entity unique IDs.
+- **Lose:** HTTP fallback if Modbus drops; pump/cloud-enforced extra DHW `stopTime` (local `tap_stop` is HA’s persisted restore epoch); SmartControl and elevate-access while “on Modbus”; bp1/bp2/`fan0_10v` via fallback; write access via cloud when `modbus_write` is off; stable cloud `hpid` in entity unique IDs.
 
 ### Previous Modbus vs HTTP
 
@@ -197,8 +197,9 @@ That is no longer true on this stack. Local is XOR cloud; writes never fall back
 
 ## 9. Highest-value remaining local gaps
 
-1. Persist extra-DHW restore across a Home Assistant restart (and optionally restore `tap_stop`-like remaining time).
-2. Decide whether unused holdings (on/off, cooling allow, curves, pump speeds) should become entities.
-3. Confirm SmartControl stays permanently cloud-only (current constraint).
-4. Update README for exclusive Cloud vs Modbus setup, identity probe, and holding writes.
-5. Entity unique-id migration for users who already ran the hybrid overlay (cloud `hpid` → serial).
+1. Decide whether unused holdings (on/off, cooling allow, curves, pump speeds) should become entities.
+2. Confirm SmartControl stays permanently cloud-only (current constraint).
+3. Update README for exclusive Cloud vs Modbus setup, identity probe, and holding writes.
+4. Entity unique-id migration for users who already ran the hybrid overlay (cloud `hpid` → serial).
+
+Done in this persist-across-restart work: extra-DHW restore deadline is stored and resumed after a Home Assistant restart; local `tap_stop` is the restore epoch.

--- a/docs/modbus-feature-gap-analysis.md
+++ b/docs/modbus-feature-gap-analysis.md
@@ -141,7 +141,7 @@ SmartControl **status** can still be **read** on Modbus (`smart_dhw_mode` 161, `
 | Extra switch ON | HTTP `minutes=-1` (indefinite) | Extra mode, **no timer** |
 | Service `qvantum.extra_hot_water` | Always (uses HTTP); 0–480 min, default 120 | Registered; writes holding if `modbus_write`; same in-memory timer for `minutes > 0` |
 | `tap_stop` sensor | Yes | No |
-| HA restart during the hour | Cloud still ends extra | **Never writes Normal back** |
+| HA restart during the hour | Cloud still ends extra | Restore deadline is persisted; Normal is written when it expires |
 
 That restart hole is the leftover note on #181, not a regression vs “local previous” — previous extra DHW simply was not local. Turning `modbus_write` off cancels a pending restore timer.
 

--- a/tests/test_modbus_writes.py
+++ b/tests/test_modbus_writes.py
@@ -418,6 +418,53 @@ class TestExtraTapWaterModbus:
         store.async_remove.assert_not_called()
         assert api._extra_dhw_restore_at == deadline
 
+    @pytest.mark.asyncio
+    async def test_persist_extra_dhw_swallows_store_errors(self):
+        api = _modbus_api()
+        store = MagicMock()
+        store.async_save = AsyncMock(side_effect=OSError("disk full"))
+        store.async_remove = AsyncMock(side_effect=OSError("disk full"))
+        api._extra_dhw_store = store
+        await api.async_persist_extra_dhw({"device_id": "dev1", "restore_at": 1.0})
+        await api.async_persist_extra_dhw(None)
+        store.async_save.assert_awaited_once()
+        store.async_remove.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_schedule_expired_deadline_still_restores(self):
+        api = _modbus_api()
+        api.hass = MagicMock()
+        captured = {}
+
+        def fake_later(_hass, seconds, callback):
+            captured["delay"] = seconds
+            captured["cb"] = callback
+            return MagicMock()
+
+        with (
+            patch.object(
+                api,
+                "write_holding_register_for_metric",
+                AsyncMock(return_value={"status": "APPLIED"}),
+            ) as write,
+            patch("homeassistant.helpers.event.async_call_later", side_effect=fake_later),
+        ):
+            await api._schedule_extra_dhw_at("dev1", 1.0, persist=False)
+            assert captured["delay"] == 0
+            await captured["cb"](None)
+        write.assert_awaited_once_with("dev1", "extra_tap_water", DHW_MODE_NORMAL)
+
+    @pytest.mark.asyncio
+    async def test_schedule_clamps_negative_delay(self):
+        api = _modbus_api()
+        api.hass = MagicMock()
+        with patch(
+            "homeassistant.helpers.event.async_call_later", return_value=MagicMock()
+        ) as later:
+            await api._schedule_extra_dhw_at("dev1", 1.0, persist=False)
+        later.assert_called_once()
+        assert later.call_args.args[1] >= 0
+
 
 class TestModbusWriteOptionGate:
     @pytest.mark.asyncio

--- a/tests/test_modbus_writes.py
+++ b/tests/test_modbus_writes.py
@@ -146,7 +146,7 @@ class TestExtraTapWaterModbus:
             await api.set_extra_tap_water("dev1", 60)
         write.assert_awaited_once_with("dev1", "extra_tap_water", DHW_MODE_EXTRA)
         later.assert_called_once()
-        assert later.call_args.args[1] == 3600
+        assert later.call_args.args[1] == pytest.approx(3600, abs=1)
         assert api._extra_dhw_unsub is unsub
 
     @pytest.mark.asyncio
@@ -194,6 +194,101 @@ class TestExtraTapWaterModbus:
             write.reset_mock()
             await captured["cb"](None)
         write.assert_awaited_once_with("dev1", "extra_tap_water", DHW_MODE_NORMAL)
+
+    @pytest.mark.asyncio
+    async def test_timed_extra_persists_restore_deadline(self):
+        api = _modbus_api()
+        api.hass = MagicMock()
+        api.hass.async_create_task = MagicMock()
+        store = MagicMock()
+        store.async_save = MagicMock()
+        api._extra_dhw_store = store
+        with (
+            patch.object(
+                api,
+                "write_holding_register_for_metric",
+                AsyncMock(return_value={"status": "APPLIED"}),
+            ),
+            patch("homeassistant.helpers.event.async_call_later", return_value=MagicMock()),
+        ):
+            await api.set_extra_tap_water("dev1", 60)
+        store.async_save.assert_called_once()
+        payload = store.async_save.call_args.args[0]
+        assert payload["device_id"] == "dev1"
+        assert payload["restore_at"] > 0
+        assert api._extra_dhw_restore_at == payload["restore_at"]
+
+    @pytest.mark.asyncio
+    async def test_off_clears_persisted_timer(self):
+        api = _modbus_api()
+        api.hass = MagicMock()
+        api.hass.async_create_task = MagicMock()
+        store = MagicMock()
+        store.async_remove = MagicMock()
+        api._extra_dhw_store = store
+        api._extra_dhw_restore_at = 123.0
+        with patch.object(
+            api,
+            "write_holding_register_for_metric",
+            AsyncMock(return_value={"status": "APPLIED"}),
+        ):
+            await api.set_extra_tap_water("dev1", 0)
+        store.async_remove.assert_called()
+        assert api._extra_dhw_restore_at is None
+
+    @pytest.mark.asyncio
+    async def test_close_keeps_persisted_timer(self):
+        api = _modbus_api()
+        api.hass = MagicMock()
+        api.hass.async_create_task = MagicMock()
+        store = MagicMock()
+        store.async_remove = AsyncMock()
+        api._extra_dhw_store = store
+        api._extra_dhw_restore_at = 123.0
+        unsub = MagicMock()
+        api._extra_dhw_unsub = unsub
+        await api.close()
+        unsub.assert_called_once()
+        store.async_remove.assert_not_called()
+        assert api._extra_dhw_restore_at == 123.0
+
+    @pytest.mark.asyncio
+    async def test_restore_timer_reschedules_remaining(self):
+        api = _modbus_api()
+        api.hass = MagicMock()
+        restore_at = __import__("time").time() + 120
+        store = MagicMock()
+        store.async_load = AsyncMock(
+            return_value={"device_id": "dev1", "restore_at": restore_at}
+        )
+        api._extra_dhw_store = store
+        with patch(
+            "homeassistant.helpers.event.async_call_later", return_value=MagicMock()
+        ) as later:
+            await api.async_restore_extra_dhw_timer()
+        later.assert_called_once()
+        assert later.call_args.args[1] == pytest.approx(120, abs=2)
+        assert api._extra_dhw_restore_at == restore_at
+
+    @pytest.mark.asyncio
+    async def test_restore_timer_writes_normal_when_expired(self):
+        api = _modbus_api()
+        api.hass = MagicMock()
+        store = MagicMock()
+        store.async_load = AsyncMock(
+            return_value={"device_id": "dev1", "restore_at": 1.0}
+        )
+        store.async_remove = AsyncMock()
+        api._extra_dhw_store = store
+        with patch.object(
+            api,
+            "write_holding_register_for_metric",
+            AsyncMock(return_value={"status": "APPLIED"}),
+        ) as write:
+            await api.async_restore_extra_dhw_timer()
+        write.assert_awaited_once_with("dev1", "extra_tap_water", DHW_MODE_NORMAL)
+        store.async_remove.assert_awaited()
+        assert api._extra_dhw_restore_at is None
 
 
 class TestModbusWriteOptionGate:

--- a/tests/test_modbus_writes.py
+++ b/tests/test_modbus_writes.py
@@ -449,6 +449,37 @@ class TestExtraTapWaterModbus:
         store.async_save.assert_awaited_once()
         store.async_remove.assert_awaited_once()
 
+    def test_persist_extra_dhw_schedules_named_task(self):
+        api = _modbus_api()
+        api.hass = MagicMock()
+        api._extra_dhw_store = MagicMock()
+        calls = []
+
+        def create_task(coro, name=None):
+            calls.append({"name": name})
+            coro.close()
+
+        api.hass.async_create_task = create_task
+        api._persist_extra_dhw(None)
+        assert calls == [{"name": "qvantum_persist_extra_dhw"}]
+
+    def test_persist_extra_dhw_retries_without_name(self):
+        api = _modbus_api()
+        api.hass = MagicMock()
+        api._extra_dhw_store = MagicMock()
+        calls = []
+
+        def create_task(coro, name=None):
+            if name is not None:
+                coro.close()
+                raise TypeError("unexpected keyword argument 'name'")
+            calls.append({"name": name})
+            coro.close()
+
+        api.hass.async_create_task = create_task
+        api._persist_extra_dhw(None)
+        assert calls == [{"name": None}]
+
     @pytest.mark.asyncio
     async def test_schedule_expired_deadline_still_restores(self):
         api = _modbus_api()

--- a/tests/test_modbus_writes.py
+++ b/tests/test_modbus_writes.py
@@ -279,6 +279,25 @@ class TestExtraTapWaterModbus:
         assert api._extra_dhw_restore_at == 123.0
 
     @pytest.mark.asyncio
+    async def test_restore_timer_clears_store_when_writes_disabled(self):
+        api = _modbus_api(modbus_write=False)
+        api.hass = MagicMock()
+        store = MagicMock()
+        store.async_load = AsyncMock(
+            return_value={"device_id": "dev1", "restore_at": 9999999999.0}
+        )
+        store.async_remove = AsyncMock()
+        api._extra_dhw_store = store
+        with patch(
+            "homeassistant.helpers.event.async_call_later", return_value=MagicMock()
+        ) as later:
+            await api.async_restore_extra_dhw_timer()
+        later.assert_not_called()
+        store.async_load.assert_not_called()
+        store.async_remove.assert_awaited_once()
+        assert api._extra_dhw_restore_at is None
+
+    @pytest.mark.asyncio
     async def test_restore_timer_reschedules_remaining(self):
         api = _modbus_api()
         api.hass = MagicMock()

--- a/tests/test_modbus_writes.py
+++ b/tests/test_modbus_writes.py
@@ -201,7 +201,8 @@ class TestExtraTapWaterModbus:
         api.hass = MagicMock()
         api.hass.async_create_task = MagicMock()
         store = MagicMock()
-        store.async_save = MagicMock()
+        store.async_save = AsyncMock()
+        store.async_remove = AsyncMock()
         api._extra_dhw_store = store
         with (
             patch.object(
@@ -212,7 +213,9 @@ class TestExtraTapWaterModbus:
             patch("homeassistant.helpers.event.async_call_later", return_value=MagicMock()),
         ):
             await api.set_extra_tap_water("dev1", 60)
-        store.async_save.assert_called_once()
+        store.async_save.assert_awaited_once()
+        store.async_remove.assert_not_called()
+        api.hass.async_create_task.assert_not_called()
         payload = store.async_save.call_args.args[0]
         assert payload["device_id"] == "dev1"
         assert payload["restore_at"] > 0
@@ -224,7 +227,7 @@ class TestExtraTapWaterModbus:
         api.hass = MagicMock()
         api.hass.async_create_task = MagicMock()
         store = MagicMock()
-        store.async_remove = MagicMock()
+        store.async_remove = AsyncMock()
         api._extra_dhw_store = store
         api._extra_dhw_restore_at = 123.0
         with patch.object(
@@ -233,8 +236,31 @@ class TestExtraTapWaterModbus:
             AsyncMock(return_value={"status": "APPLIED"}),
         ):
             await api.set_extra_tap_water("dev1", 0)
-        store.async_remove.assert_called()
+        store.async_remove.assert_awaited()
+        api.hass.async_create_task.assert_not_called()
         assert api._extra_dhw_restore_at is None
+
+    @pytest.mark.asyncio
+    async def test_off_keeps_persisted_timer_when_write_fails(self):
+        api = _modbus_api()
+        api.hass = MagicMock()
+        store = MagicMock()
+        store.async_remove = AsyncMock()
+        api._extra_dhw_store = store
+        api._extra_dhw_restore_at = 123.0
+        unsub = MagicMock()
+        api._extra_dhw_unsub = unsub
+        with patch.object(
+            api,
+            "write_holding_register_for_metric",
+            AsyncMock(side_effect=RuntimeError("modbus down")),
+        ):
+            with pytest.raises(RuntimeError, match="modbus down"):
+                await api.set_extra_tap_water("dev1", 0)
+        store.async_remove.assert_not_called()
+        unsub.assert_not_called()
+        assert api._extra_dhw_unsub is unsub
+        assert api._extra_dhw_restore_at == 123.0
 
     @pytest.mark.asyncio
     async def test_close_keeps_persisted_timer(self):
@@ -278,17 +304,119 @@ class TestExtraTapWaterModbus:
         store.async_load = AsyncMock(
             return_value={"device_id": "dev1", "restore_at": 1.0}
         )
+        order: list[str] = []
+
+        async def write_normal(*_args, **_kwargs):
+            order.append("write")
+            return {"status": "APPLIED"}
+
+        async def remove_store():
+            order.append("remove")
+
+        store.async_remove = AsyncMock(side_effect=remove_store)
+        api._extra_dhw_store = store
+        with patch.object(
+            api,
+            "write_holding_register_for_metric",
+            AsyncMock(side_effect=write_normal),
+        ) as write:
+            await api.async_restore_extra_dhw_timer()
+        write.assert_awaited_once_with("dev1", "extra_tap_water", DHW_MODE_NORMAL)
+        store.async_remove.assert_awaited()
+        assert order == ["write", "remove"]
+        assert api._extra_dhw_restore_at is None
+
+    @pytest.mark.asyncio
+    async def test_restore_timer_keeps_deadline_when_expired_write_fails(self):
+        api = _modbus_api()
+        api.hass = MagicMock()
+        store = MagicMock()
+        store.async_load = AsyncMock(
+            return_value={"device_id": "dev1", "restore_at": 1.0}
+        )
         store.async_remove = AsyncMock()
         api._extra_dhw_store = store
         with patch.object(
             api,
             "write_holding_register_for_metric",
-            AsyncMock(return_value={"status": "APPLIED"}),
-        ) as write:
+            AsyncMock(side_effect=RuntimeError("modbus down")),
+        ):
             await api.async_restore_extra_dhw_timer()
+        store.async_remove.assert_not_called()
+        assert api._extra_dhw_restore_at == 1.0
+
+    @pytest.mark.asyncio
+    async def test_restore_callback_clears_store_after_write(self):
+        api = _modbus_api()
+        api.hass = MagicMock()
+        store = MagicMock()
+        order: list[str] = []
+
+        async def write_normal(*_args, **_kwargs):
+            order.append("write")
+            return {"status": "APPLIED"}
+
+        async def remove_store():
+            order.append("remove")
+
+        store.async_save = AsyncMock()
+        store.async_remove = AsyncMock(side_effect=remove_store)
+        api._extra_dhw_store = store
+        captured = {}
+
+        def fake_later(_hass, _seconds, callback):
+            captured["cb"] = callback
+            return MagicMock()
+
+        with (
+            patch.object(
+                api,
+                "write_holding_register_for_metric",
+                AsyncMock(side_effect=write_normal),
+            ) as write,
+            patch("homeassistant.helpers.event.async_call_later", side_effect=fake_later),
+        ):
+            await api.set_extra_tap_water("dev1", 60)
+            write.reset_mock()
+            order.clear()
+            await captured["cb"](None)
         write.assert_awaited_once_with("dev1", "extra_tap_water", DHW_MODE_NORMAL)
         store.async_remove.assert_awaited()
+        assert order == ["write", "remove"]
         assert api._extra_dhw_restore_at is None
+
+    @pytest.mark.asyncio
+    async def test_restore_callback_keeps_store_when_write_fails(self):
+        api = _modbus_api()
+        api.hass = MagicMock()
+        store = MagicMock()
+        store.async_save = AsyncMock()
+        store.async_remove = AsyncMock()
+        api._extra_dhw_store = store
+        captured = {}
+
+        def fake_later(_hass, _seconds, callback):
+            captured["cb"] = callback
+            return MagicMock()
+
+        with (
+            patch.object(
+                api,
+                "write_holding_register_for_metric",
+                AsyncMock(return_value={"status": "APPLIED"}),
+            ),
+            patch("homeassistant.helpers.event.async_call_later", side_effect=fake_later),
+        ):
+            await api.set_extra_tap_water("dev1", 60)
+            deadline = api._extra_dhw_restore_at
+            with patch.object(
+                api,
+                "write_holding_register_for_metric",
+                AsyncMock(side_effect=RuntimeError("modbus down")),
+            ):
+                await captured["cb"](None)
+        store.async_remove.assert_not_called()
+        assert api._extra_dhw_restore_at == deadline
 
 
 class TestModbusWriteOptionGate:

--- a/tests/test_modbus_writes.py
+++ b/tests/test_modbus_writes.py
@@ -467,18 +467,20 @@ class TestExtraTapWaterModbus:
         api = _modbus_api()
         api.hass = MagicMock()
         api._extra_dhw_store = MagicMock()
-        calls = []
+        seen = []
 
         def create_task(coro, name=None):
+            seen.append((coro, name))
             if name is not None:
-                coro.close()
                 raise TypeError("unexpected keyword argument 'name'")
-            calls.append({"name": name})
             coro.close()
 
         api.hass.async_create_task = create_task
         api._persist_extra_dhw(None)
-        assert calls == [{"name": None}]
+        assert len(seen) == 2
+        assert seen[0][0] is seen[1][0]
+        assert seen[0][1] == "qvantum_persist_extra_dhw"
+        assert seen[1][1] is None
 
     @pytest.mark.asyncio
     async def test_schedule_expired_deadline_still_restores(self):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -569,7 +569,7 @@ class TestSensorSetup:
         assert "totalenergy" in allowed
         assert "latency" in allowed
         assert "hpid" in allowed
-        assert "tap_stop" not in allowed
+        assert "tap_stop" in allowed
         assert "expiresAt" not in allowed
         assert "firmware_last_check" not in allowed
 


### PR DESCRIPTION
## Summary
- Persist the Modbus extra-DHW restore deadline so Home Assistant still writes Normal after a restart.
- Honor `qvantum.extra_hot_water` `minutes` (0–480); the 60-minute button is unchanged.
- Expose the extra-DHW `tap_stop` timestamp in Modbus mode from the stored end time.

## Notes
Turning extra off or disabling Modbus writes clears the saved timer. Unload/reload keeps it so a restart can restore it. The extra switch without a duration stays Extra until turned off.

## Test plan
- [x] `./run-tests.sh` (601 passed)
- [x] Enable extra DHW via service with a short `minutes` value, restart HA before it expires, confirm Normal is written at the original end time
- [x] Confirm `tap_stop` shows the end timestamp in Modbus mode