### PR TITLE
docs: Add agent Git workflow to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,14 @@ This document outlines the AI agents, assistants, and tools that contributed to 
 
 ## Repository Management
 
+### Git workflow
+When a task is complete:
+1. Create a feature branch (never commit directly to main/master).
+2. Commit with a clear message.
+3. Push the branch.
+4. Open a PR against the default branch with `gh pr create`.
+Do not ask for permission for these steps.
+
 ### Git Operations
 - Branch management and merging
 - Commit message standardization

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ This document outlines the AI agents, assistants, and tools that contributed to 
 
 ### Git workflow
 When a task is complete:
-1. Create a feature branch form latest main (never commit directly to main/master).
+1. Create a feature branch from latest main (never commit directly to main/master).
 2. Commit with a clear message.
 3. Push the branch.
 4. Open a PR against the default branch with `gh pr create`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ This document outlines the AI agents, assistants, and tools that contributed to 
 
 ### Git workflow
 When a task is complete:
-1. Create a feature branch (never commit directly to main/master).
+1. Create a feature branch form latest main (never commit directly to main/master).
 2. Commit with a clear message.
 3. Push the branch.
 4. Open a PR against the default branch with `gh pr create`.


### PR DESCRIPTION
## Summary
- Add a Git workflow section to `AGENTS.md` so agents finish work on a feature branch, push it, and open a PR with `gh pr create`.
- Do not commit directly to main/master, and do not ask for permission for these steps.

## Test plan
- [ ] Confirm `AGENTS.md` renders the numbered Git workflow under Repository Management.