### PR TITLE
fix: Omit SmartControl entities in Modbus mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Cloud-only sensors (firmware boards and access expiry) are not created in this m
 >
 > Supported local writes include indoor target/offset, DHW start/stop, extra DHW, fan preset, operation/manual switches, room compensation, fan speeds, extra-DHW stop, outdoor temperature stop heating (`stop_heating`), external room temperature, and indoor sensor source.
 >
-> **SmartControl** (`use_adaptive`, `enable_sc_sh`, `enable_sc_dhw`), **vacation mode**, and **elevate-access** stay cloud-only. They are unavailable in local mode.
+> **SmartControl** (`use_adaptive`, `enable_sc_sh`, `enable_sc_dhw`) and **elevate-access** are not created in local Modbus mode. **Vacation mode** stays cloud-only.
 >
 > By enabling Modbus writing you accept full responsibility for values written to the pump. Incorrect or out-of-range values may void the warranty and/or affect lifecycle and performance.
 

--- a/custom_components/qvantum/select.py
+++ b/custom_components/qvantum/select.py
@@ -27,13 +27,23 @@ async def async_setup_entry(
     coordinator: QvantumDataUpdateCoordinator = config_entry.runtime_data.coordinator
     device: DeviceInfo = config_entry.runtime_data.device
 
+    values = coordinator.data.get("values", {})
     entities = []
-    if "use_adaptive" in coordinator.data.get("values", {}):
-        entities.append(QvantumSelectEntity(coordinator, "use_adaptive", device))
-    if "use_operation_sensor" in coordinator.data.get("values", {}):
-        entities.append(QvantumSelectEntity(coordinator, "use_operation_sensor", device))
+    select_keys = {"use_operation_sensor"}
+    if not coordinator.modbus_enabled:
+        select_keys.add("use_adaptive")
+        if "use_adaptive" in values:
+            entities.append(QvantumSelectEntity(coordinator, "use_adaptive", device))
+    if "use_operation_sensor" in values:
+        entities.append(
+            QvantumSelectEntity(coordinator, "use_operation_sensor", device)
+        )
 
     async_add_entities(entities)
+
+    from .entity import cleanup_disabled_entities
+
+    cleanup_disabled_entities(hass, coordinator, select_keys, "select")
 
     _LOGGER.debug("Setting up platform SELECT")
 

--- a/custom_components/qvantum/switch.py
+++ b/custom_components/qvantum/switch.py
@@ -30,10 +30,10 @@ async def async_setup_entry(
         "op_man_dhw",
         "op_man_addition",
         "man_mode",
-        "enable_sc_sh",
-        "enable_sc_dhw",
         "vacation_mode",
     ]
+    if not coordinator.modbus_enabled:
+        switch_names.extend(["enable_sc_sh", "enable_sc_dhw"])
 
     sensors = []
     for switch_name in switch_names:
@@ -41,6 +41,10 @@ async def async_setup_entry(
             sensors.append(QvantumSwitchEntity(coordinator, switch_name, device))
 
     async_add_entities(sensors)
+
+    from .entity import cleanup_disabled_entities
+
+    cleanup_disabled_entities(hass, coordinator, set(switch_names), "switch")
 
     _LOGGER.debug("Setting up platform SWITCH")
 

--- a/tests/test_select_working.py
+++ b/tests/test_select_working.py
@@ -42,6 +42,7 @@ with patch(
 def mock_coordinator():
     """Create a mock coordinator with test data."""
     coordinator = MagicMock()
+    coordinator.modbus_enabled = False
     coordinator.data = {
         "device": {"id": "test_device_123"},
         "values": {

--- a/tests/test_smartcontrol_setup.py
+++ b/tests/test_smartcontrol_setup.py
@@ -1,0 +1,104 @@
+"""SmartControl entities are cloud-only and omitted in Modbus mode."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from custom_components.qvantum import RuntimeData
+from custom_components.qvantum.select import async_setup_entry as setup_select
+from custom_components.qvantum.switch import async_setup_entry as setup_switch
+
+
+@pytest.fixture
+def mock_device():
+    return DeviceInfo(
+        identifiers={("qvantum", "qvantum-test_device_123")},
+        manufacturer="Qvantum",
+        model="QE-6",
+    )
+
+
+def _coordinator(*, modbus: bool):
+    coordinator = MagicMock()
+    coordinator.modbus_enabled = modbus
+    coordinator.data = {
+        "device": {"id": "test_device_123"},
+        "values": {
+            "hpid": "test_device_123",
+            "use_adaptive": True,
+            "enable_sc_sh": True,
+            "enable_sc_dhw": True,
+            "use_operation_sensor": 1,
+            "extra_tap_water": "off",
+            "op_mode": 1,
+            "op_man_dhw": 1,
+            "op_man_addition": 0,
+            "man_mode": 0,
+            "vacation_mode": False,
+        },
+    }
+    coordinator.config_entry = MagicMock()
+    coordinator.config_entry.runtime_data.maintenance_coordinator = MagicMock()
+    coordinator.config_entry.runtime_data.maintenance_coordinator.data = {
+        "access_level": {"writeAccessLevel": 20}
+    }
+    return coordinator
+
+
+@pytest.mark.asyncio
+async def test_cloud_setup_creates_smartcontrol_entities(
+    hass, mock_config_entry, mock_device
+):
+    coordinator = _coordinator(modbus=False)
+    mock_config_entry.runtime_data = RuntimeData(
+        coordinator=coordinator, device=mock_device
+    )
+
+    added = MagicMock()
+    with patch("custom_components.qvantum.entity.cleanup_disabled_entities") as cleanup:
+        await setup_select(hass, mock_config_entry, added)
+    assert {entity._metric_key for entity in added.call_args.args[0]} == {
+        "use_adaptive",
+        "use_operation_sensor",
+    }
+    assert cleanup.call_args.args[2] == {"use_adaptive", "use_operation_sensor"}
+    assert cleanup.call_args.args[3] == "select"
+
+    added = MagicMock()
+    with patch("custom_components.qvantum.entity.cleanup_disabled_entities") as cleanup:
+        await setup_switch(hass, mock_config_entry, added)
+    keys = {entity._metric_key for entity in added.call_args.args[0]}
+    assert {"enable_sc_sh", "enable_sc_dhw"}.issubset(keys)
+    assert "enable_sc_sh" in cleanup.call_args.args[2]
+    assert "enable_sc_dhw" in cleanup.call_args.args[2]
+    assert cleanup.call_args.args[3] == "switch"
+
+
+@pytest.mark.asyncio
+async def test_modbus_setup_omits_smartcontrol_entities(
+    hass, mock_config_entry, mock_device
+):
+    coordinator = _coordinator(modbus=True)
+    mock_config_entry.runtime_data = RuntimeData(
+        coordinator=coordinator, device=mock_device
+    )
+
+    added = MagicMock()
+    with patch("custom_components.qvantum.entity.cleanup_disabled_entities") as cleanup:
+        await setup_select(hass, mock_config_entry, added)
+    assert {entity._metric_key for entity in added.call_args.args[0]} == {
+        "use_operation_sensor"
+    }
+    assert "use_adaptive" not in cleanup.call_args.args[2]
+    assert cleanup.call_args.args[3] == "select"
+
+    added = MagicMock()
+    with patch("custom_components.qvantum.entity.cleanup_disabled_entities") as cleanup:
+        await setup_switch(hass, mock_config_entry, added)
+    keys = {entity._metric_key for entity in added.call_args.args[0]}
+    assert "enable_sc_sh" not in keys
+    assert "enable_sc_dhw" not in keys
+    assert "enable_sc_sh" not in cleanup.call_args.args[2]
+    assert "enable_sc_dhw" not in cleanup.call_args.args[2]
+    assert cleanup.call_args.args[3] == "switch"


### PR DESCRIPTION
## Summary
- Do not create the three SmartControl entities in local Modbus mode: `use_adaptive`, `enable_sc_sh`, and `enable_sc_dhw`.
- They stay in cloud HTTP mode.
- Switching to Modbus drops leftover SmartControl entities from the registry.

## Test plan
- [x] `./run-tests.sh` (633 passed)
- [ ] Cloud setup still shows SmartControl select/switches
- [ ] Local Modbus setup does not create them; leftover entities are removed after reconfigure