### PR TITLE
feat: Expose remaining picpin relay bits as binary sensors

### DIFF
--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -330,7 +330,12 @@ BINARY_SENSOR_NAMES = [
     "picpin_relay_heat_l1",
     "picpin_relay_heat_l2",
     "picpin_relay_heat_l3",
+    "picpin_relay_gp10",
     "picpin_relay_qm10",
+    "picpin_relay_qn8_1",
+    "picpin_relay_qn8_2",
+    "picpin_relay_gp3",
+    "picpin_relay_ha12",
     "dhwdemand",
     "heatingdemand",
     "coolingdemand",
@@ -349,8 +354,10 @@ BINARY_SENSOR_NAMES = [
 ]
 
 # Read-only on Modbus (input 170). HTTP keeps the writable vacation_mode switch.
+# picpin_relay_pump is bit 8 of input 33; HTTP has no equivalent metric.
 MODBUS_ONLY_BINARY_SENSORS = [
     "vacation_mode",
+    "picpin_relay_pump",
 ]
 
 # Sensor filtering: substring patterns vs exact binary-sensor metric names.
@@ -363,3 +370,14 @@ EXCLUDED_METRIC_PATTERNS = [
     "use_",
 ]
 EXCLUDED_METRIC_NAMES = frozenset(BINARY_SENSOR_NAMES + MODBUS_ONLY_BINARY_SENSORS)
+
+
+def default_metric_creates_entity(metric: str) -> bool:
+    """Return True if a default-enabled metric can appear in the entity registry.
+
+    Numeric sensors skip EXCLUDED_METRIC_PATTERNS. Binary sensors are created
+    anyway and are listed in EXCLUDED_METRIC_NAMES.
+    """
+    if metric in EXCLUDED_METRIC_NAMES:
+        return True
+    return not any(pattern in metric for pattern in EXCLUDED_METRIC_PATTERNS)

--- a/custom_components/qvantum/coordinator.py
+++ b/custom_components/qvantum/coordinator.py
@@ -40,6 +40,7 @@ from .const import (
     CONF_MODBUS_TCP,
     HTTP_CLOUD_LOOKUP_TIMEOUT,
     TAP_WATER_CAPACITY_MAPPINGS,
+    default_metric_creates_entity,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -546,11 +547,12 @@ class QvantumDataUpdateCoordinator(QvantumCalculationsMixin, DataUpdateCoordinat
                 for metric in default_metrics:
                     if metric not in known_metrics:
                         final_metrics.add(metric)
-                        _LOGGER.debug(
-                            "Adding new default metric '%s' for device %s since it's not in the registry",
-                            metric,
-                            device_id,
-                        )
+                        if default_metric_creates_entity(metric):
+                            _LOGGER.debug(
+                                "Adding new default metric '%s' for device %s since it's not in the registry",
+                                metric,
+                                device_id,
+                            )
 
             _LOGGER.debug(
                 "Final enabled metrics for device %s: %s",

--- a/custom_components/qvantum/entity.py
+++ b/custom_components/qvantum/entity.py
@@ -144,6 +144,13 @@ _ENTITY_ICONS: dict[str, str] = {
     "picpin_relay_heat_l1": "mdi:transmission-tower-import",
     "picpin_relay_heat_l2": "mdi:transmission-tower-import",
     "picpin_relay_heat_l3": "mdi:transmission-tower-import",
+    "picpin_relay_gp10": "mdi:pump",
+    "picpin_relay_qm10": "mdi:valve",
+    "picpin_relay_qn8_1": "mdi:valve",
+    "picpin_relay_qn8_2": "mdi:valve",
+    "picpin_relay_gp3": "mdi:pump",
+    "picpin_relay_pump": "mdi:pump",
+    "picpin_relay_ha12": "mdi:pump",
     # Sensors
     "tap_water_cap": "mdi:account-group",
     "fanrpm": "mdi:fan",

--- a/docs/modbus-feature-gap-analysis.md
+++ b/docs/modbus-feature-gap-analysis.md
@@ -102,9 +102,9 @@ Duration:
 
 On HTTP it is a cloud value (disabled by default). On Modbus it is a local shower-capacity estimate from `bt30` / `bt33` / `bf1_l_min`. Same entity name, different meaning.
 
-### Polled but never shown
+### Relay bits as binary sensors
 
-`picpin_relay_pump` is in the Modbus-only metric list, but `picpin_` is in `EXCLUDED_METRIC_PATTERNS`, so there is no sensor or binary sensor. Same for `gp10`, `qn8_*`, `gp3`, `ha12`.
+All `RELAY_BIT_MAP` bits are binary sensors: L1/L2/L3, QM10, GP10, QN8_1/QN8_2, GP3, and HA12 on both transports; `picpin_relay_pump` is Modbus-only. `picpin_` stays in `EXCLUDED_METRIC_PATTERNS` so they are not also created as numeric sensors.
 
 ---
 

--- a/tests/test_binary_sensor_working.py
+++ b/tests/test_binary_sensor_working.py
@@ -64,7 +64,12 @@ def mock_coordinator():
             "picpin_relay_heat_l1": 1,
             "picpin_relay_heat_l2": 0,
             "picpin_relay_heat_l3": 1,
+            "picpin_relay_gp10": 0,
             "picpin_relay_qm10": 0,
+            "picpin_relay_qn8_1": 0,
+            "picpin_relay_qn8_2": 1,
+            "picpin_relay_gp3": 0,
+            "picpin_relay_ha12": 1,
             "qn8position": 1,
         },
         "connectivity": {
@@ -189,7 +194,7 @@ async def test_async_setup_entry(
         # Check that entities were added
         assert async_add_entities.called
         entities = async_add_entities.call_args[0][0]
-        assert len(entities) == 12
+        assert len(entities) == 17
 
         # Check that we have the expected sensor types
         sensor_names = [
@@ -201,15 +206,64 @@ async def test_async_setup_entry(
             "dhwdemand",
             "heatingdemand",
             "heatingreleased",
+            "picpin_relay_gp10",
+            "picpin_relay_gp3",
+            "picpin_relay_ha12",
             "picpin_relay_heat_l1",
             "picpin_relay_heat_l2",
             "picpin_relay_heat_l3",
             "picpin_relay_qm10",
+            "picpin_relay_qn8_1",
+            "picpin_relay_qn8_2",
         ]
 
         entity_metric_keys = sorted([e._metric_key for e in entities])
         assert entity_metric_keys == sorted(sensor_names)
     finally:
         # Clean up
+        if hasattr(QvantumBaseBinaryEntity, "entity_id"):
+            delattr(QvantumBaseBinaryEntity, "entity_id")
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_modbus_includes_pump_relay(
+    hass, mock_config_entry, mock_coordinator, mock_device
+):
+    """Modbus setup creates picpin_relay_pump; HTTP setup does not."""
+    from custom_components.qvantum.binary_sensor import (
+        async_setup_entry,
+        QvantumBaseBinaryEntity,
+    )
+    from custom_components.qvantum import RuntimeData
+
+    hass.data["entity_registry"] = MagicMock()
+    mock_device_registry = MagicMock()
+    mock_device_registry.async_get_device_by_identifier.return_value = None
+    hass.data["device_registry"] = mock_device_registry
+
+    mock_config_entry.runtime_data = RuntimeData(
+        coordinator=mock_coordinator,
+        device=mock_device,
+    )
+    mock_coordinator.modbus_enabled = True
+    mock_coordinator.data["values"]["picpin_relay_pump"] = 1
+    mock_coordinator.data["values"]["vacation_mode"] = 0
+
+    async_add_entities = MagicMock()
+
+    @property
+    def entity_id(self):
+        return f"binary_sensor.{self._attr_unique_id}"
+
+    QvantumBaseBinaryEntity.entity_id = entity_id
+
+    try:
+        await async_setup_entry(hass, mock_config_entry, async_add_entities)
+        keys = {entity._metric_key for entity in async_add_entities.call_args[0][0]}
+        assert "picpin_relay_pump" in keys
+        assert "vacation_mode" in keys
+        assert "picpin_relay_gp10" in keys
+        assert "picpin_relay_ha12" in keys
+    finally:
         if hasattr(QvantumBaseBinaryEntity, "entity_id"):
             delattr(QvantumBaseBinaryEntity, "entity_id")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,6 +1,7 @@
 """Tests for Qvantum coordinator functions."""
 
 import asyncio
+import logging
 import pytest
 from datetime import datetime, timezone, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -459,6 +460,61 @@ class TestQvantumDataUpdateCoordinator:
 
         assert "bt1" in result
         assert "compressor_state" in result
+        assert "picpin_relay_gp10" in result
+
+    @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
+    def test_get_enabled_metrics_skips_new_default_log_for_non_entities(
+        self, mock_super_init, caplog
+    ):
+        """Defaults that cannot become entities are still fetched, but not logged as new."""
+        mock_hass = MagicMock()
+        mock_device_registry = MagicMock()
+        mock_entity_registry = MagicMock()
+
+        mock_device = MagicMock()
+        mock_device.id = "device_id_123"
+        mock_device.identifiers = {(DOMAIN, "qvantum-test_device")}
+        mock_device_registry.async_get_device_by_identifier.return_value = mock_device
+
+        mock_entity = MagicMock()
+        mock_entity.device_id = "device_id_123"
+        mock_entity.disabled_by = None
+        mock_entity.unique_id = "qvantum_bt1_test_device"
+        mock_entity_registry.entities.get_entries_for_device_id.return_value = [
+            mock_entity
+        ]
+
+        mock_hass.data = {
+            DOMAIN: MagicMock(),
+            "device_registry": mock_device_registry,
+            "entity_registry": mock_entity_registry,
+        }
+
+        mock_super_init.return_value = None
+        config_entry = MagicMock()
+        config_entry.options.get.side_effect = lambda key, default=None: (
+            False if key == CONF_MODBUS_TCP else 30
+        )
+        config_entry.unique_id = "test_device"
+        coordinator = QvantumDataUpdateCoordinator(mock_hass, config_entry)
+        coordinator.hass = mock_hass
+
+        with (
+            patch(
+                "custom_components.qvantum.coordinator.DEFAULT_ENABLED_HTTP_METRICS",
+                ["bt1", "op_man_dhw", "picpin_relay_gp10"],
+            ),
+            caplog.at_level(
+                logging.DEBUG, logger="custom_components.qvantum.coordinator"
+            ),
+        ):
+            result = coordinator._get_enabled_metrics("test_device")
+
+        assert "bt1" in result
+        assert "op_man_dhw" in result
+        assert "picpin_relay_gp10" in result
+        assert "Adding new default metric 'op_man_dhw'" not in caplog.text
+        assert "Adding new default metric 'picpin_relay_gp10'" in caplog.text
 
     @patch("homeassistant.helpers.update_coordinator.DataUpdateCoordinator.__init__")
     def test_get_enabled_metrics_modbus_excludes_http_disabled_metrics(self, mock_super_init):

--- a/tests/test_modbus_device.py
+++ b/tests/test_modbus_device.py
@@ -3,6 +3,10 @@
 import pytest
 from modbus_connection.mock import MockModbusConnection
 
+from custom_components.qvantum.const import (
+    BINARY_SENSOR_NAMES,
+    MODBUS_ONLY_BINARY_SENSORS,
+)
 from custom_components.qvantum.modbus import (
     MODBUS_HOLDING_REGISTER_MAP,
     MODBUS_IDENTITY_REGISTER_MAP,
@@ -47,6 +51,12 @@ class TestRegisterMapAlignment:
             field = QvantumInputs.declared_fields[name]
             assert field.address == bitmask_address
             assert field.start == index
+
+    def test_all_relay_bits_are_binary_sensors(self):
+        exposed = set(BINARY_SENSOR_NAMES) | set(MODBUS_ONLY_BINARY_SENSORS)
+        assert set(RELAY_BIT_MAP) <= exposed
+        assert "picpin_relay_pump" in MODBUS_ONLY_BINARY_SENSORS
+        assert "picpin_relay_pump" not in BINARY_SENSOR_NAMES
 
     def test_holding_fields_match_register_map(self):
         for name, (address, data_type, scale) in MODBUS_HOLDING_REGISTER_MAP.items():

--- a/tests/test_sensor_working.py
+++ b/tests/test_sensor_working.py
@@ -412,6 +412,17 @@ def test_should_exclude_metric_respects_excluded_patterns():
         assert entity.state is None
 
 
+def test_default_metric_creates_entity_for_binary_sensors_not_switches():
+    """Relay bits become binary sensors; switch-style excluded patterns do not."""
+    from custom_components.qvantum.const import default_metric_creates_entity
+
+    assert default_metric_creates_entity("picpin_relay_gp10") is True
+    assert default_metric_creates_entity("picpin_relay_pump") is True
+    assert default_metric_creates_entity("bt1") is True
+    assert default_metric_creates_entity("op_man_dhw") is False
+    assert default_metric_creates_entity("use_adaptive") is False
+
+
 class TestQvantumFirmwareLastCheckSensorEntity:
     """Test the QvantumFirmwareLastCheckSensorEntity class."""
 


### PR DESCRIPTION
## Summary
- Create binary sensors for the remaining `picpin_relay_*` bits (`gp10`, `qn8_1`, `qn8_2`, `gp3`, `ha12`) and Modbus-only `picpin_relay_pump`.
- These were default-enabled metrics that never became entities (`picpin_` is excluded from numeric sensors, and they were missing from `BINARY_SENSOR_NAMES`), so HTTP/Cloud logged `Adding new default metric ... since it's not in the registry` on every poll.
- Skip that debug log for default metrics that cannot land in the entity registry (switch/select-style excluded patterns).

## Test plan
- [x] `pytest tests/` (660 passed)
- [ ] In HTTP/Cloud debug logs: after reload, `picpin_relay_gp10` / `qn8_*` / `gp3` / `ha12` appear as binary sensors and are no longer logged as new defaults on later polls
- [ ] In Modbus: same relays plus `picpin_relay_pump` show as binary sensors