### PR TITLE
feat: Add cloud support for outdoor temperature stop heating

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Cloud-only sensors (firmware boards and access expiry) are not created in this m
 > [!IMPORTANT]
 > Local Modbus is **read-only** until you enable writing. Writes never go to the cloud API.
 >
-> Supported local writes include indoor target/offset, DHW start/stop, extra DHW, fan preset, operation/manual switches, room compensation, fan speeds, extra-DHW stop, outdoor temperature stop heating, external room temperature, and indoor sensor source.
+> Supported local writes include indoor target/offset, DHW start/stop, extra DHW, fan preset, operation/manual switches, room compensation, fan speeds, extra-DHW stop, outdoor temperature stop heating (`stop_heating`), external room temperature, and indoor sensor source.
 >
 > **SmartControl** (`use_adaptive`, `enable_sc_sh`, `enable_sc_dhw`), **vacation mode**, and **elevate-access** stay cloud-only. They are unavailable in local mode.
 >

--- a/custom_components/qvantum/entity.py
+++ b/custom_components/qvantum/entity.py
@@ -107,7 +107,6 @@ _LOCAL_MODBUS_WRITE_METRICS = {
     "dhw_stop_extra",
     "room_temp_external",
     "use_operation_sensor",
-    "outdoor_stop_heating",
 }
 
 # No holding-register write exists for these; they stay cloud-only.
@@ -153,7 +152,7 @@ _ENTITY_ICONS: dict[str, str] = {
     "use_operation_sensor": "mdi:motion-sensor",
     # Number / writable temperature
     "room_temp_external": "mdi:thermometer",
-    "outdoor_stop_heating": "mdi:thermometer-off",
+    "stop_heating": "mdi:thermometer-off",
 }
 
 

--- a/custom_components/qvantum/modbus.py
+++ b/custom_components/qvantum/modbus.py
@@ -163,5 +163,5 @@ MODBUS_HOLDING_TO_SETTINGS_MAP = {
     "ventilation_state": "fanspeedselector",
     "dhw_stop_extra": "dhw_stop_extra",
     "room_temp_external": "room_temp_external",
-    "outdoor_stop_heating": "outdoor_stop_heating",
+    "outdoor_stop_heating": "stop_heating",
 }

--- a/custom_components/qvantum/number.py
+++ b/custom_components/qvantum/number.py
@@ -24,13 +24,12 @@ _LOGGER = logging.getLogger(__name__)
 MODBUS_WRITE_METRICS = {
     "dhw_stop_extra",
     "room_temp_external",  # Written via Modbus and only relevant when the external room sensor mode is enabled.
-    "outdoor_stop_heating",  # Holding 18: outdoor temperature that stops heating.
 }
 
 # Number metrics that represent temperatures (°C).
 TEMPERATURE_NUMBER_METRICS = frozenset(
     {
-        "outdoor_stop_heating",
+        "stop_heating",
         "indoor_temperature_offset",
         "tap_water_start",
         "tap_water_stop",
@@ -60,7 +59,7 @@ async def async_setup_entry(
         "fan_normal": (0, 100, 5),
         "fan_speed_2": (0, 100, 5),
         "room_temp_external": (10, 40, 0.1),
-        "outdoor_stop_heating": (-30, 30, 1),
+        "stop_heating": (-30, 30, 1),
     }
 
     # Only create number entities for metrics present in the coordinator's current data.
@@ -129,14 +128,14 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
                 response = await self.coordinator.api.set_tap_water(
                     self._hpid, start=coordinator_update_value
                 )
-            case "room_comp_factor" | "fan_normal" | "fan_speed_2":
+            case "room_comp_factor" | "fan_normal" | "fan_speed_2" | "stop_heating":
                 coordinator_update_value = int(value)
                 response = await self.coordinator.api.update_setting(
                     self._hpid, self._metric_key, coordinator_update_value
                 )
 
-            case "dhw_stop_extra" | "outdoor_stop_heating":
-                # These settings have no update_setting HTTP endpoint; write via Modbus holding register.
+            case "dhw_stop_extra":
+                # dhw_stop_extra has no update_setting HTTP endpoint; write via Modbus holding register.
                 if not self._is_modbus_write_allowed():
                     raise HomeAssistantError(
                         "Modbus writing is disabled. Turn on writing via Modbus in the integration options."

--- a/custom_components/qvantum/test_data/settings_test_device_123.json
+++ b/custom_components/qvantum/test_data/settings_test_device_123.json
@@ -43,6 +43,11 @@
       "name": "tap_water_start",
       "value": 52,
       "read_only": false
+    },
+    {
+      "name": "stop_heating",
+      "value": 18,
+      "read_only": false
     }
   ]
 }

--- a/custom_components/qvantum/translations/cs.json
+++ b/custom_components/qvantum/translations/cs.json
@@ -511,7 +511,7 @@
       "room_temp_external": {
         "name": "Externí vnitřní teplota"
       },
-      "outdoor_stop_heating": {
+      "stop_heating": {
         "name": "Venkovní teplota zastavení topení"
       }
     },

--- a/custom_components/qvantum/translations/da.json
+++ b/custom_components/qvantum/translations/da.json
@@ -511,7 +511,7 @@
       "room_temp_external": {
         "name": "Ekstern indetemperatur"
       },
-      "outdoor_stop_heating": {
+      "stop_heating": {
         "name": "Udetemperatur stop opvarmning"
       }
     },

--- a/custom_components/qvantum/translations/de.json
+++ b/custom_components/qvantum/translations/de.json
@@ -511,7 +511,7 @@
       "room_temp_external": {
         "name": "Externe Innentemperatur"
       },
-      "outdoor_stop_heating": {
+      "stop_heating": {
         "name": "Außentemperatur Heizstopp"
       }
     },

--- a/custom_components/qvantum/translations/en.json
+++ b/custom_components/qvantum/translations/en.json
@@ -511,7 +511,7 @@
       "room_temp_external": {
         "name": "External indoor temperature"
       },
-      "outdoor_stop_heating": {
+      "stop_heating": {
         "name": "Outdoor temperature stop heating"
       }
     },

--- a/custom_components/qvantum/translations/es.json
+++ b/custom_components/qvantum/translations/es.json
@@ -511,7 +511,7 @@
       "room_temp_external": {
         "name": "Temperatura interior externa"
       },
-      "outdoor_stop_heating": {
+      "stop_heating": {
         "name": "Temperatura exterior de parada de calefacción"
       }
     },

--- a/custom_components/qvantum/translations/fi.json
+++ b/custom_components/qvantum/translations/fi.json
@@ -511,7 +511,7 @@
       "room_temp_external": {
         "name": "Ulkoinen sisälämpötila"
       },
-      "outdoor_stop_heating": {
+      "stop_heating": {
         "name": "Ulkolämpötila lämmityksen pysäytys"
       }
     },

--- a/custom_components/qvantum/translations/fr.json
+++ b/custom_components/qvantum/translations/fr.json
@@ -511,7 +511,7 @@
       "room_temp_external": {
         "name": "Température intérieure externe"
       },
-      "outdoor_stop_heating": {
+      "stop_heating": {
         "name": "Température extérieure d'arrêt du chauffage"
       }
     },

--- a/custom_components/qvantum/translations/hu.json
+++ b/custom_components/qvantum/translations/hu.json
@@ -511,7 +511,7 @@
       "room_temp_external": {
         "name": "Külső beltéri hőmérséklet"
       },
-      "outdoor_stop_heating": {
+      "stop_heating": {
         "name": "Kültéri hőmérséklet fűtésleállítás"
       }
     },

--- a/custom_components/qvantum/translations/nl.json
+++ b/custom_components/qvantum/translations/nl.json
@@ -511,7 +511,7 @@
       "room_temp_external": {
         "name": "Externe binnentemperatuur"
       },
-      "outdoor_stop_heating": {
+      "stop_heating": {
         "name": "Buitentemperatuur stop verwarming"
       }
     },

--- a/custom_components/qvantum/translations/pl.json
+++ b/custom_components/qvantum/translations/pl.json
@@ -511,7 +511,7 @@
       "room_temp_external": {
         "name": "Zewnętrzna temperatura wewnętrzna"
       },
-      "outdoor_stop_heating": {
+      "stop_heating": {
         "name": "Temperatura zewnętrzna wyłączenia ogrzewania"
       }
     },

--- a/custom_components/qvantum/translations/sv.json
+++ b/custom_components/qvantum/translations/sv.json
@@ -514,7 +514,7 @@
       "room_temp_external": {
         "name": "Extern inomhustemperatur"
       },
-      "outdoor_stop_heating": {
+      "stop_heating": {
         "name": "Utomhustemperatur stoppa värme"
       }
     },

--- a/docs/modbus-feature-gap-analysis.md
+++ b/docs/modbus-feature-gap-analysis.md
@@ -113,7 +113,7 @@ If `modbus_write` is off, current local is **read-only**. Previous Modbus with w
 | `op_mode`, `man_mode`, `op_man_dhw`, `op_man_addition` | 1 / 2 / 5 / 4 | HTTP `update_settings` |
 | `room_comp_factor`, `fan_normal`, `fan_speed_2` | 13 / 70 / 69 | HTTP |
 | `dhw_stop_extra`, `room_temp_external`, sensor mode | 59 / 14 / 9 | Same as previous local writes |
-| `outdoor_stop_heating` | 18 | Number entity, Modbus-only |
+| `stop_heating` | 18 `outdoor_stop_heating` | HTTP setting `stop_heating` |
 
 `start_cooling_temp` (38) is **readable** as a sensor; there is no number entity to write it.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2164,3 +2164,18 @@ class TestWriteHoldingRegister:
 
         assert result == {"status": "APPLIED"}
         assert device.unit.holding[18] == 0xFFF1
+
+    @pytest.mark.asyncio
+    async def test_write_holding_register_for_metric_stop_heating_alias(
+        self, mock_session
+    ):
+        """HTTP setting stop_heating writes signed int16 to holding register 18."""
+        api = self._make_api(mock_session)
+        _connection, device = attach_mock_modbus(api)
+
+        result = await api.write_holding_register_for_metric(
+            "dev1", "stop_heating", -15
+        )
+
+        assert result == {"status": "APPLIED"}
+        assert device.unit.holding[18] == 0xFFF1

--- a/tests/test_modbus_device.py
+++ b/tests/test_modbus_device.py
@@ -139,7 +139,7 @@ class TestComponentDecode:
         await device.write_metric("room_comp_factor", 2.5)
         await device.write_metric("room_temp_external", 21.5)
         await device.write_metric("dhw_stop_extra", 75)
-        await device.write_metric("outdoor_stop_heating", -15)
+        await device.write_metric("stop_heating", -15)
 
         assert unit.holding[13] == 25
         assert unit.holding[14] == 215
@@ -291,6 +291,12 @@ class TestPayloadAdapter:
         assert settings["extra_tap_water"] == "on"
         assert settings["fanspeedselector"] == "extra"
 
+    def test_stop_heating_http_alias(self):
+        payload = build_settings_payload({"outdoor_stop_heating": 18})
+        settings = {item["name"]: item["value"] for item in payload["settings"]}
+        assert settings["stop_heating"] == 18
+        assert settings["outdoor_stop_heating"] == 18
+
     def test_unknown_metric_raises(self):
         with pytest.raises(
             ValueError, match="No Modbus holding register mapping found"
@@ -300,4 +306,5 @@ class TestPayloadAdapter:
     def test_holding_field_for_http_alias(self):
         assert holding_field_for_metric("room_comp_factor") == "room_compensation"
         assert holding_field_for_metric("dhw_stop_extra") == "dhw_stop_extra"
+        assert holding_field_for_metric("stop_heating") == "outdoor_stop_heating"
         assert holding_field_for_metric("outdoor_stop_heating") == "outdoor_stop_heating"

--- a/tests/test_number_working.py
+++ b/tests/test_number_working.py
@@ -734,131 +734,139 @@ class TestRoomTempExternal:
         mock_coordinator.api.write_holding_register_for_metric.assert_not_called()
 
 
-class TestOutdoorStopHeating:
-    """Tests for the outdoor_stop_heating number entity (Modbus holding 18)."""
+class TestStopHeating:
+    """Tests for the stop_heating number entity (HTTP setting / Modbus holding 18)."""
 
-    def test_init_outdoor_stop_heating(self, mock_coordinator, mock_device):
-        """Test outdoor_stop_heating entity initialization."""
-        mock_coordinator.data["values"]["outdoor_stop_heating"] = 15
-        mock_coordinator.config_entry.options = {
-            "modbus_write": True,
-            "modbus_tcp": True,
-        }
+    def test_init_stop_heating(self, mock_coordinator, mock_device):
+        """Test stop_heating entity initialization."""
+        mock_coordinator.modbus_enabled = False
+        mock_coordinator.data["values"]["stop_heating"] = 15
         entity = QvantumNumberEntity(
-            mock_coordinator, "outdoor_stop_heating", -30, 30, 1, mock_device
+            mock_coordinator, "stop_heating", -30, 30, 1, mock_device
         )
 
-        assert entity._metric_key == "outdoor_stop_heating"
+        assert entity._metric_key == "stop_heating"
         assert entity._attr_native_min_value == -30
         assert entity._attr_native_max_value == 30
         assert entity._attr_native_step == 1
-        assert (
-            entity._attr_unique_id
-            == "qvantum_number_outdoor_stop_heating_test_device_123"
-        )
+        assert entity._attr_unique_id == "qvantum_number_stop_heating_test_device_123"
         assert entity.state == 15
         assert entity._attr_native_unit_of_measurement == UnitOfTemperature.CELSIUS
         assert entity._attr_device_class == NumberDeviceClass.TEMPERATURE
 
-    def test_available_when_modbus_write_enabled(
-        self, mock_coordinator, mock_device
-    ):
-        """Test entity is available when Modbus write is enabled."""
-        mock_coordinator.data["values"]["outdoor_stop_heating"] = 15
-        mock_coordinator.config_entry.options = {
+    def test_available_in_cloud_mode(self, mock_coordinator, mock_device):
+        """Test entity is available in cloud mode when write access is granted."""
+        mock_coordinator.modbus_enabled = False
+        mock_coordinator.data["values"]["stop_heating"] = 15
+        entity = QvantumNumberEntity(
+            mock_coordinator, "stop_heating", -30, 30, 1, mock_device
+        )
+        assert entity.available is True
+
+    def test_available_when_modbus_write_enabled(self, mock_device):
+        """Test entity is available in Modbus mode when writing is enabled."""
+        from custom_components.qvantum.coordinator import QvantumDataUpdateCoordinator
+
+        coordinator = QvantumDataUpdateCoordinator.__new__(
+            QvantumDataUpdateCoordinator
+        )
+        coordinator.data = {
+            "values": {"stop_heating": 15, "hpid": "test_device_123"}
+        }
+        coordinator.modbus_enabled = True
+        coordinator.config_entry = MagicMock()
+        coordinator.config_entry.options = {
             "modbus_write": True,
             "modbus_tcp": True,
         }
+        coordinator.config_entry.data = {}
         entity = QvantumNumberEntity(
-            mock_coordinator, "outdoor_stop_heating", -30, 30, 1, mock_device
+            coordinator, "stop_heating", -30, 30, 1, mock_device
         )
         assert entity.available is True
 
     def test_unavailable_when_modbus_write_disabled(
         self, mock_coordinator, mock_device
     ):
-        """Test entity is unavailable when Modbus write is disabled."""
-        mock_coordinator.data["values"]["outdoor_stop_heating"] = 15
-        mock_coordinator.config_entry.options = {}
-        mock_coordinator.config_entry.data = {}
-        entity = QvantumNumberEntity(
-            mock_coordinator, "outdoor_stop_heating", -30, 30, 1, mock_device
-        )
-        assert entity.available is False
+        """Test entity is unavailable in Modbus mode when writing is disabled."""
+        from custom_components.qvantum.coordinator import QvantumDataUpdateCoordinator
 
-    def test_unavailable_when_modbus_tcp_disabled(
-        self, mock_coordinator, mock_device
-    ):
-        """Test entity is unavailable when Modbus TCP is disabled."""
-        mock_coordinator.data["values"]["outdoor_stop_heating"] = 15
-        mock_coordinator.config_entry.options = {
-            "modbus_write": True,
-            "modbus_tcp": False,
+        coordinator = QvantumDataUpdateCoordinator.__new__(
+            QvantumDataUpdateCoordinator
+        )
+        coordinator.data = {
+            "values": {"stop_heating": 15, "hpid": "test_device_123"}
         }
-        mock_coordinator.config_entry.data = {}
+        coordinator.modbus_enabled = True
+        coordinator.config_entry = MagicMock()
+        coordinator.config_entry.options = {}
+        coordinator.config_entry.data = {}
         entity = QvantumNumberEntity(
-            mock_coordinator, "outdoor_stop_heating", -30, 30, 1, mock_device
+            coordinator, "stop_heating", -30, 30, 1, mock_device
         )
         assert entity.available is False
 
     @pytest.mark.asyncio
-    async def test_async_set_native_value_outdoor_stop_heating(
+    async def test_async_set_native_value_cloud(
         self, mock_coordinator, mock_device
     ):
-        """Test setting outdoor_stop_heating writes via Modbus holding register."""
-        mock_coordinator.data["values"]["outdoor_stop_heating"] = 15
+        """Test setting stop_heating in cloud mode uses update_setting."""
+        mock_coordinator.modbus_enabled = False
+        mock_coordinator.data["values"]["stop_heating"] = 15
+        entity = QvantumNumberEntity(
+            mock_coordinator, "stop_heating", -30, 30, 1, mock_device
+        )
+
+        mock_coordinator.api.update_setting = AsyncMock(
+            return_value={"status": "APPLIED"}
+        )
+        mock_coordinator.api.write_holding_register_for_metric = AsyncMock()
+
+        await entity.async_set_native_value(-5.0)
+
+        mock_coordinator.api.update_setting.assert_called_once_with(
+            "test_device_123", "stop_heating", -5
+        )
+        mock_coordinator.api.write_holding_register_for_metric.assert_not_called()
+        assert mock_coordinator.data["values"]["stop_heating"] == -5
+
+    @pytest.mark.asyncio
+    async def test_async_set_native_value_modbus(
+        self, mock_coordinator, mock_device
+    ):
+        """Test setting stop_heating in Modbus mode uses update_setting (holding write)."""
+        mock_coordinator.modbus_enabled = True
+        mock_coordinator.data["values"]["stop_heating"] = 15
         mock_coordinator.config_entry.options = {
             "modbus_write": True,
             "modbus_tcp": True,
         }
         entity = QvantumNumberEntity(
-            mock_coordinator, "outdoor_stop_heating", -30, 30, 1, mock_device
+            mock_coordinator, "stop_heating", -30, 30, 1, mock_device
         )
 
-        mock_coordinator.api.write_holding_register_for_metric = AsyncMock(
-            return_value={"status": "APPLIED"}
-        )
         mock_coordinator.api.update_setting = AsyncMock(
             return_value={"status": "APPLIED"}
         )
+        mock_coordinator.api.write_holding_register_for_metric = AsyncMock()
 
         await entity.async_set_native_value(-5.0)
 
-        mock_coordinator.api.write_holding_register_for_metric.assert_called_once_with(
-            "test_device_123", "outdoor_stop_heating", -5
+        mock_coordinator.api.update_setting.assert_called_once_with(
+            "test_device_123", "stop_heating", -5
         )
-        mock_coordinator.api.update_setting.assert_not_called()
-        assert mock_coordinator.data["values"]["outdoor_stop_heating"] == -5
-
-    @pytest.mark.asyncio
-    async def test_async_set_native_value_raises_when_write_disabled(
-        self, mock_coordinator, mock_device
-    ):
-        """Test that HomeAssistantError is raised when Modbus write is disabled."""
-        from homeassistant.exceptions import HomeAssistantError
-
-        mock_coordinator.data["values"]["outdoor_stop_heating"] = 15
-        mock_coordinator.config_entry.options = {}
-        mock_coordinator.config_entry.data = {}
-        entity = QvantumNumberEntity(
-            mock_coordinator, "outdoor_stop_heating", -30, 30, 1, mock_device
-        )
-        mock_coordinator.api.write_holding_register_for_metric = AsyncMock()
-
-        with pytest.raises(HomeAssistantError, match="Modbus writing is disabled"):
-            await entity.async_set_native_value(-5.0)
-
         mock_coordinator.api.write_holding_register_for_metric.assert_not_called()
+        assert mock_coordinator.data["values"]["stop_heating"] == -5
 
     @pytest.mark.asyncio
-    async def test_async_setup_entry_creates_outdoor_stop_heating(
+    async def test_async_setup_entry_creates_stop_heating(
         self, hass, mock_config_entry, mock_coordinator, mock_device
     ):
-        """Test setup creates the number when the holding value is present."""
+        """Test setup creates the number when stop_heating is present."""
         from custom_components.qvantum import RuntimeData
 
-        mock_coordinator.modbus_enabled = True
-        mock_coordinator.data["values"]["outdoor_stop_heating"] = 18
+        mock_coordinator.modbus_enabled = False
+        mock_coordinator.data["values"]["stop_heating"] = 18
         mock_config_entry.runtime_data = RuntimeData(
             coordinator=mock_coordinator, device=mock_device
         )
@@ -868,4 +876,4 @@ class TestOutdoorStopHeating:
 
         entities = async_add_entities.call_args[0][0]
         entity_keys = [entity._metric_key for entity in entities]
-        assert "outdoor_stop_heating" in entity_keys
+        assert "stop_heating" in entity_keys


### PR DESCRIPTION
## Summary

Expose **Outdoor temperature stop heating** in Cloud/HTTP mode using the API setting name `stop_heating`.

The number entity is now keyed by `stop_heating` in both modes:
- **Cloud:** read from HTTP settings, write via `update_setting(..., "stop_heating", value)`
- **Modbus:** holding register 18 (`outdoor_stop_heating`) is aliased to `stop_heating`; `update_setting` still writes the holding register when Modbus writing is enabled

No config-entry / unique-id migration.

## Test plan
- [x] `pytest tests/` — 632 passed
- [ ] Cloud: confirm `number.*_stop_heating_*` appears from the `stop_heating` setting and a change is sent to the HTTP API
- [ ] Modbus: confirm the same entity still reads/writes holding 18