### PR TITLE
feat: Add vacation mode switch entity for Cloud mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ This document outlines the AI agents, assistants, and tools that contributed to 
   - Derived metric implementation: `heatingpower` calculated from `heatingenergy` counter delta with accurate time-window measurement and hold-last-value while heating
   - Centralized icon mapping in `QvantumEntity` base class
   - Bug fixes for heating power overestimation caused by coarse counter resolution vs. fast poll intervals
+  - Vacation mode (`vacation_mode`) switch entity support
 - **Tools Used**:
   - Code completion and suggestions
   - Multi-file editing capabilities

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Cloud-only sensors (firmware boards and access expiry) are not created in this m
 ### Features
 
 - **Real-time Monitoring**: Temperature sensors, pressure readings, energy consumption
-- **System Control**: Adjust operation modes, set temperatures, control ventilation
+- **System Control**: Adjust operation modes, set temperatures, toggle vacation mode, control ventilation
 - **Energy Analytics**: Daily and total energy usage tracking
 - **Smart Status**: Heat pump status, defrost cycles, priority modes
 - **Comprehensive Coverage**: Supports all major Qvantum heat pump parameters
@@ -97,7 +97,7 @@ Cloud-only sensors (firmware boards and access expiry) are not created in this m
 >
 > Supported local writes include indoor target/offset, DHW start/stop, extra DHW, fan preset, operation/manual switches, room compensation, fan speeds, extra-DHW stop, external room temperature, and indoor sensor source.
 >
-> **SmartControl** (`use_adaptive`, `enable_sc_sh`, `enable_sc_dhw`) and **elevate-access** stay cloud-only. They are unavailable in local mode.
+> **SmartControl** (`use_adaptive`, `enable_sc_sh`, `enable_sc_dhw`), **vacation mode**, and **elevate-access** stay cloud-only. They are unavailable in local mode.
 >
 > By enabling Modbus writing you accept full responsibility for values written to the pump. Incorrect or out-of-range values may void the warranty and/or affect lifecycle and performance.
 

--- a/custom_components/qvantum/entity.py
+++ b/custom_components/qvantum/entity.py
@@ -116,6 +116,7 @@ _CLOUD_ONLY_WRITE_METRICS = frozenset(
         "enable_sc_sh",
         "enable_sc_dhw",
         "elevate_access",
+        "vacation_mode",
     }
 )
 
@@ -145,6 +146,7 @@ _ENTITY_ICONS: dict[str, str] = {
     "extra_tap_water": "mdi:water-boiler",
     "enable_sc_sh": "mdi:radiator",
     "enable_sc_dhw": "mdi:water-thermometer",
+    "vacation_mode": "mdi:palm-tree",
     # Select
     "use_adaptive": "mdi:leaf",
     "use_operation_sensor": "mdi:motion-sensor",

--- a/custom_components/qvantum/switch.py
+++ b/custom_components/qvantum/switch.py
@@ -32,6 +32,7 @@ async def async_setup_entry(
         "man_mode",
         "enable_sc_sh",
         "enable_sc_dhw",
+        "vacation_mode",
     ]
 
     sensors = []
@@ -66,7 +67,7 @@ class QvantumSwitchEntity(QvantumEntity, SwitchEntity):
                     response, self.coordinator, "values", self._metric_key, "off"
                 )
 
-            case "enable_sc_dhw" | "enable_sc_sh":
+            case "enable_sc_dhw" | "enable_sc_sh" | "vacation_mode":
                 response = await self.coordinator.api.update_setting(
                     self._hpid, self._metric_key, False
                 )
@@ -93,7 +94,7 @@ class QvantumSwitchEntity(QvantumEntity, SwitchEntity):
                     response, self.coordinator, "values", self._metric_key, "on"
                 )
 
-            case "enable_sc_dhw" | "enable_sc_sh":
+            case "enable_sc_dhw" | "enable_sc_sh" | "vacation_mode":
                 response = await self.coordinator.api.update_setting(
                     self._hpid, self._metric_key, True
                 )
@@ -143,6 +144,12 @@ class QvantumSwitchEntity(QvantumEntity, SwitchEntity):
                     and values.get("use_adaptive") is True
                     and self._has_write_access
                 )
+
+            case "vacation_mode":
+                if getattr(self.coordinator, "modbus_enabled", False):
+                    return False
+                return values.get("vacation_mode") is not None
+
             case _:
                 return (
                     values.get(self._metric_key) is not None

--- a/custom_components/qvantum/translations/cs.json
+++ b/custom_components/qvantum/translations/cs.json
@@ -26,6 +26,9 @@
       },
       "enable_sc_sh": {
         "name": "SmartControl: Topení"
+      },
+      "vacation_mode": {
+        "name": "Režim dovolené"
       }
     },
     "select": {

--- a/custom_components/qvantum/translations/da.json
+++ b/custom_components/qvantum/translations/da.json
@@ -26,6 +26,9 @@
       },
       "enable_sc_sh": {
         "name": "SmartControl: Opvarmning"
+      },
+      "vacation_mode": {
+        "name": "Ferietilstand"
       }
     },
     "select": {

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -26,6 +26,9 @@
       },
       "enable_sc_sh": {
         "name": "SmartControl: Heizung"
+      },
+      "vacation_mode": {
+        "name": "Urlaubsmodus"
       }
     },
     "select": {

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -26,6 +26,9 @@
       },
       "enable_sc_sh": {
         "name": "SmartControl: Heating"
+      },
+      "vacation_mode": {
+        "name": "Vacation mode"
       }
     },
     "select": {

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -26,6 +26,9 @@
       },
       "enable_sc_sh": {
         "name": "SmartControl: Calefacción"
+      },
+      "vacation_mode": {
+        "name": "Modo vacaciones"
       }
     },
     "select": {

--- a/custom_components/qvantum/translations/fi.json
+++ b/custom_components/qvantum/translations/fi.json
@@ -26,6 +26,9 @@
       },
       "enable_sc_sh": {
         "name": "SmartControl: Lämmitys"
+      },
+      "vacation_mode": {
+        "name": "Lomatila"
       }
     },
     "select": {

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -26,6 +26,9 @@
       },
       "enable_sc_sh": {
         "name": "Smart Control : chauffage"
+      },
+      "vacation_mode": {
+        "name": "Mode vacances"
       }
     },
     "select": {

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -26,6 +26,9 @@
       },
       "enable_sc_sh": {
         "name": "Intelligens vezérlés: fűtés"
+      },
+      "vacation_mode": {
+        "name": "Szabadság üzemmód"
       }
     },
     "select": {

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -26,6 +26,9 @@
       },
       "enable_sc_sh": {
         "name": "SmartControl: Verwarming"
+      },
+      "vacation_mode": {
+        "name": "Vakantiemodus"
       }
     },
     "select": {

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -26,6 +26,9 @@
       },
       "enable_sc_sh": {
         "name": "SmartControl: Ogrzewanie"
+      },
+      "vacation_mode": {
+        "name": "Tryb wakacyjny"
       }
     },
     "select": {

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -66,6 +66,9 @@
       },
       "enable_sc_sh": {
         "name": "SmartControl: Uppvärmning"
+      },
+      "vacation_mode": {
+        "name": "Semesterläge"
       }
     },
     "button": {

--- a/tests/test_switch_working.py
+++ b/tests/test_switch_working.py
@@ -40,13 +40,17 @@ with patch(
                     ):
                         from homeassistant.helpers.device_registry import DeviceInfo
 
-                        from custom_components.qvantum.switch import QvantumSwitchEntity
+                        from custom_components.qvantum.switch import (
+                            QvantumDataUpdateCoordinator,
+                            QvantumSwitchEntity,
+                        )
 
 
 @pytest.fixture
 def mock_coordinator():
     """Create a mock coordinator with test data."""
-    coordinator = MagicMock()
+    coordinator = MagicMock(spec=QvantumDataUpdateCoordinator)
+    coordinator.modbus_enabled = False
     coordinator.data = {
         "device": {"id": "test_device_123"},
         "values": {
@@ -122,6 +126,11 @@ class TestQvantumSwitchEntity:
         """Test switch entity initialization with op_man_addition icon."""
         entity = QvantumSwitchEntity(mock_coordinator, "op_man_addition", mock_device)
         assert entity._attr_icon == "mdi:transmission-tower-import"
+
+    def test_init_vacation_mode_icon(self, mock_coordinator, mock_device):
+        """Test switch entity initialization with vacation_mode icon."""
+        entity = QvantumSwitchEntity(mock_coordinator, "vacation_mode", mock_device)
+        assert entity._attr_icon == "mdi:palm-tree"
 
     def test_init_default_icon(self, mock_coordinator, mock_device):
         """Test switch entity initialization with unknown metric has no icon."""
@@ -448,6 +457,95 @@ class TestQvantumSwitchEntity:
         )
         # The method updates metrics
         assert mock_coordinator.data["values"]["enable_sc_sh"] is False
+        mock_coordinator.async_set_updated_data.assert_called_once_with(
+            mock_coordinator.data
+        )
+
+    def test_is_on_vacation_mode_off(self, mock_coordinator, mock_device):
+        """Test is_on when vacation_mode is 'off'."""
+        mock_coordinator.data["values"]["vacation_mode"] = "off"
+        entity = QvantumSwitchEntity(mock_coordinator, "vacation_mode", mock_device)
+        assert entity.is_on is False
+
+    def test_is_on_vacation_mode_on(self, mock_coordinator, mock_device):
+        """Test is_on when vacation_mode is 'on'."""
+        mock_coordinator.data["values"]["vacation_mode"] = "on"
+        entity = QvantumSwitchEntity(mock_coordinator, "vacation_mode", mock_device)
+        assert entity.is_on is True
+
+    def test_is_on_vacation_mode_bool(self, mock_coordinator, mock_device):
+        """Test is_on when vacation_mode is boolean."""
+        entity = QvantumSwitchEntity(mock_coordinator, "vacation_mode", mock_device)
+        mock_coordinator.data["values"]["vacation_mode"] = True
+        assert entity.is_on is True
+        mock_coordinator.data["values"]["vacation_mode"] = False
+        assert entity.is_on is False
+
+    def test_available_vacation_mode_available(self, mock_coordinator, mock_device):
+        """Test available for vacation_mode when data is present."""
+        mock_coordinator.data["values"]["vacation_mode"] = "off"
+        entity = QvantumSwitchEntity(mock_coordinator, "vacation_mode", mock_device)
+        assert entity.available is True
+
+    def test_available_vacation_mode_without_elevated_access(
+        self, mock_coordinator, mock_device
+    ):
+        """Test vacation_mode is available even without elevated write access (level 10)."""
+        mock_coordinator.data["values"]["vacation_mode"] = "off"
+        mock_coordinator.config_entry.runtime_data.maintenance_coordinator.data = {
+            "access_level": {"writeAccessLevel": 10}
+        }
+        entity = QvantumSwitchEntity(mock_coordinator, "vacation_mode", mock_device)
+        assert entity._has_write_access is False
+        assert entity.available is True
+
+    def test_available_vacation_mode_none(self, mock_coordinator, mock_device):
+        """Test available for vacation_mode when value is None."""
+        mock_coordinator.data["values"]["vacation_mode"] = None
+        entity = QvantumSwitchEntity(mock_coordinator, "vacation_mode", mock_device)
+        assert entity.available is False
+
+    def test_available_vacation_mode_modbus_unavailable(self, mock_coordinator, mock_device):
+        """Test vacation_mode is unavailable in Modbus mode (cloud-only write)."""
+        mock_coordinator.data["values"]["vacation_mode"] = "off"
+        mock_coordinator.modbus_enabled = True
+        entity = QvantumSwitchEntity(mock_coordinator, "vacation_mode", mock_device)
+        assert entity.available is False
+
+    @pytest.mark.asyncio
+    async def test_async_turn_on_vacation_mode(self, mock_coordinator, mock_device):
+        """Test turning on vacation_mode."""
+        entity = QvantumSwitchEntity(mock_coordinator, "vacation_mode", mock_device)
+
+        mock_coordinator.api.update_setting = AsyncMock(
+            return_value={"status": "APPLIED"}
+        )
+
+        await entity.async_turn_on()
+
+        mock_coordinator.api.update_setting.assert_called_once_with(
+            "test_device_123", "vacation_mode", True
+        )
+        assert mock_coordinator.data["values"]["vacation_mode"] is True
+        mock_coordinator.async_set_updated_data.assert_called_once_with(
+            mock_coordinator.data
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_turn_off_vacation_mode(self, mock_coordinator, mock_device):
+        """Test turning off vacation_mode."""
+        entity = QvantumSwitchEntity(mock_coordinator, "vacation_mode", mock_device)
+
+        mock_coordinator.api.update_setting = AsyncMock(
+            return_value={"status": "APPLIED"}
+        )
+
+        await entity.async_turn_off()
+
+        mock_coordinator.api.update_setting.assert_called_once_with(
+            "test_device_123", "vacation_mode", False
+        )
+        assert mock_coordinator.data["values"]["vacation_mode"] is False
         mock_coordinator.async_set_updated_data.assert_called_once_with(
             mock_coordinator.data
         )


### PR DESCRIPTION
## Summary
This PR adds support for the `vacation_mode` setting as a switch entity in the Qvantum integration.

### Details
- **Entity**: Implemented `vacation_mode` in `switch.py` with `mdi:palm-tree` icon.
- **Cloud API**: Sends boolean `True`/`False` to `update_settings` as expected by the Qvantum API.
- **User Access**: Available for standard users without requiring elevated technician access (`writeAccessLevel >= 20`), matching the official Qvantum mobile app where vacation mode can be toggled by any user.
- **Modbus**: Marked as cloud-only (`_CLOUD_ONLY_WRITE_METRICS`) since Modbus holding registers do not expose vacation mode.
- **Localization**: Added translations across all 11 supported languages.
- **Documentation**: Updated `README.md` (features list and cloud-only notice) and `AGENTS.md`.
- **Tests**: Added comprehensive unit test coverage in `tests/test_switch_working.py` covering icons, states, availability without elevated access, and Modbus unavailability.

### Testing
- Tested live against a Qvantum QE-6 heat pump running Home Assistant.
- Verified state toggle (`on` / `off`) reflects on the heat pump (verified heating curve offset adjusts from 0 to -4 and back to 0).