### PR TITLE
feat: Add outdoor temperature stop heating number entity for Modbus

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Cloud-only sensors (firmware boards and access expiry) are not created in this m
 > [!IMPORTANT]
 > Local Modbus is **read-only** until you enable writing. Writes never go to the cloud API.
 >
-> Supported local writes include indoor target/offset, DHW start/stop, extra DHW, fan preset, operation/manual switches, room compensation, fan speeds, extra-DHW stop, external room temperature, and indoor sensor source.
+> Supported local writes include indoor target/offset, DHW start/stop, extra DHW, fan preset, operation/manual switches, room compensation, fan speeds, extra-DHW stop, outdoor temperature stop heating, external room temperature, and indoor sensor source.
 >
 > **SmartControl** (`use_adaptive`, `enable_sc_sh`, `enable_sc_dhw`), **vacation mode**, and **elevate-access** stay cloud-only. They are unavailable in local mode.
 >

--- a/custom_components/qvantum/entity.py
+++ b/custom_components/qvantum/entity.py
@@ -107,6 +107,7 @@ _LOCAL_MODBUS_WRITE_METRICS = {
     "dhw_stop_extra",
     "room_temp_external",
     "use_operation_sensor",
+    "outdoor_stop_heating",
 }
 
 # No holding-register write exists for these; they stay cloud-only.
@@ -152,6 +153,7 @@ _ENTITY_ICONS: dict[str, str] = {
     "use_operation_sensor": "mdi:motion-sensor",
     # Number / writable temperature
     "room_temp_external": "mdi:thermometer",
+    "outdoor_stop_heating": "mdi:thermometer-off",
 }
 
 

--- a/custom_components/qvantum/modbus.py
+++ b/custom_components/qvantum/modbus.py
@@ -163,4 +163,5 @@ MODBUS_HOLDING_TO_SETTINGS_MAP = {
     "ventilation_state": "fanspeedselector",
     "dhw_stop_extra": "dhw_stop_extra",
     "room_temp_external": "room_temp_external",
+    "outdoor_stop_heating": "outdoor_stop_heating",
 }

--- a/custom_components/qvantum/number.py
+++ b/custom_components/qvantum/number.py
@@ -24,6 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 MODBUS_WRITE_METRICS = {
     "dhw_stop_extra",
     "room_temp_external",  # Written via Modbus and only relevant when the external room sensor mode is enabled.
+    "outdoor_stop_heating",  # Holding 18: outdoor temperature that stops heating.
 }
 
 
@@ -47,6 +48,7 @@ async def async_setup_entry(
         "fan_normal": (0, 100, 5),
         "fan_speed_2": (0, 100, 5),
         "room_temp_external": (10, 40, 0.1),
+        "outdoor_stop_heating": (-30, 30, 1),
     }
 
     # Only create number entities for metrics present in the coordinator's current data.
@@ -118,8 +120,8 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
                     self._hpid, self._metric_key, coordinator_update_value
                 )
 
-            case "dhw_stop_extra":
-                # dhw_stop_extra has no update_setting HTTP endpoint; write via Modbus holding register
+            case "dhw_stop_extra" | "outdoor_stop_heating":
+                # These settings have no update_setting HTTP endpoint; write via Modbus holding register.
                 if not self._is_modbus_write_allowed():
                     raise HomeAssistantError(
                         "Modbus writing is disabled. Turn on writing via Modbus in the integration options."

--- a/custom_components/qvantum/translations/cs.json
+++ b/custom_components/qvantum/translations/cs.json
@@ -510,6 +510,9 @@
       },
       "room_temp_external": {
         "name": "Externí vnitřní teplota"
+      },
+      "outdoor_stop_heating": {
+        "name": "Venkovní teplota zastavení topení"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/da.json
+++ b/custom_components/qvantum/translations/da.json
@@ -510,6 +510,9 @@
       },
       "room_temp_external": {
         "name": "Ekstern indetemperatur"
+      },
+      "outdoor_stop_heating": {
+        "name": "Udetemperatur stop opvarmning"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -510,6 +510,9 @@
       },
       "room_temp_external": {
         "name": "Externe Innentemperatur"
+      },
+      "outdoor_stop_heating": {
+        "name": "Außentemperatur Heizstopp"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -510,6 +510,9 @@
       },
       "room_temp_external": {
         "name": "External indoor temperature"
+      },
+      "outdoor_stop_heating": {
+        "name": "Outdoor temperature stop heating"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -510,6 +510,9 @@
       },
       "room_temp_external": {
         "name": "Temperatura interior externa"
+      },
+      "outdoor_stop_heating": {
+        "name": "Temperatura exterior de parada de calefacción"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/fi.json
+++ b/custom_components/qvantum/translations/fi.json
@@ -510,6 +510,9 @@
       },
       "room_temp_external": {
         "name": "Ulkoinen sisälämpötila"
+      },
+      "outdoor_stop_heating": {
+        "name": "Ulkolämpötila lämmityksen pysäytys"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -510,6 +510,9 @@
       },
       "room_temp_external": {
         "name": "Température intérieure externe"
+      },
+      "outdoor_stop_heating": {
+        "name": "Température extérieure d'arrêt du chauffage"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -510,6 +510,9 @@
       },
       "room_temp_external": {
         "name": "Külső beltéri hőmérséklet"
+      },
+      "outdoor_stop_heating": {
+        "name": "Kültéri hőmérséklet fűtésleállítás"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -510,6 +510,9 @@
       },
       "room_temp_external": {
         "name": "Externe binnentemperatuur"
+      },
+      "outdoor_stop_heating": {
+        "name": "Buitentemperatuur stop verwarming"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -510,6 +510,9 @@
       },
       "room_temp_external": {
         "name": "Zewnętrzna temperatura wewnętrzna"
+      },
+      "outdoor_stop_heating": {
+        "name": "Temperatura zewnętrzna wyłączenia ogrzewania"
       }
     },
     "climate": {

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -513,6 +513,9 @@
       },
       "room_temp_external": {
         "name": "Extern inomhustemperatur"
+      },
+      "outdoor_stop_heating": {
+        "name": "Utomhustemperatur stoppa värme"
       }
     },
     "climate": {

--- a/docs/modbus-feature-gap-analysis.md
+++ b/docs/modbus-feature-gap-analysis.md
@@ -113,6 +113,7 @@ If `modbus_write` is off, current local is **read-only**. Previous Modbus with w
 | `op_mode`, `man_mode`, `op_man_dhw`, `op_man_addition` | 1 / 2 / 5 / 4 | HTTP `update_settings` |
 | `room_comp_factor`, `fan_normal`, `fan_speed_2` | 13 / 70 / 69 | HTTP |
 | `dhw_stop_extra`, `room_temp_external`, sensor mode | 59 / 14 / 9 | Same as previous local writes |
+| `outdoor_stop_heating` | 18 | Number entity, Modbus-only |
 
 `start_cooling_temp` (38) is **readable** as a sensor; there is no number entity to write it.
 
@@ -153,7 +154,7 @@ The holding map includes many registers that are **not** in `MODBUS_HOLDING_TO_S
 
 - `unit_on_off` (0), `allow_cooling` (3)
 - `time_between_modes` (6), `allow_addition_temp` (7), `filtertime_outdoor` (8)
-- Heating: outdoor stop, min/max supply, curve type, temp compensation (18–23)
+- Heating: min/max supply, curve type, temp compensation (19–23)
 - Cooling: offset, dew point, min supply (36, 39, 40)
 - DHW: `dhw_start_extra` (58), `dhw_outlet_temp` (60), `dhw_uninterrupted_cooling` (61)
 - Pump speeds (63–66)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2149,3 +2149,18 @@ class TestWriteHoldingRegister:
 
         assert result == {"status": "APPLIED"}
         assert device.unit.holding[14] == 215
+
+    @pytest.mark.asyncio
+    async def test_write_holding_register_for_metric_outdoor_stop_heating(
+        self, mock_session
+    ):
+        """outdoor_stop_heating writes signed int16 to holding register 18."""
+        api = self._make_api(mock_session)
+        _connection, device = attach_mock_modbus(api)
+
+        result = await api.write_holding_register_for_metric(
+            "dev1", "outdoor_stop_heating", -15
+        )
+
+        assert result == {"status": "APPLIED"}
+        assert device.unit.holding[18] == 0xFFF1

--- a/tests/test_modbus_device.py
+++ b/tests/test_modbus_device.py
@@ -139,10 +139,12 @@ class TestComponentDecode:
         await device.write_metric("room_comp_factor", 2.5)
         await device.write_metric("room_temp_external", 21.5)
         await device.write_metric("dhw_stop_extra", 75)
+        await device.write_metric("outdoor_stop_heating", -15)
 
         assert unit.holding[13] == 25
         assert unit.holding[14] == 215
         assert unit.holding[59] == 75
+        assert unit.holding[18] == 0xFFF1  # int16 -15
 
     @pytest.mark.asyncio
     async def test_raw_holding_write(self):
@@ -298,3 +300,4 @@ class TestPayloadAdapter:
     def test_holding_field_for_http_alias(self):
         assert holding_field_for_metric("room_comp_factor") == "room_compensation"
         assert holding_field_for_metric("dhw_stop_extra") == "dhw_stop_extra"
+        assert holding_field_for_metric("outdoor_stop_heating") == "outdoor_stop_heating"

--- a/tests/test_number_working.py
+++ b/tests/test_number_working.py
@@ -711,3 +711,138 @@ class TestRoomTempExternal:
             await entity.async_set_native_value(21.5)
 
         mock_coordinator.api.write_holding_register_for_metric.assert_not_called()
+
+
+class TestOutdoorStopHeating:
+    """Tests for the outdoor_stop_heating number entity (Modbus holding 18)."""
+
+    def test_init_outdoor_stop_heating(self, mock_coordinator, mock_device):
+        """Test outdoor_stop_heating entity initialization."""
+        mock_coordinator.data["values"]["outdoor_stop_heating"] = 15
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": True,
+        }
+        entity = QvantumNumberEntity(
+            mock_coordinator, "outdoor_stop_heating", -30, 30, 1, mock_device
+        )
+
+        assert entity._metric_key == "outdoor_stop_heating"
+        assert entity._attr_native_min_value == -30
+        assert entity._attr_native_max_value == 30
+        assert entity._attr_native_step == 1
+        assert (
+            entity._attr_unique_id
+            == "qvantum_number_outdoor_stop_heating_test_device_123"
+        )
+        assert entity.state == 15
+
+    def test_available_when_modbus_write_enabled(
+        self, mock_coordinator, mock_device
+    ):
+        """Test entity is available when Modbus write is enabled."""
+        mock_coordinator.data["values"]["outdoor_stop_heating"] = 15
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": True,
+        }
+        entity = QvantumNumberEntity(
+            mock_coordinator, "outdoor_stop_heating", -30, 30, 1, mock_device
+        )
+        assert entity.available is True
+
+    def test_unavailable_when_modbus_write_disabled(
+        self, mock_coordinator, mock_device
+    ):
+        """Test entity is unavailable when Modbus write is disabled."""
+        mock_coordinator.data["values"]["outdoor_stop_heating"] = 15
+        mock_coordinator.config_entry.options = {}
+        mock_coordinator.config_entry.data = {}
+        entity = QvantumNumberEntity(
+            mock_coordinator, "outdoor_stop_heating", -30, 30, 1, mock_device
+        )
+        assert entity.available is False
+
+    def test_unavailable_when_modbus_tcp_disabled(
+        self, mock_coordinator, mock_device
+    ):
+        """Test entity is unavailable when Modbus TCP is disabled."""
+        mock_coordinator.data["values"]["outdoor_stop_heating"] = 15
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": False,
+        }
+        mock_coordinator.config_entry.data = {}
+        entity = QvantumNumberEntity(
+            mock_coordinator, "outdoor_stop_heating", -30, 30, 1, mock_device
+        )
+        assert entity.available is False
+
+    @pytest.mark.asyncio
+    async def test_async_set_native_value_outdoor_stop_heating(
+        self, mock_coordinator, mock_device
+    ):
+        """Test setting outdoor_stop_heating writes via Modbus holding register."""
+        mock_coordinator.data["values"]["outdoor_stop_heating"] = 15
+        mock_coordinator.config_entry.options = {
+            "modbus_write": True,
+            "modbus_tcp": True,
+        }
+        entity = QvantumNumberEntity(
+            mock_coordinator, "outdoor_stop_heating", -30, 30, 1, mock_device
+        )
+
+        mock_coordinator.api.write_holding_register_for_metric = AsyncMock(
+            return_value={"status": "APPLIED"}
+        )
+        mock_coordinator.api.update_setting = AsyncMock(
+            return_value={"status": "APPLIED"}
+        )
+
+        await entity.async_set_native_value(-5.0)
+
+        mock_coordinator.api.write_holding_register_for_metric.assert_called_once_with(
+            "test_device_123", "outdoor_stop_heating", -5
+        )
+        mock_coordinator.api.update_setting.assert_not_called()
+        assert mock_coordinator.data["values"]["outdoor_stop_heating"] == -5
+
+    @pytest.mark.asyncio
+    async def test_async_set_native_value_raises_when_write_disabled(
+        self, mock_coordinator, mock_device
+    ):
+        """Test that HomeAssistantError is raised when Modbus write is disabled."""
+        from homeassistant.exceptions import HomeAssistantError
+
+        mock_coordinator.data["values"]["outdoor_stop_heating"] = 15
+        mock_coordinator.config_entry.options = {}
+        mock_coordinator.config_entry.data = {}
+        entity = QvantumNumberEntity(
+            mock_coordinator, "outdoor_stop_heating", -30, 30, 1, mock_device
+        )
+        mock_coordinator.api.write_holding_register_for_metric = AsyncMock()
+
+        with pytest.raises(HomeAssistantError, match="Modbus writing is disabled"):
+            await entity.async_set_native_value(-5.0)
+
+        mock_coordinator.api.write_holding_register_for_metric.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_setup_entry_creates_outdoor_stop_heating(
+        self, hass, mock_config_entry, mock_coordinator, mock_device
+    ):
+        """Test setup creates the number when the holding value is present."""
+        from custom_components.qvantum import RuntimeData
+
+        mock_coordinator.modbus_enabled = True
+        mock_coordinator.data["values"]["outdoor_stop_heating"] = 18
+        mock_config_entry.runtime_data = RuntimeData(
+            coordinator=mock_coordinator, device=mock_device
+        )
+
+        async_add_entities = MagicMock()
+        await async_setup_entry(hass, mock_config_entry, async_add_entities)
+
+        entities = async_add_entities.call_args[0][0]
+        entity_keys = [entity._metric_key for entity in entities]
+        assert "outdoor_stop_heating" in entity_keys


### PR DESCRIPTION
## Summary

Adds a writable Home Assistant **number** entity for **Outdoor temperature stop heating** in Modbus mode.

The register was already in `MODBUS_HOLDING_REGISTER_MAP` but not exposed as an entity. This wires it through the same Modbus-only number path as `dhw_stop_extra`:
- Read via holding settings (`MODBUS_HOLDING_TO_SETTINGS_MAP`)
- Write via `write_holding_register_for_metric` when **Enable writing via Modbus** is on
- Unavailable when Modbus writing is off (no HTTP endpoint for this setting)

## Changes
- Number entity `outdoor_stop_heating` (-30..30, step 1)
- Translations for all locales
- README / gap-analysis note that holding 18 is now a local write
- Tests for entity setup, availability, signed writes to register 18

## Test plan
- [x] `pytest tests/` — 629 passed
- [ ] On a Modbus-connected pump with writing enabled, confirm `number.*_outdoor_stop_heating_*` appears, reads the current stop temperature, and a change is written to holding 18