### PR TITLE
fix: Cancel extra-DHW restore timer when Extra is stopped

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Cloud-only sensors (firmware boards and access expiry) are not created in this m
 >
 > By enabling Modbus writing you accept full responsibility for values written to the pump. Incorrect or out-of-range values may void the warranty and/or affect lifecycle and performance.
 
-Extra DHW on local Modbus writes DHW mode Extra/Normal. Use the extra-DHW button (60 minutes) or `qvantum.extra_hot_water` with `minutes` (0–480). Home Assistant restores Normal when the timer ends, including after a restart. The extra-DHW timer entity (`tap_stop`) shows the end time. The extra switch without a duration stays Extra until you turn it off.
+Extra DHW on local Modbus writes DHW mode Extra/Normal. Use the extra-DHW button (60 minutes) or `qvantum.extra_hot_water` with `minutes` (0–480). Home Assistant restores Normal when the timer ends, including after a restart. The extra-DHW timer entity (`tap_stop`) shows the end time. If extra DHW is stopped on the heat pump or from the extra switch, that timer is cancelled. The extra switch without a duration stays Extra until you turn it off.
 
 Fan extra on local Modbus is a sticky preset. Cloud extra ventilation is a timed boost.
 

--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -3,6 +3,7 @@
 import aiohttp
 import asyncio
 import json
+import time
 from datetime import datetime, timedelta, timezone
 import logging
 from typing import Any, Optional
@@ -83,6 +84,7 @@ class QvantumAPI:
         self._closed = False
         self._extra_dhw_unsub = None
         self._extra_dhw_restore_at: float | None = None
+        self._extra_dhw_armed_at: float | None = None
         self._extra_dhw_store = None
         # Modbus-only mode never opens an HTTP session, even if a caller
         # injects one. Cloud mode owns a session unless a test injects it.
@@ -378,11 +380,18 @@ class QvantumAPI:
         """Cancel a pending extra-DHW restore callback."""
         unsub = self._extra_dhw_unsub
         self._extra_dhw_unsub = None
+        self._extra_dhw_armed_at = None
         if unsub:
             unsub()
         if clear_store:
             self._extra_dhw_restore_at = None
             self._persist_extra_dhw(None)
+
+    async def async_clear_extra_dhw_timer(self) -> None:
+        """Stop a pending extra-DHW restore because extra DHW is no longer active."""
+        self._cancel_extra_dhw_timer(clear_store=False)
+        self._extra_dhw_restore_at = None
+        await self.async_persist_extra_dhw(None)
 
     async def async_persist_extra_dhw(self, payload: dict | None) -> None:
         """Save or clear the extra-DHW restore deadline."""
@@ -429,6 +438,7 @@ class QvantumAPI:
         if not self.hass:
             return
         self._extra_dhw_restore_at = restore_at
+        self._extra_dhw_armed_at = time.monotonic()
         if persist:
             await self.async_persist_extra_dhw(
                 {"device_id": str(device_id), "restore_at": restore_at}
@@ -447,6 +457,7 @@ class QvantumAPI:
                 )
                 return
             self._extra_dhw_restore_at = None
+            self._extra_dhw_armed_at = None
             try:
                 await self.async_persist_extra_dhw(None)
             except Exception:
@@ -490,6 +501,7 @@ class QvantumAPI:
                 )
                 return
             self._extra_dhw_restore_at = None
+            self._extra_dhw_armed_at = None
             try:
                 await self.async_persist_extra_dhw(None)
             except Exception:
@@ -749,9 +761,7 @@ class QvantumAPI:
                 result = await self.write_holding_register_for_metric(
                     device_id, "extra_tap_water", DHW_MODE_EXTRA
                 )
-            self._cancel_extra_dhw_timer(clear_store=False)
-            self._extra_dhw_restore_at = None
-            await self.async_persist_extra_dhw(None)
+            await self.async_clear_extra_dhw_timer()
             return result
 
         # Capture current time once to ensure consistency across all code paths

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from datetime import datetime, timedelta
 from typing import Any, Callable, Optional
 from homeassistant.config_entries import ConfigEntry
@@ -22,6 +23,7 @@ from .const import (
     DEFAULT_DISABLED_MODBUS_METRICS,
     DEFAULT_MODBUS_SCAN_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
+    DHW_MODE_EXTRA,
     DOMAIN,
     FIRMWARE_KEYS,
     HP_STATUS_COOLING,
@@ -77,10 +79,33 @@ async def handle_setting_update_response(
     )
     if success and data_section and key is not None:
         coordinator.data.get(data_section)[key] = value
+        if key == "extra_tap_water":
+            _apply_extra_dhw_tap_stop(coordinator, coordinator.data.get(data_section), value)
         # async_set_updated_data is a synchronous method despite the name
         coordinator.async_set_updated_data(coordinator.data)
         return True
     return False
+
+
+def _is_extra_dhw_on(value: Any) -> bool:
+    """Return True when extra DHW is active (holding 53 Extra, or on/True)."""
+    return value in ("on", True, DHW_MODE_EXTRA)
+
+
+def _apply_extra_dhw_tap_stop(coordinator: Any, section: Any, extra_value: Any) -> None:
+    """Keep the extra-DHW timer sensor in sync with an optimistic extra DHW write."""
+    if not isinstance(section, dict):
+        return
+    if extra_value in ("off", False, 0):
+        section.pop("tap_stop", None)
+        return
+    if not _is_extra_dhw_on(extra_value):
+        return
+    restore_at = getattr(getattr(coordinator, "api", None), "_extra_dhw_restore_at", None)
+    if isinstance(restore_at, (int, float)):
+        section["tap_stop"] = int(restore_at)
+    elif restore_at is None:
+        section.pop("tap_stop", None)
 
 
 def _firmware_metadata_from_sw_version(sw_version: str | None) -> dict:
@@ -617,6 +642,33 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
                 values.get("tap_water_capacity_target", "none"),
             )
 
+    async def _sync_modbus_extra_dhw_timer(
+        self, values: dict[str, Any], *, poll_started: float
+    ) -> None:
+        """Cancel the HA extra-DHW restore timer when Modbus reports Extra is off.
+
+        Extra DHW can be stopped on the heat pump (display or its own timeout)
+        without going through ``set_extra_tap_water``. The local ``tap_stop``
+        sensor is the restore deadline, so it must be cleared too.
+
+        A poll that started before Extra was written must not cancel the timer
+        just scheduled for that write.
+        """
+        restore_at = getattr(self.api, "_extra_dhw_restore_at", None)
+        if not isinstance(restore_at, (int, float)):
+            return
+        extra = values.get("extra_tap_water")
+        if extra is None or _is_extra_dhw_on(extra):
+            values["tap_stop"] = int(restore_at)
+            return
+        armed_at = getattr(self.api, "_extra_dhw_armed_at", None)
+        if isinstance(armed_at, (int, float)) and armed_at > poll_started:
+            values["tap_stop"] = int(restore_at)
+            return
+        await self.api.async_clear_extra_dhw_timer()
+        values.pop("tap_stop", None)
+        _LOGGER.debug("Cleared extra-DHW restore timer; extra DHW is off")
+
     async def async_update_data(self):
         """Fetch data from API endpoint."""
         try:
@@ -640,6 +692,7 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
             )
 
             # Fetch metrics and settings concurrently for better performance
+            poll_started = time.monotonic()
             metrics_task = self.api.get_metrics(
                 device_id, enabled_metrics=enabled_metrics
             )
@@ -687,9 +740,8 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
             # Settings take precedence over metrics in case of conflicts
             values = {**metrics_dict, **settings_dict}
 
-            restore_at = getattr(self.api, "_extra_dhw_restore_at", None)
-            if self.modbus_enabled and isinstance(restore_at, (int, float)):
-                values["tap_stop"] = int(restore_at)
+            if self.modbus_enabled:
+                await self._sync_modbus_extra_dhw_timer(values, poll_started=poll_started)
 
             self._derive_tap_water_capacity(values)
 

--- a/docs/modbus-feature-gap-analysis.md
+++ b/docs/modbus-feature-gap-analysis.md
@@ -144,7 +144,7 @@ SmartControl **status** can still be **read** on Modbus (`smart_dhw_mode` 161, `
 | `tap_stop` sensor | Yes (cloud countdown) | Yes, from `_extra_dhw_restore_at` |
 | HA restart during the hour | Cloud still ends extra | Restore deadline is persisted; Normal is written when it expires |
 
-Turning `modbus_write` off cancels a pending restore timer.
+Turning `modbus_write` off cancels a pending restore timer. Extra DHW going off on the pump (or from the extra switch) also cancels the HA restore timer and clears `tap_stop`.
 
 ---
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -92,6 +92,95 @@ class TestHandleSettingUpdateResponse:
         coordinator.async_refresh.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_extra_tap_water_off_clears_tap_stop(self):
+        """Turning extra DHW off must drop the extra-DHW timer sensor immediately."""
+        coordinator = MagicMock()
+        coordinator.data = {
+            "values": {"extra_tap_water": "on", "tap_stop": 1712232000}
+        }
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.api = MagicMock()
+        coordinator.api._extra_dhw_restore_at = 1712232000.0
+
+        result = await handle_setting_update_response(
+            {"status": "APPLIED"}, coordinator, "values", "extra_tap_water", "off"
+        )
+
+        assert result is True
+        assert coordinator.data["values"]["extra_tap_water"] == "off"
+        assert "tap_stop" not in coordinator.data["values"]
+
+    @pytest.mark.asyncio
+    async def test_extra_tap_water_on_sets_tap_stop_from_restore(self):
+        """Timed extra DHW should surface tap_stop from the restore deadline."""
+        coordinator = MagicMock()
+        coordinator.data = {"values": {"extra_tap_water": "off"}}
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.api = MagicMock()
+        coordinator.api._extra_dhw_restore_at = 1712232000.7
+
+        result = await handle_setting_update_response(
+            {"status": "APPLIED"}, coordinator, "values", "extra_tap_water", "on"
+        )
+
+        assert result is True
+        assert coordinator.data["values"]["tap_stop"] == 1712232000
+
+    @pytest.mark.asyncio
+    async def test_extra_tap_water_on_indefinite_clears_tap_stop(self):
+        """Indefinite extra DHW has no restore timer, so tap_stop is cleared."""
+        coordinator = MagicMock()
+        coordinator.data = {
+            "values": {"extra_tap_water": "off", "tap_stop": 1712232000}
+        }
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.api = MagicMock()
+        coordinator.api._extra_dhw_restore_at = None
+
+        result = await handle_setting_update_response(
+            {"status": "APPLIED"}, coordinator, "values", "extra_tap_water", "on"
+        )
+
+        assert result is True
+        assert "tap_stop" not in coordinator.data["values"]
+
+    @pytest.mark.asyncio
+    async def test_extra_tap_water_false_clears_tap_stop(self):
+        """Boolean/integer extra-off values also drop tap_stop."""
+        coordinator = MagicMock()
+        coordinator.data = {
+            "values": {"extra_tap_water": "on", "tap_stop": 1712232000}
+        }
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.api = MagicMock()
+        coordinator.api._extra_dhw_restore_at = 1712232000.0
+
+        result = await handle_setting_update_response(
+            {"status": "APPLIED"}, coordinator, "values", "extra_tap_water", False
+        )
+
+        assert result is True
+        assert "tap_stop" not in coordinator.data["values"]
+
+    @pytest.mark.asyncio
+    async def test_extra_tap_water_unknown_leaves_tap_stop(self):
+        """Unrecognized extra DHW values must not touch tap_stop."""
+        coordinator = MagicMock()
+        coordinator.data = {
+            "values": {"extra_tap_water": "on", "tap_stop": 1712232000}
+        }
+        coordinator.async_set_updated_data = MagicMock()
+        coordinator.api = MagicMock()
+        coordinator.api._extra_dhw_restore_at = 1712232000.0
+
+        result = await handle_setting_update_response(
+            {"status": "APPLIED"}, coordinator, "values", "extra_tap_water", "unknown"
+        )
+
+        assert result is True
+        assert coordinator.data["values"]["tap_stop"] == 1712232000
+
+    @pytest.mark.asyncio
     async def test_handle_setting_update_no_data_section(self):
         """Test setting update with no data section."""
         coordinator = MagicMock()
@@ -717,6 +806,99 @@ class TestQvantumDataUpdateCoordinator:
         await coordinator.async_update_data()
 
         mock_api.get_http_metrics.assert_not_called()
+
+
+class TestModbusExtraDhwTimerSync:
+    """Cancel the HA extra-DHW restore timer when Modbus reports Extra is off."""
+
+    def _make_coordinator(self, mock_super_init, extra_tap_water, restore_at, armed_at):
+        mock_super_init.return_value = None
+
+        mock_api = MagicMock()
+        mock_api.async_probe_identity = AsyncMock(
+            return_value={"id": "test_device_123"}
+        )
+        mock_api.get_metrics = AsyncMock(
+            return_value={"metrics": {"hpid": "test_device_123"}}
+        )
+        mock_api.get_settings = AsyncMock(
+            return_value={
+                "settings": [{"name": "extra_tap_water", "value": extra_tap_water}]
+            }
+        )
+        mock_api.get_http_metrics = AsyncMock()
+        mock_api._extra_dhw_restore_at = restore_at
+        mock_api._extra_dhw_armed_at = armed_at
+        mock_api.async_clear_extra_dhw_timer = AsyncMock()
+
+        mock_hass = MagicMock()
+        mock_hass.data = {
+            DOMAIN: mock_api,
+            "device_registry": MagicMock(),
+            "entity_registry": MagicMock(),
+        }
+
+        mock_config_entry = MagicMock()
+        mock_config_entry.options.get.side_effect = _modbus_options_get
+        mock_config_entry.data = {}
+        mock_config_entry.unique_id = "test_device_123"
+
+        coordinator = QvantumDataUpdateCoordinator(mock_hass, mock_config_entry)
+        coordinator.api = mock_api
+        coordinator.hass = mock_hass
+        return coordinator, mock_api
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_extra_on_keeps_restore_timer(self, mock_super_init):
+        coordinator, mock_api = self._make_coordinator(
+            mock_super_init, "on", 1712232000.0, 0.0
+        )
+
+        result = await coordinator.async_update_data()
+
+        mock_api.async_clear_extra_dhw_timer.assert_not_awaited()
+        assert result["values"]["tap_stop"] == 1712232000
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_extra_off_clears_restore_timer(self, mock_super_init):
+        coordinator, mock_api = self._make_coordinator(
+            mock_super_init, "off", 1712232000.0, 0.0
+        )
+
+        result = await coordinator.async_update_data()
+
+        mock_api.async_clear_extra_dhw_timer.assert_awaited_once()
+        assert "tap_stop" not in result["values"]
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_stale_off_poll_keeps_just_armed_timer(self, mock_super_init):
+        """A poll started before Extra was written must not cancel that timer."""
+        import time
+
+        coordinator, mock_api = self._make_coordinator(
+            mock_super_init, "off", 1712232000.0, time.monotonic() + 60
+        )
+
+        result = await coordinator.async_update_data()
+
+        mock_api.async_clear_extra_dhw_timer.assert_not_awaited()
+        assert result["values"]["tap_stop"] == 1712232000
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_unknown_extra_keeps_restore_timer(self, mock_super_init):
+        coordinator, mock_api = self._make_coordinator(
+            mock_super_init, None, 1712232000.0, 0.0
+        )
+        mock_api.get_settings = AsyncMock(return_value={"settings": []})
+
+        result = await coordinator.async_update_data()
+
+        mock_api.async_clear_extra_dhw_timer.assert_not_awaited()
+        assert result["values"]["tap_stop"] == 1712232000
 
 
 class TestHpStatusPostProcessing:

--- a/tests/test_modbus_writes.py
+++ b/tests/test_modbus_writes.py
@@ -148,6 +148,7 @@ class TestExtraTapWaterModbus:
         later.assert_called_once()
         assert later.call_args.args[1] == pytest.approx(3600, abs=1)
         assert api._extra_dhw_unsub is unsub
+        assert api._extra_dhw_armed_at is not None
 
     @pytest.mark.asyncio
     async def test_off_cancels_pending_timer(self):
@@ -162,6 +163,26 @@ class TestExtraTapWaterModbus:
             await api.set_extra_tap_water("dev1", 0)
         unsub.assert_called_once()
         assert api._extra_dhw_unsub is None
+        assert api._extra_dhw_armed_at is None
+
+    @pytest.mark.asyncio
+    async def test_clear_extra_dhw_timer_drops_deadline(self):
+        api = _modbus_api()
+        store = MagicMock()
+        store.async_remove = AsyncMock()
+        api._extra_dhw_store = store
+        unsub = MagicMock()
+        api._extra_dhw_unsub = unsub
+        api._extra_dhw_restore_at = 123.0
+        api._extra_dhw_armed_at = 1.0
+
+        await api.async_clear_extra_dhw_timer()
+
+        unsub.assert_called_once()
+        store.async_remove.assert_awaited_once()
+        assert api._extra_dhw_unsub is None
+        assert api._extra_dhw_restore_at is None
+        assert api._extra_dhw_armed_at is None
 
     @pytest.mark.asyncio
     async def test_close_cancels_timer(self):
@@ -344,6 +365,7 @@ class TestExtraTapWaterModbus:
         store.async_remove.assert_awaited()
         assert order == ["write", "remove"]
         assert api._extra_dhw_restore_at is None
+        assert api._extra_dhw_armed_at is None
 
     @pytest.mark.asyncio
     async def test_restore_timer_keeps_deadline_when_expired_write_fails(self):
@@ -403,6 +425,7 @@ class TestExtraTapWaterModbus:
         store.async_remove.assert_awaited()
         assert order == ["write", "remove"]
         assert api._extra_dhw_restore_at is None
+        assert api._extra_dhw_armed_at is None
 
     @pytest.mark.asyncio
     async def test_restore_callback_keeps_store_when_write_fails(self):

--- a/tests/test_switch_working.py
+++ b/tests/test_switch_working.py
@@ -323,6 +323,8 @@ class TestQvantumSwitchEntity:
         mock_coordinator.api.set_extra_tap_water = AsyncMock(
             return_value={"status": "APPLIED"}
         )
+        mock_coordinator.api._extra_dhw_restore_at = 1712232000.0
+        mock_coordinator.data["values"]["tap_stop"] = 1712232000
 
         await entity.async_turn_off()
 
@@ -333,6 +335,7 @@ class TestQvantumSwitchEntity:
         mock_coordinator.async_set_updated_data.assert_called_once()
         updated_data = mock_coordinator.async_set_updated_data.call_args[0][0]
         assert updated_data["values"]["extra_tap_water"] == "off"
+        assert "tap_stop" not in updated_data["values"]
         # No immediate refresh to avoid overwriting the update
 
     @pytest.mark.asyncio


### PR DESCRIPTION
In Modbus mode, extra DHW can be stopped on the heat pump (display or the pump's own timeout) without going through `set_extra_tap_water`. The Home Assistant restore timer and `tap_stop` sensor kept running until the deadline, so HA still showed a countdown after extra DHW was already off.

## Changes
- Cancel the persisted extra-DHW restore timer when a Modbus poll reports Extra is off, and drop `tap_stop`.
- Turning extra DHW off from the extra switch clears `tap_stop` immediately, without waiting for the next poll.
- Ignore a stale poll that started before Extra was written, so it cannot cancel a timer that was just armed.
- Timed extra DHW now surfaces `tap_stop` from the restore deadline as soon as Extra is turned on.

## Tests
- Coordinator: Extra off clears the restore timer; Extra on keeps it; in-flight stale off does not cancel a just-armed timer.
- Switch: turning extra DHW off removes `tap_stop` from coordinator data.
- API: `async_clear_extra_dhw_timer` drops the deadline and armed timestamp.