### PR TITLE
fix: Stop using deprecated device_registry.devices mapping

### DIFF
--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -343,21 +343,12 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
         if registry is None:
             return None
 
-        devices = getattr(registry, "devices", None)
-        if devices is None:
+        entry_id = getattr(self._config_entry, "entry_id", None)
+        if not entry_id:
             return None
 
-        entry_id = getattr(self._config_entry, "entry_id", None)
-        values = devices.values() if hasattr(devices, "values") else devices
         prefix = f"{DOMAIN}-"
-        for ha_device in values:
-            config_entries = getattr(ha_device, "config_entries", None)
-            if (
-                entry_id
-                and config_entries is not None
-                and entry_id not in config_entries
-            ):
-                continue
+        for ha_device in dr.async_entries_for_config_entry(registry, entry_id):
             identifiers = getattr(ha_device, "identifiers", None) or set()
             for identifier in identifiers:
                 if not isinstance(identifier, (tuple, list)) or len(identifier) != 2:
@@ -487,8 +478,9 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
 
     def _get_enabled_metrics(self, device_id: str) -> list[str]:
         """Get list of enabled metrics for a device based on entity registry."""
-        from homeassistant.helpers import device_registry as dr
         from homeassistant.helpers import entity_registry as er
+
+        from .entity import async_get_qvantum_device_entry, extract_metric_key
 
         default_metrics = (
             DEFAULT_ENABLED_MODBUS_METRICS
@@ -496,24 +488,21 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
             else DEFAULT_ENABLED_HTTP_METRICS
         )
 
-        device_registry = dr.async_get(self.hass)
-        device_reg_id = None
-        for device in device_registry.devices.values():
-            if (DOMAIN, f"qvantum-{device_id}") in device.identifiers:
-                device_reg_id = device.id
-                break
-        if device_reg_id:
+        device_entry = async_get_qvantum_device_entry(
+            self.hass,
+            device_id,
+            getattr(self._config_entry, "entry_id", None),
+        )
+        if device_entry:
             registry = er.async_get(self.hass)
             enabled_metrics = set()
             known_metrics = set()
-            for entity in registry.entities.values():
-                if (
-                    entity.device_id == device_reg_id
-                    and entity.unique_id.startswith("qvantum_")
-                    and entity.unique_id.endswith(f"_{device_id}")
+            for entity in er.async_entries_for_device(
+                registry, device_entry.id, include_disabled_entities=True
+            ):
+                if entity.unique_id.startswith("qvantum_") and entity.unique_id.endswith(
+                    f"_{device_id}"
                 ):
-                    from .entity import extract_metric_key
-
                     metric_key = extract_metric_key(entity.unique_id, device_id)
 
                     # Known metrics include the default metrics always.

--- a/custom_components/qvantum/entity.py
+++ b/custom_components/qvantum/entity.py
@@ -257,6 +257,32 @@ def extract_metric_key(unique_id: str, device_id: str) -> str:
     return unique_id[len(prefix) : len(unique_id) - len(suffix)]
 
 
+def async_get_qvantum_device_entry(
+    hass: HomeAssistant,
+    device_id: str | None,
+    config_entry_id: str | None,
+):
+    """Return the device registry entry for a Qvantum heat pump, if registered.
+
+    Looks the device up by identifier, scoped to the owning config entry.
+    """
+    from homeassistant.helpers import device_registry as dr
+
+    if not device_id or not config_entry_id:
+        return None
+    return dr.async_get(hass).async_get_device_by_identifier(
+        (DOMAIN, f"qvantum-{device_id}"), config_entry_id
+    )
+
+
+def _coordinator_config_entry_id(coordinator: QvantumDataUpdateCoordinator) -> str | None:
+    """Return the config entry id that owns this coordinator, if known."""
+    config_entry = getattr(coordinator, "config_entry", None) or getattr(
+        coordinator, "_config_entry", None
+    )
+    return getattr(config_entry, "entry_id", None)
+
+
 def cleanup_disabled_entities(
     hass: HomeAssistant,
     coordinator: QvantumDataUpdateCoordinator,
@@ -265,28 +291,27 @@ def cleanup_disabled_entities(
 ) -> None:
     """Clean up disabled entities that are no longer supported in the current mode."""
     from homeassistant.helpers import entity_registry as er
-    from homeassistant.helpers import device_registry as dr
+
+    device_entry = async_get_qvantum_device_entry(
+        hass, coordinator.device_id, _coordinator_config_entry_id(coordinator)
+    )
+    if not device_entry:
+        return
 
     entity_registry = er.async_get(hass)
-    device_registry = dr.async_get(hass)
-    device_reg_id = None
-    for dev in device_registry.devices.values():
-        if (DOMAIN, f"qvantum-{coordinator.device_id}") in dev.identifiers:
-            device_reg_id = dev.id
-            break
-    if device_reg_id:
-        entities_to_remove = []
-        for entity_entry in entity_registry.entities.values():
-            if (
-                entity_entry.device_id == device_reg_id
-                and entity_entry.domain == domain
-                and entity_entry.unique_id.startswith("qvantum_")
-                and entity_entry.unique_id.endswith(f"_{coordinator.device_id}")
-            ):
-                metric_key = extract_metric_key(
-                    entity_entry.unique_id, coordinator.device_id
-                )
-                if metric_key not in possible_metrics:
-                    entities_to_remove.append(entity_entry.entity_id)
-        for entity_id in entities_to_remove:
-            entity_registry.async_remove(entity_id)
+    entities_to_remove = []
+    for entity_entry in er.async_entries_for_device(
+        entity_registry, device_entry.id, include_disabled_entities=True
+    ):
+        if (
+            entity_entry.domain == domain
+            and entity_entry.unique_id.startswith("qvantum_")
+            and entity_entry.unique_id.endswith(f"_{coordinator.device_id}")
+        ):
+            metric_key = extract_metric_key(
+                entity_entry.unique_id, coordinator.device_id
+            )
+            if metric_key not in possible_metrics:
+                entities_to_remove.append(entity_entry.entity_id)
+    for entity_id in entities_to_remove:
+        entity_registry.async_remove(entity_id)

--- a/custom_components/qvantum/maintenance_coordinator.py
+++ b/custom_components/qvantum/maintenance_coordinator.py
@@ -216,13 +216,14 @@ The firmware has been automatically updated. No action is required.
         """Update the device registry with current firmware versions."""
         try:
             device_registry = async_get(self.hass)
-
-            # Find the device entry
-            device_entry = None
-            for device in device_registry.devices.values():
-                if (DOMAIN, f"qvantum-{device_id}") in device.identifiers:
-                    device_entry = device
-                    break
+            config_entry_id = getattr(self.config_entry, "entry_id", None)
+            device_entry = (
+                device_registry.async_get_device_by_identifier(
+                    (DOMAIN, f"qvantum-{device_id}"), config_entry_id
+                )
+                if config_entry_id
+                else None
+            )
 
             if not device_entry:
                 _LOGGER.debug("Device entry not found for device %s", device_id)

--- a/tests/test_binary_sensor_working.py
+++ b/tests/test_binary_sensor_working.py
@@ -164,7 +164,7 @@ async def test_async_setup_entry(
 
     # Mock the device registry
     mock_device_registry = MagicMock()
-    mock_device_registry.devices.values.return_value = []
+    mock_device_registry.async_get_device_by_identifier.return_value = None
     hass.data["device_registry"] = mock_device_registry
 
     mock_config_entry.runtime_data = RuntimeData(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -248,7 +248,7 @@ class TestQvantumDataUpdateCoordinator:
         mock_device = MagicMock()
         mock_device.id = "device_id_123"
         mock_device.identifiers = {(DOMAIN, "qvantum-test_device")}
-        mock_device_registry.devices.values.return_value = [mock_device]
+        mock_device_registry.async_get_device_by_identifier.return_value = mock_device
 
         # Mock entities
         mock_entity1 = MagicMock()
@@ -266,7 +266,7 @@ class TestQvantumDataUpdateCoordinator:
         mock_entity3.disabled_by = "user"
         mock_entity3.unique_id = "qvantum_bt4_test_device"
 
-        mock_entity_registry.entities.values.return_value = [
+        mock_entity_registry.entities.get_entries_for_device_id.return_value = [
             mock_entity1,
             mock_entity2,
             mock_entity3,
@@ -307,7 +307,7 @@ class TestQvantumDataUpdateCoordinator:
         mock_device = MagicMock()
         mock_device.id = "device_id_123"
         mock_device.identifiers = {(DOMAIN, "qvantum-test_device")}
-        mock_device_registry.devices.values.return_value = [mock_device]
+        mock_device_registry.async_get_device_by_identifier.return_value = mock_device
 
         # Disabled HTTP metric in entity registry already; should stay out of final metrics
         mock_entity_disabled = MagicMock()
@@ -315,7 +315,9 @@ class TestQvantumDataUpdateCoordinator:
         mock_entity_disabled.disabled_by = "user"
         mock_entity_disabled.unique_id = "qvantum_calc_suppy_cpr_test_device"
 
-        mock_entity_registry.entities.values.return_value = [mock_entity_disabled]
+        mock_entity_registry.entities.get_entries_for_device_id.return_value = [
+            mock_entity_disabled
+        ]
 
         mock_hass.data = {
             DOMAIN: mock_api,
@@ -343,7 +345,7 @@ class TestQvantumDataUpdateCoordinator:
         mock_hass = MagicMock()
         mock_device_registry = MagicMock()
         mock_api = MagicMock()
-        mock_device_registry.devices.values.return_value = []
+        mock_device_registry.async_get_device_by_identifier.return_value = None
 
         mock_hass.data = {DOMAIN: mock_api, "device_registry": mock_device_registry}
 
@@ -380,7 +382,7 @@ class TestQvantumDataUpdateCoordinator:
         mock_device = MagicMock()
         mock_device.id = "device_id_123"
         mock_device.identifiers = {(DOMAIN, "qvantum-test_device")}
-        mock_device_registry.devices.values.return_value = [mock_device]
+        mock_device_registry.async_get_device_by_identifier.return_value = mock_device
 
         # Mock entities that don't match our criteria
         mock_entity = MagicMock()
@@ -388,7 +390,9 @@ class TestQvantumDataUpdateCoordinator:
         mock_entity.disabled_by = None
         mock_entity.unique_id = "other_prefix_test_device"  # Wrong prefix
 
-        mock_entity_registry.entities.values.return_value = [mock_entity]
+        mock_entity_registry.entities.get_entries_for_device_id.return_value = [
+            mock_entity
+        ]
 
         mock_hass.data = {
             DOMAIN: mock_api,
@@ -422,14 +426,16 @@ class TestQvantumDataUpdateCoordinator:
         mock_device = MagicMock()
         mock_device.id = "device_id_123"
         mock_device.identifiers = {(DOMAIN, "qvantum-test_device")}
-        mock_device_registry.devices.values.return_value = [mock_device]
+        mock_device_registry.async_get_device_by_identifier.return_value = mock_device
 
         mock_entity = MagicMock()
         mock_entity.device_id = "device_id_123"
         mock_entity.disabled_by = None
         mock_entity.unique_id = "qvantum_bt1_test_device"
 
-        mock_entity_registry.entities.values.return_value = [mock_entity]
+        mock_entity_registry.entities.get_entries_for_device_id.return_value = [
+            mock_entity
+        ]
 
         mock_hass.data = {
             DOMAIN: mock_api,
@@ -459,14 +465,16 @@ class TestQvantumDataUpdateCoordinator:
         mock_device = MagicMock()
         mock_device.id = "device_id_123"
         mock_device.identifiers = {(DOMAIN, "qvantum-test_device")}
-        mock_device_registry.devices.values.return_value = [mock_device]
+        mock_device_registry.async_get_device_by_identifier.return_value = mock_device
 
         mock_entity_registry = MagicMock()
         mock_entity = MagicMock()
         mock_entity.device_id = "device_id_123"
         mock_entity.unique_id = "qvantum_inputcurrent1_test_device"
         mock_entity.disabled_by = None
-        mock_entity_registry.entities.values.return_value = [mock_entity]
+        mock_entity_registry.entities.get_entries_for_device_id.return_value = [
+            mock_entity
+        ]
 
         mock_hass = MagicMock()
         mock_hass.data = {
@@ -3391,11 +3399,13 @@ class TestDeviceLookupWhenHttpDown:
         ha_device.sw_version = "1.3.6/140/140"
 
         mock_registry = MagicMock()
-        mock_registry.devices.values.return_value = [ha_device]
 
         with patch(
             "homeassistant.helpers.device_registry.async_get",
             return_value=mock_registry,
+        ), patch(
+            "homeassistant.helpers.device_registry.async_entries_for_config_entry",
+            return_value=[ha_device],
         ):
             result = await coordinator.async_update_data()
 
@@ -3549,11 +3559,13 @@ class TestDeviceLookupWhenHttpDown:
         ha_device.sw_version = "1.3.6/140/140"
 
         mock_registry = MagicMock()
-        mock_registry.devices.values.return_value = [ha_device]
 
         with patch(
             "homeassistant.helpers.device_registry.async_get",
             return_value=mock_registry,
+        ), patch(
+            "homeassistant.helpers.device_registry.async_entries_for_config_entry",
+            return_value=[ha_device],
         ):
             with pytest.raises(UpdateFailed):
                 await coordinator.async_update_data()
@@ -3585,11 +3597,13 @@ class TestDeviceLookupWhenHttpDown:
         ha_device.sw_version = "1.3.6/140/140"
 
         mock_registry = MagicMock()
-        mock_registry.devices.values.return_value = [ha_device]
 
         with patch(
             "homeassistant.helpers.device_registry.async_get",
             return_value=mock_registry,
+        ), patch(
+            "homeassistant.helpers.device_registry.async_entries_for_config_entry",
+            return_value=[ha_device],
         ):
             result = await coordinator.async_update_data()
 
@@ -3648,15 +3662,10 @@ class TestDeviceLookupWhenHttpDown:
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     def test_device_from_registry_skips_unusable_entries(self, mock_super_init):
-        """Registry fallback must ignore devices that are not this config entry."""
+        """Registry fallback must ignore unusable identifiers and missing registry."""
         coordinator, _ = self._make_coordinator(mock_super_init, modbus=True)
 
-        other_entry = MagicMock()
-        other_entry.config_entries = {"other_entry"}
-        other_entry.identifiers = {(DOMAIN, "qvantum-other")}
-
         bad_identifier = MagicMock()
-        bad_identifier.config_entries = {"test_entry_id"}
         bad_identifier.identifiers = {
             "not-a-tuple",
             (DOMAIN,),
@@ -3667,11 +3676,13 @@ class TestDeviceLookupWhenHttpDown:
         }
 
         mock_registry = MagicMock()
-        mock_registry.devices.values.return_value = [other_entry, bad_identifier]
 
         with patch(
             "homeassistant.helpers.device_registry.async_get",
             return_value=mock_registry,
+        ), patch(
+            "homeassistant.helpers.device_registry.async_entries_for_config_entry",
+            return_value=[bad_identifier],
         ):
             assert coordinator._device_from_registry() is None
 
@@ -3687,11 +3698,10 @@ class TestDeviceLookupWhenHttpDown:
         ):
             assert coordinator._device_from_registry() is None
 
-        empty_registry = MagicMock()
-        empty_registry.devices = None
+        coordinator._config_entry.entry_id = None
         with patch(
             "homeassistant.helpers.device_registry.async_get",
-            return_value=empty_registry,
+            return_value=mock_registry,
         ):
             assert coordinator._device_from_registry() is None
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,8 +1,13 @@
 """Tests for qvantum entity helpers."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from custom_components.qvantum.entity import QvantumAccessMixin, QvantumEntity
+from custom_components.qvantum.entity import (
+    QvantumAccessMixin,
+    QvantumEntity,
+    async_get_qvantum_device_entry,
+    cleanup_disabled_entities,
+)
 from custom_components.qvantum.const import DOMAIN
 
 
@@ -245,3 +250,94 @@ def test_resolve_device_id_from_coordinator_values():
     device = {}
 
     assert dummy._resolve_device_id(device) == "test_device_456"
+
+
+def test_async_get_qvantum_device_entry_looks_up_by_identifier():
+    """Device lookup must use the config-entry-scoped identifier helper."""
+    hass = MagicMock()
+    mock_registry = MagicMock()
+    mock_device = MagicMock()
+    mock_registry.async_get_device_by_identifier.return_value = mock_device
+
+    with patch(
+        "homeassistant.helpers.device_registry.async_get", return_value=mock_registry
+    ):
+        assert (
+            async_get_qvantum_device_entry(hass, "pump-1", "entry-1") is mock_device
+        )
+
+    mock_registry.async_get_device_by_identifier.assert_called_once_with(
+        (DOMAIN, "qvantum-pump-1"), "entry-1"
+    )
+    assert async_get_qvantum_device_entry(hass, None, "entry-1") is None
+    assert async_get_qvantum_device_entry(hass, "pump-1", None) is None
+
+
+def test_cleanup_disabled_entities_removes_unsupported_metrics():
+    """Stale entities for a known device are removed; current metrics stay."""
+    hass = MagicMock()
+    coordinator = MagicMock()
+    coordinator.device_id = "pump-1"
+    coordinator.config_entry.entry_id = "entry-1"
+
+    device_entry = MagicMock()
+    device_entry.id = "ha-device-1"
+
+    keep = MagicMock()
+    keep.domain = "sensor"
+    keep.unique_id = "qvantum_bt1_pump-1"
+    keep.entity_id = "sensor.qvantum_bt1"
+
+    stale = MagicMock()
+    stale.domain = "sensor"
+    stale.unique_id = "qvantum_obsolete_pump-1"
+    stale.entity_id = "sensor.qvantum_obsolete"
+
+    other_domain = MagicMock()
+    other_domain.domain = "switch"
+    other_domain.unique_id = "qvantum_obsolete_pump-1"
+    other_domain.entity_id = "switch.qvantum_obsolete"
+
+    mock_entity_registry = MagicMock()
+    mock_entity_registry.entities.get_entries_for_device_id.return_value = [
+        keep,
+        stale,
+        other_domain,
+    ]
+
+    with (
+        patch(
+            "custom_components.qvantum.entity.async_get_qvantum_device_entry",
+            return_value=device_entry,
+        ),
+        patch(
+            "homeassistant.helpers.entity_registry.async_get",
+            return_value=mock_entity_registry,
+        ),
+    ):
+        cleanup_disabled_entities(hass, coordinator, {"bt1"}, "sensor")
+
+    mock_entity_registry.async_remove.assert_called_once_with("sensor.qvantum_obsolete")
+
+
+def test_cleanup_disabled_entities_skips_when_device_missing():
+    """Cleanup is a no-op when the heat pump is not in the device registry."""
+    hass = MagicMock()
+    coordinator = MagicMock()
+    coordinator.device_id = "pump-1"
+    coordinator.config_entry.entry_id = "entry-1"
+    mock_entity_registry = MagicMock()
+
+    with (
+        patch(
+            "custom_components.qvantum.entity.async_get_qvantum_device_entry",
+            return_value=None,
+        ),
+        patch(
+            "homeassistant.helpers.entity_registry.async_get",
+            return_value=mock_entity_registry,
+        ),
+    ):
+        cleanup_disabled_entities(hass, coordinator, {"bt1"}, "sensor")
+
+    mock_entity_registry.async_remove.assert_not_called()

--- a/tests/test_maintenance_coordinator.py
+++ b/tests/test_maintenance_coordinator.py
@@ -349,7 +349,9 @@ class TestQvantumMaintenanceCoordinator:
         mock_device_entry = MagicMock()
         mock_device_entry.id = "device_id_123"
         mock_device_entry.identifiers = {("qvantum", "qvantum-test_device_123")}
-        mock_device_registry.devices.values.return_value = [mock_device_entry]
+        mock_device_registry.async_get_device_by_identifier.return_value = (
+            mock_device_entry
+        )
         mock_device_registry.async_update_device = MagicMock()
 
         with patch(
@@ -372,7 +374,7 @@ class TestQvantumMaintenanceCoordinator:
         """Test device registry update when device is not found."""
         # Mock device registry with no matching device
         mock_device_registry = MagicMock()
-        mock_device_registry.devices.values.return_value = []
+        mock_device_registry.async_get_device_by_identifier.return_value = None
 
         with patch(
             "custom_components.qvantum.maintenance_coordinator.async_get",
@@ -403,7 +405,9 @@ class TestQvantumMaintenanceCoordinator:
         mock_device_registry = MagicMock()
         mock_device_entry = MagicMock()
         mock_device_entry.id = "device_id_123"
-        mock_device_registry.devices.values.return_value = [mock_device_entry]
+        mock_device_registry.async_get_device_by_identifier.return_value = (
+            mock_device_entry
+        )
 
         with patch(
             "custom_components.qvantum.maintenance_coordinator.async_get",
@@ -432,7 +436,9 @@ class TestQvantumMaintenanceCoordinator:
 
         # Mock device registry to raise an exception
         mock_device_registry = MagicMock()
-        mock_device_registry.devices.values.side_effect = Exception("Registry error")
+        mock_device_registry.async_get_device_by_identifier.side_effect = Exception(
+            "Registry error"
+        )
 
         with patch(
             "custom_components.qvantum.maintenance_coordinator.async_get",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -406,7 +406,7 @@ class TestSensorSetup:
     def mock_device_registry(self):
         """Mock device registry."""
         registry = MagicMock()
-        registry.devices.values.return_value = []
+        registry.async_get_device_by_identifier.return_value = None
         return registry
 
     @pytest.fixture


### PR DESCRIPTION
## Summary
Home Assistant 2026.8 warns when a custom integration treats `device_registry.devices` as a mapping (`devices.values()`, `.get()`, etc.). That mapping surface is removed in 2027.9.

This replaces those lookups with the supported helpers:

- `DeviceRegistry.async_get_device_by_identifier()` for a known Qvantum identifier, scoped to the config entry
- `device_registry.async_entries_for_config_entry()` when recovering device identity after a restart
- `entity_registry.async_entries_for_device()` (including disabled entities) when enumerating entities for that device

Call sites: `cleanup_disabled_entities`, `_get_enabled_metrics`, `_device_from_registry`, and firmware version updates on the maintenance coordinator.

## Test plan
- [x] `pytest tests/` — 652 passed, 90.71% coverage
- [ ] Confirm the HA log no longer contains `uses device_registry.devices as a mapping` after reload