### PR TITLE
fix: Use 0.1°C steps for climate target temperature

### DIFF
--- a/custom_components/qvantum/climate.py
+++ b/custom_components/qvantum/climate.py
@@ -5,9 +5,7 @@ import logging
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.const import (
     PRECISION_TENTHS,
-    UnitOfEnergy,
     UnitOfTemperature,
-    EntityCategory,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo

--- a/custom_components/qvantum/climate.py
+++ b/custom_components/qvantum/climate.py
@@ -3,7 +3,12 @@
 import logging
 
 from homeassistant.components.climate import ClimateEntity
-from homeassistant.const import UnitOfEnergy, UnitOfTemperature, EntityCategory
+from homeassistant.const import (
+    PRECISION_TENTHS,
+    UnitOfEnergy,
+    UnitOfTemperature,
+    EntityCategory,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -48,6 +53,7 @@ class QvantumIndoorClimateEntity(QvantumAccessMixin, CoordinatorEntity, ClimateE
         self._hpid = (self.coordinator.data or {}).get("values", {}).get("hpid")
         self._attr_unique_id = f"qvantum_indoor_climate_{self._hpid}"
         self._attr_temperature_unit = UnitOfTemperature.CELSIUS
+        self._attr_target_temperature_step = PRECISION_TENTHS
         self._attr_device_info = device
         self._attr_translation_key = "indoor_climate"
         self._attr_has_entity_name = True

--- a/tests/test_climate_working.py
+++ b/tests/test_climate_working.py
@@ -54,6 +54,7 @@ with patch(
                         with patch(
                             "custom_components.qvantum.const.SETTING_UPDATE_APPLIED", "APPLIED"
                         ):
+                            from homeassistant.const import PRECISION_TENTHS
                             from homeassistant.helpers.device_registry import DeviceInfo
 
                             from custom_components.qvantum.climate import (
@@ -110,7 +111,7 @@ class TestQvantumIndoorClimateEntity:
         assert entity._hpid == "test_device_123"
         assert entity._attr_unique_id == "qvantum_indoor_climate_test_device_123"
         assert entity._attr_temperature_unit == "°C"
-        assert entity._attr_target_temperature_step == 0.1
+        assert entity._attr_target_temperature_step == PRECISION_TENTHS
         assert entity._attr_device_info == mock_device
         assert entity._attr_translation_key == "indoor_climate"
         assert entity._attr_has_entity_name is True

--- a/tests/test_climate_working.py
+++ b/tests/test_climate_working.py
@@ -110,6 +110,7 @@ class TestQvantumIndoorClimateEntity:
         assert entity._hpid == "test_device_123"
         assert entity._attr_unique_id == "qvantum_indoor_climate_test_device_123"
         assert entity._attr_temperature_unit == "°C"
+        assert entity._attr_target_temperature_step == 0.1
         assert entity._attr_device_info == mock_device
         assert entity._attr_translation_key == "indoor_climate"
         assert entity._attr_has_entity_name is True


### PR DESCRIPTION
## Summary
- Climate UI used whole-degree steps because `target_temperature_step` was unset.
- Set `_attr_target_temperature_step` to `PRECISION_TENTHS` (0.1°C) so the indoor setpoint matches the pump's 0.1°C resolution.

## Test plan
- [x] `pytest tests/test_climate_working.py --no-cov`
- [ ] In HA, open the climate card and confirm +/- adjusts by 0.1°C
- [ ] Set a fractional target (e.g. 21.5) and confirm it is written