### PR TITLE
fix: Request stop_heating in REQUIRED_METRICS for HTTP cloud mode

### DIFF
--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -203,6 +203,7 @@ REQUIRED_METRICS = [
     "room_comp_factor",  # Required by number component
     "fan_normal",  # Required by number component
     "fan_speed_2",  # Required by number component
+    "stop_heating",  # Required by number component
     "enable_sc_dhw",
     "enable_sc_sh",
     "compressorenergy",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -363,6 +363,8 @@ class TestQvantumDataUpdateCoordinator:
         assert set(result) == expected_metrics
         # Extra hot water stop timestamp must be fetched in HTTP mode
         assert "tap_stop" in result
+        # stop_heating is required by the number entity in HTTP mode
+        assert "stop_heating" in result
         # tap_water_start/stop come from the settings endpoint, not HTTP /values
         assert "tap_water_start" not in result
         assert "tap_water_stop" not in result
@@ -682,6 +684,44 @@ class TestQvantumDataUpdateCoordinator:
         assert "tap_water_stop" not in enabled_metrics
         assert result["values"]["tap_water_start"] == 52
         assert result["values"]["tap_water_stop"] == 62
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    @pytest.mark.asyncio
+    async def test_async_update_data_http_stop_heating(self, mock_super_init):
+        """HTTP stop_heating is requested in metrics and populated into values."""
+        mock_super_init.return_value = None
+
+        mock_api = MagicMock()
+        mock_api.get_primary_device = AsyncMock(return_value={"id": "test_device_123"})
+        mock_api.get_metrics = AsyncMock(
+            return_value={"metrics": {"hpid": "test_device_123", "stop_heating": 16}}
+        )
+        mock_api.get_settings = AsyncMock(return_value={"settings": []})
+
+        mock_hass = MagicMock()
+        mock_hass.data = {
+            DOMAIN: mock_api,
+            "device_registry": MagicMock(),
+            "entity_registry": MagicMock(),
+        }
+
+        mock_config_entry = MagicMock()
+        mock_config_entry.options.get.side_effect = lambda key, default=None: (
+            120 if key == CONF_SCAN_INTERVAL else default
+        )
+        mock_config_entry.data = {}
+        mock_config_entry.unique_id = "test_device_123"
+
+        coordinator = QvantumDataUpdateCoordinator(mock_hass, mock_config_entry)
+        coordinator.api = mock_api
+        coordinator.hass = mock_hass
+        coordinator.modbus_enabled = False
+
+        result = await coordinator.async_update_data()
+
+        enabled_metrics = mock_api.get_metrics.await_args.kwargs["enabled_metrics"]
+        assert "stop_heating" in enabled_metrics
+        assert result["values"]["stop_heating"] == 16
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     @pytest.mark.asyncio


### PR DESCRIPTION
## Description

PR #189 added cloud support for writing `stop_heating` and added it to `NUMBER_CONFIG` in `number.py`. However, `stop_heating` was omitted from `REQUIRED_METRICS` in `const.py`.

In real-world usage, Qvantum's cloud settings endpoint (`GET /settings`) only returns consumer settings and does not include `stop_heating`. As a result, in HTTP cloud mode:
1. `coordinator._get_enabled_metrics()` never requested `stop_heating` from the internal metrics endpoint (`/values`).
2. `coordinator.data["values"]` was never populated with `stop_heating`.
3. `number.py` skipped creating the entity due to `if metric in coordinator.data.get("values", {})`.

Even though `GET /settings` omits `stop_heating`, Qvantum's internal metrics endpoint (`GET /values?names[]=stop_heating`) **does** provide the live value, and the device accepts updates to it via `update_setting` (when write access level is granted).

This PR:
- Adds `"stop_heating"` to `REQUIRED_METRICS` in `const.py` alongside other number metrics (`room_comp_factor`, `fan_normal`, `fan_speed_2`).
- Adds coordinator unit tests verifying that `stop_heating` is included in enabled metrics in HTTP mode and populated into `values`.

## Testing
- All 650 unit tests pass with 90.38% coverage.
- Verified on a real Qvantum QE6 device in Home Assistant Core: the entity `number.<device>_utomhustemperatur_stoppa_varme` is created, reads the live setpoint, and successfully writes adjustments back to the heat pump via the cloud API.