### PR TITLE
fix: Stop requesting tap_water_start/stop as HTTP metrics

### DIFF
--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -176,15 +176,15 @@ DEFAULT_DISABLED_MODBUS_METRICS = [
     "time_to_defrost",  # should be interpreted as binary (defrosting vs not) rather than a continuous time value
 ]
 
-# Metrics that must always be fetched regardless of entity enablement (HTTP and Modbus)
+# Metrics that must always be fetched regardless of entity enablement (HTTP and Modbus).
+# tap_water_start/stop are settings (HTTP settings API / Modbus holdings), not /values
+# metrics. Requesting them as HTTP metrics logs "Metric X not found in response data".
 REQUIRED_METRICS = [
     "bt2",  # Required by climate component for current temperature
     "man_mode",  # Required by switch component
     "op_man_addition",  # Required by switch component
     "op_man_dhw",  # Required by switch component
     "op_mode",  # Required by switch components for availability checks
-    "tap_water_stop",  # Required by number component
-    "tap_water_start",  # Required by number component
     "smart_sh_mode",  # Required by select component
     "smart_dhw_mode",  # Required by select component
     "use_adaptive",  # Required by select component and switch components

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -363,6 +363,9 @@ class TestQvantumDataUpdateCoordinator:
         assert set(result) == expected_metrics
         # Extra hot water stop timestamp must be fetched in HTTP mode
         assert "tap_stop" in result
+        # tap_water_start/stop come from the settings endpoint, not HTTP /values
+        assert "tap_water_start" not in result
+        assert "tap_water_stop" not in result
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     def test_get_enabled_metrics_no_matching_entities(self, mock_super_init):
@@ -628,8 +631,57 @@ class TestQvantumDataUpdateCoordinator:
 
         enabled_metrics = mock_api.get_metrics.await_args.kwargs["enabled_metrics"]
         assert "tap_stop" in enabled_metrics
+        assert "tap_water_start" not in enabled_metrics
+        assert "tap_water_stop" not in enabled_metrics
         assert result["values"]["tap_stop"] == 1712232000
         mock_api.get_http_metrics.assert_not_called()
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_async_update_data_http_tap_water_from_settings(self, mock_super_init):
+        """HTTP tap_water_start/stop come from settings, not the metrics query."""
+        mock_super_init.return_value = None
+
+        mock_api = MagicMock()
+        mock_api.get_primary_device = AsyncMock(return_value={"id": "test_device_123"})
+        mock_api.get_metrics = AsyncMock(
+            return_value={"metrics": {"hpid": "test_device_123"}}
+        )
+        mock_api.get_settings = AsyncMock(
+            return_value={
+                "settings": [
+                    {"name": "tap_water_start", "value": 52},
+                    {"name": "tap_water_stop", "value": 62},
+                ]
+            }
+        )
+
+        mock_hass = MagicMock()
+        mock_hass.data = {
+            DOMAIN: mock_api,
+            "device_registry": MagicMock(),
+            "entity_registry": MagicMock(),
+        }
+
+        mock_config_entry = MagicMock()
+        mock_config_entry.options.get.side_effect = lambda key, default=None: (
+            120 if key == CONF_SCAN_INTERVAL else default
+        )
+        mock_config_entry.data = {}
+        mock_config_entry.unique_id = "test_device_123"
+
+        coordinator = QvantumDataUpdateCoordinator(mock_hass, mock_config_entry)
+        coordinator.api = mock_api
+        coordinator.hass = mock_hass
+        coordinator.modbus_enabled = False
+
+        result = await coordinator.async_update_data()
+
+        enabled_metrics = mock_api.get_metrics.await_args.kwargs["enabled_metrics"]
+        assert "tap_water_start" not in enabled_metrics
+        assert "tap_water_stop" not in enabled_metrics
+        assert result["values"]["tap_water_start"] == 52
+        assert result["values"]["tap_water_stop"] == 62
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `tap_water_start` and `tap_water_stop` are settings (HTTP settings API / Modbus holding registers), not `/values` metrics.
- They were listed in `REQUIRED_METRICS`, so HTTP mode asked the values endpoint for them on every poll and logged `Metric tap_water_start not found in response data.` (same for `_stop`).
- Number entities still get the values from the settings response; they are just no longer requested as HTTP metrics.

Fixes #195

## Test plan
- [x] `pytest tests/` — 644 passed
- [x] Coordinator tests assert HTTP enabled metrics do not include `tap_water_start`/`tap_water_stop`
- [x] Coordinator test asserts those keys still appear in `values` from settings