### PR TITLE
fix: Allow climate target temperature with external room sensor

### DIFF
--- a/custom_components/qvantum/climate.py
+++ b/custom_components/qvantum/climate.py
@@ -15,6 +15,7 @@ from homeassistant.components.climate.const import ClimateEntityFeature
 from .entity import QvantumAccessMixin
 from .coordinator import QvantumDataUpdateCoordinator
 from .coordinator import handle_setting_update_response
+from .const import SensorMode
 from . import MyConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -74,7 +75,7 @@ class QvantumIndoorClimateEntity(QvantumAccessMixin, CoordinatorEntity, ClimateE
     def supported_features(self):
         """Return the list of supported features."""
         values = (self.coordinator.data or {}).get("values", {})
-        if values.get("sensor_mode") in ("bt2", 1):
+        if SensorMode.allows_target_temperature(values.get("sensor_mode")):
             return ClimateEntityFeature.TARGET_TEMPERATURE
 
         return {}

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -1,5 +1,7 @@
 """Constants for the Qvantum Heat Pump Integration."""
 
+from enum import IntEnum
+
 DOMAIN = "qvantum"
 DEFAULT_SCAN_INTERVAL = 120
 MIN_SCAN_INTERVAL = 60
@@ -25,6 +27,35 @@ DHW_MODE_ECO = 0
 DHW_MODE_NORMAL = 1
 DHW_MODE_EXTRA = 2
 DHW_MODE_SMART = 3
+
+# Cloud/HTTP `sensor_mode` setting names (same meanings as SensorMode).
+SENSOR_MODE_HTTP_BT2 = "bt2"
+SENSOR_MODE_HTTP_EXT_ROOM_SENSOR = "ext_room_sensor"
+
+
+class SensorMode(IntEnum):
+    """Indoor sensor source. Modbus holding 9 (`use_operation_sensor`)."""
+
+    DISABLED = 0
+    BT2 = 1
+    BT3 = 2
+    AUX = 3
+    EXTERNAL = 4
+
+    @classmethod
+    def allows_target_temperature(cls, value: object) -> bool:
+        """True when indoor setpoint is used (BT2 or external room sensor).
+
+        Cloud/HTTP reports string names; Modbus reports the integer register value.
+        """
+        return value in (
+            cls.BT2,
+            cls.EXTERNAL,
+            SENSOR_MODE_HTTP_BT2,
+            SENSOR_MODE_HTTP_EXT_ROOM_SENSOR,
+        )
+
+
 VERSION = "2026.9.9"
 CONFIG_VERSION = 7
 # Shared Modbus units (`async_get_unit`) shipped in Home Assistant 2026.9.

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -47,13 +47,18 @@ class SensorMode(IntEnum):
         """True when indoor setpoint is used (BT2 or external room sensor).
 
         Cloud/HTTP reports string names; Modbus reports the integer register value.
+        Reject bool explicitly: ``True == 1`` / ``False == 0`` would otherwise match.
         """
-        return value in (
-            cls.BT2,
-            cls.EXTERNAL,
-            SENSOR_MODE_HTTP_BT2,
-            SENSOR_MODE_HTTP_EXT_ROOM_SENSOR,
-        )
+        if isinstance(value, bool):
+            return False
+        if isinstance(value, str):
+            return value in (
+                SENSOR_MODE_HTTP_BT2,
+                SENSOR_MODE_HTTP_EXT_ROOM_SENSOR,
+            )
+        if isinstance(value, int):
+            return value in (cls.BT2, cls.EXTERNAL)
+        return False
 
 
 VERSION = "2026.9.9"

--- a/custom_components/qvantum/number.py
+++ b/custom_components/qvantum/number.py
@@ -11,9 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import MyConfigEntry
-from .const import (
-    TAP_WATER_CAPACITY_MAPPINGS,
-)
+from .const import SensorMode, TAP_WATER_CAPACITY_MAPPINGS
 from .coordinator import QvantumDataUpdateCoordinator, handle_setting_update_response
 from .entity import QvantumEntity
 
@@ -192,10 +190,9 @@ class QvantumNumberEntity(QvantumEntity, NumberEntity):
             and self._has_write_access
             and (
                 # `room_temp_external` is only meaningful when the heat pump is
-                # configured to use the external operation sensor; in the API,
-                # `use_operation_sensor == 4` represents the "External" sensor.
+                # configured to use the external operation sensor.
                 self._metric_key != "room_temp_external"
-                or self._values.get("use_operation_sensor") == 4
+                or self._values.get("use_operation_sensor") == SensorMode.EXTERNAL
             )
         )
 

--- a/custom_components/qvantum/select.py
+++ b/custom_components/qvantum/select.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.qvantum.const import SETTING_UPDATE_APPLIED
+from custom_components.qvantum.const import SETTING_UPDATE_APPLIED, SensorMode
 
 from . import MyConfigEntry
 from .coordinator import QvantumDataUpdateCoordinator, handle_setting_update_response
@@ -68,7 +68,7 @@ class QvantumSelectEntity(QvantumEntity, SelectEntity):
                     "2",
                 ]  # Translation keys that will be translated by HA
             case "use_operation_sensor":
-                self._attr_options = ["0", "1", "2", "3", "4"]
+                self._attr_options = [str(mode.value) for mode in SensorMode]
 
     def _is_valid_mode(self, mode, valid_modes: set) -> bool:
         """Check if a mode value is valid."""

--- a/docs/modbus-feature-gap-analysis.md
+++ b/docs/modbus-feature-gap-analysis.md
@@ -137,7 +137,7 @@ If `modbus_write` is off, current local is **read-only**. Previous Modbus with w
 
 `start_cooling_temp` (38) is **readable** as a sensor; there is no number entity to write it.
 
-Climate is heat-only. `async_set_hvac_mode` is a no-op in **all** modes. Target-temperature is only offered when `sensor_mode` is `bt2` or `1`.
+Climate is heat-only. `async_set_hvac_mode` is a no-op in **all** modes. Target-temperature is offered when `sensor_mode` is BT2 (`bt2` / `1`) or external room sensor (`ext_room_sensor` / `4`).
 
 ### Not writable locally (HTTP / previous hybrid still can)
 

--- a/tests/test_climate_working.py
+++ b/tests/test_climate_working.py
@@ -59,7 +59,12 @@ with patch(
                             from custom_components.qvantum.climate import (
                                 QvantumIndoorClimateEntity,
                             )
-                            from custom_components.qvantum.const import SETTING_UPDATE_APPLIED
+                            from custom_components.qvantum.const import (
+                                SENSOR_MODE_HTTP_BT2,
+                                SENSOR_MODE_HTTP_EXT_ROOM_SENSOR,
+                                SETTING_UPDATE_APPLIED,
+                                SensorMode,
+                            )
 
 
 @pytest.fixture
@@ -73,7 +78,7 @@ def mock_coordinator():
             "bt2": 22.5,  # Current temperature
             "hp_status": 3,  # Heating status
             "indoor_temperature_target": 21.0,
-            "sensor_mode": "bt2",
+            "sensor_mode": SENSOR_MODE_HTTP_BT2,
         },
     }
     coordinator.api = MagicMock()
@@ -98,6 +103,39 @@ def mock_device():
         manufacturer="Qvantum",
         model="QE-6",
     )
+
+
+class TestSensorMode:
+    """Test Modbus SensorMode enum and HTTP name mapping."""
+
+    def test_modbus_values(self):
+        """Modbus holding 9 uses these integer values."""
+        assert SensorMode.DISABLED == 0
+        assert SensorMode.BT2 == 1
+        assert SensorMode.BT3 == 2
+        assert SensorMode.AUX == 3
+        assert SensorMode.EXTERNAL == 4
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            SENSOR_MODE_HTTP_BT2,
+            SENSOR_MODE_HTTP_EXT_ROOM_SENSOR,
+            SensorMode.BT2,
+            SensorMode.EXTERNAL,
+            1,
+            4,
+        ],
+    )
+    def test_allows_target_temperature(self, value):
+        assert SensorMode.allows_target_temperature(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [None, "other", SensorMode.DISABLED, SensorMode.BT3, SensorMode.AUX, 0, 2, 3],
+    )
+    def test_disallows_target_temperature(self, value):
+        assert SensorMode.allows_target_temperature(value) is False
 
 
 class TestQvantumIndoorClimateEntity:
@@ -157,14 +195,43 @@ class TestQvantumIndoorClimateEntity:
         entity = QvantumIndoorClimateEntity(mock_coordinator, mock_device)
         assert entity.hvac_action == "idle"  # Default to idle
 
-    def test_supported_features_with_bt2(self, mock_coordinator, mock_device):
-        """Test supported features when sensor_mode is bt2."""
+    @pytest.mark.parametrize(
+        "sensor_mode",
+        [
+            SENSOR_MODE_HTTP_BT2,
+            SENSOR_MODE_HTTP_EXT_ROOM_SENSOR,
+            SensorMode.BT2,
+            SensorMode.EXTERNAL,
+            SensorMode.BT2.value,
+            SensorMode.EXTERNAL.value,
+        ],
+    )
+    def test_supported_features_with_indoor_sensor(
+        self, mock_coordinator, mock_device, sensor_mode
+    ):
+        """Target temperature is offered for BT2 and external room sensor."""
+        mock_coordinator.data["values"]["sensor_mode"] = sensor_mode
         entity = QvantumIndoorClimateEntity(mock_coordinator, mock_device)
         assert entity.supported_features == 1  # TARGET_TEMPERATURE
 
-    def test_supported_features_without_bt2(self, mock_coordinator, mock_device):
-        """Test supported features when sensor_mode is not bt2."""
-        mock_coordinator.data["values"]["sensor_mode"] = "other"
+    @pytest.mark.parametrize(
+        "sensor_mode",
+        [
+            "other",
+            None,
+            SensorMode.DISABLED,
+            SensorMode.BT3,
+            SensorMode.AUX,
+            SensorMode.DISABLED.value,
+            SensorMode.BT3.value,
+            SensorMode.AUX.value,
+        ],
+    )
+    def test_supported_features_without_indoor_sensor(
+        self, mock_coordinator, mock_device, sensor_mode
+    ):
+        """Target temperature is hidden when no indoor room sensor is in use."""
+        mock_coordinator.data["values"]["sensor_mode"] = sensor_mode
         entity = QvantumIndoorClimateEntity(mock_coordinator, mock_device)
         assert entity.supported_features == {}
 

--- a/tests/test_climate_working.py
+++ b/tests/test_climate_working.py
@@ -132,7 +132,7 @@ class TestSensorMode:
 
     @pytest.mark.parametrize(
         "value",
-        [None, "other", SensorMode.DISABLED, SensorMode.BT3, SensorMode.AUX, 0, 2, 3],
+        [None, "other", True, False, SensorMode.DISABLED, SensorMode.BT3, SensorMode.AUX, 0, 2, 3],
     )
     def test_disallows_target_temperature(self, value):
         assert SensorMode.allows_target_temperature(value) is False

--- a/tests/test_number_working.py
+++ b/tests/test_number_working.py
@@ -34,6 +34,7 @@ with patch(
                 QvantumNumberEntity,
                 async_setup_entry,
             )
+            from custom_components.qvantum.const import SensorMode
 
 
 @pytest.fixture
@@ -617,7 +618,7 @@ class TestRoomTempExternal:
     def test_init_room_temp_external(self, mock_coordinator, mock_device):
         """Test room_temp_external entity initialization."""
         mock_coordinator.data["values"]["room_temp_external"] = 20.0
-        mock_coordinator.data["values"]["use_operation_sensor"] = 4
+        mock_coordinator.data["values"]["use_operation_sensor"] = SensorMode.EXTERNAL
         mock_coordinator.config_entry.options = {
             "modbus_write": True,
             "modbus_tcp": True,
@@ -637,12 +638,12 @@ class TestRoomTempExternal:
         assert entity._attr_native_unit_of_measurement == UnitOfTemperature.CELSIUS
         assert entity._attr_device_class == NumberDeviceClass.TEMPERATURE
 
-    def test_available_when_use_operation_sensor_4(
+    def test_available_when_use_operation_sensor_external(
         self, mock_coordinator, mock_device
     ):
-        """Test entity is available when use_operation_sensor == 4 and Modbus write on."""
+        """Test entity is available when sensor mode is EXTERNAL and Modbus write on."""
         mock_coordinator.data["values"]["room_temp_external"] = 20.0
-        mock_coordinator.data["values"]["use_operation_sensor"] = 4
+        mock_coordinator.data["values"]["use_operation_sensor"] = SensorMode.EXTERNAL
         mock_coordinator.config_entry.options = {
             "modbus_write": True,
             "modbus_tcp": True,
@@ -652,10 +653,10 @@ class TestRoomTempExternal:
         )
         assert entity.available is True
 
-    def test_unavailable_when_use_operation_sensor_not_4(
+    def test_unavailable_when_use_operation_sensor_not_external(
         self, mock_coordinator, mock_device
     ):
-        """Test entity is unavailable when use_operation_sensor != 4."""
+        """Test entity is unavailable when sensor mode is not EXTERNAL."""
         mock_coordinator.data["values"]["room_temp_external"] = 20.0
         mock_coordinator.config_entry.options = {
             "modbus_write": True,
@@ -664,16 +665,22 @@ class TestRoomTempExternal:
         entity = QvantumNumberEntity(
             mock_coordinator, "room_temp_external", 10, 40, 0.1, mock_device
         )
-        for val in [0, 1, 2, 3, None]:
+        for val in [
+            SensorMode.DISABLED,
+            SensorMode.BT2,
+            SensorMode.BT3,
+            SensorMode.AUX,
+            None,
+        ]:
             mock_coordinator.data["values"]["use_operation_sensor"] = val
             assert entity.available is False, f"Expected unavailable for sensor={val}"
 
     def test_unavailable_when_modbus_write_disabled(
         self, mock_coordinator, mock_device
     ):
-        """Test entity is unavailable when Modbus write is disabled, even if sensor == 4."""
+        """Test entity is unavailable when Modbus write is disabled, even if sensor is EXTERNAL."""
         mock_coordinator.data["values"]["room_temp_external"] = 20.0
-        mock_coordinator.data["values"]["use_operation_sensor"] = 4
+        mock_coordinator.data["values"]["use_operation_sensor"] = SensorMode.EXTERNAL
         mock_coordinator.config_entry.options = {}
         mock_coordinator.config_entry.data = {}
         entity = QvantumNumberEntity(
@@ -687,7 +694,7 @@ class TestRoomTempExternal:
     ):
         """Test setting room_temp_external writes via Modbus holding register with float value."""
         mock_coordinator.data["values"]["room_temp_external"] = 20.0
-        mock_coordinator.data["values"]["use_operation_sensor"] = 4
+        mock_coordinator.data["values"]["use_operation_sensor"] = SensorMode.EXTERNAL
         mock_coordinator.config_entry.options = {
             "modbus_write": True,
             "modbus_tcp": True,
@@ -720,7 +727,7 @@ class TestRoomTempExternal:
         from homeassistant.exceptions import HomeAssistantError
 
         mock_coordinator.data["values"]["room_temp_external"] = 20.0
-        mock_coordinator.data["values"]["use_operation_sensor"] = 4
+        mock_coordinator.data["values"]["use_operation_sensor"] = SensorMode.EXTERNAL
         mock_coordinator.config_entry.options = {}
         mock_coordinator.config_entry.data = {}
         entity = QvantumNumberEntity(

--- a/tests/test_select_working.py
+++ b/tests/test_select_working.py
@@ -36,6 +36,7 @@ with patch(
                 from homeassistant.helpers.device_registry import DeviceInfo
 
                 from custom_components.qvantum.select import QvantumSelectEntity
+                from custom_components.qvantum.const import SensorMode
 
 
 @pytest.fixture
@@ -320,7 +321,7 @@ class TestQvantumSelectEntityOperationSensor:
 
         assert entity._metric_key == "use_operation_sensor"
         assert entity._attr_unique_id == "qvantum_use_operation_sensor_test_device_123"
-        assert entity._attr_options == ["0", "1", "2", "3", "4"]
+        assert entity._attr_options == [str(mode.value) for mode in SensorMode]
         assert entity._attr_icon == "mdi:motion-sensor"
         assert entity._attr_translation_key == "use_operation_sensor"
 
@@ -331,9 +332,9 @@ class TestQvantumSelectEntityOperationSensor:
             mock_coordinator, "use_operation_sensor", mock_device
         )
 
-        for val in range(5):
-            mock_coordinator.data["values"]["use_operation_sensor"] = val
-            assert entity.current_option == str(val)
+        for mode in SensorMode:
+            mock_coordinator.data["values"]["use_operation_sensor"] = mode
+            assert entity.current_option == str(mode.value)
 
     def test_current_option_no_data(self, mock_coordinator, mock_device):
         """Test current_option returns None when metric key is missing from values."""
@@ -361,13 +362,14 @@ class TestQvantumSelectEntityOperationSensor:
         )
         mock_coordinator.data["values"]["sensor_mode"] = 0
 
-        for opt in ["0", "1", "2", "3", "4"]:
+        for mode in SensorMode:
+            opt = str(mode.value)
             mock_coordinator.api.write_holding_register.reset_mock()
             await entity.async_select_option(opt)
             mock_coordinator.api.write_holding_register.assert_called_once_with(
-                "test_device_123", 9, int(opt)
+                "test_device_123", 9, mode.value
             )
-            assert mock_coordinator.data["values"]["sensor_mode"] == int(opt)
+            assert mock_coordinator.data["values"]["sensor_mode"] == mode.value
 
     def test_available_modbus_write_enabled(self, mock_coordinator, mock_device):
         """Test entity is available when Modbus write is enabled."""


### PR DESCRIPTION
## Summary
- Climate previously only offered `TARGET_TEMPERATURE` when `sensor_mode` was BT2 (`"bt2"` / `1`).
- Indoor setpoint is now also available when using an external room sensor: HTTP `ext_room_sensor` or Modbus `SensorMode.EXTERNAL` (4).
- Adds `SensorMode` IntEnum for Modbus holding 9 (`use_operation_sensor`) and uses it in climate, `room_temp_external`, and the indoor sensor source select.

## Test plan
- [x] `pytest tests/test_climate_working.py tests/test_number_working.py tests/test_select_working.py --no-cov`
- [ ] In HA, set sensor mode to BT2 and confirm climate target temperature still works
- [ ] Set sensor mode to external room sensor (HTTP `ext_room_sensor` / Modbus 4) and confirm climate target temperature can be set
- [ ] Confirm other sensor modes still hide the climate setpoint