### PR TITLE
fix: Show climate current temperature from the selected sensor

### DIFF
--- a/custom_components/qvantum/climate.py
+++ b/custom_components/qvantum/climate.py
@@ -87,13 +87,20 @@ class QvantumIndoorClimateEntity(QvantumAccessMixin, CoordinatorEntity, ClimateE
     @property
     def available(self):
         """Check if data is available."""
-        values = (self.coordinator.data or {}).get("values", {})
-        return values.get("bt2") is not None and self._has_write_access
+        return self.current_temperature is not None and self._has_write_access
 
     @property
     def current_temperature(self):
-        """Return the temperature we try to reach."""
-        return (self.coordinator.data or {}).get("values", {}).get("bt2")
+        """Return the indoor temperature from the selected sensor."""
+        values = (self.coordinator.data or {}).get("values", {})
+        sensor_mode = values.get("sensor_mode")
+        if sensor_mode is None:
+            sensor_mode = values.get("use_operation_sensor")
+        for key in SensorMode.current_temperature_keys(sensor_mode):
+            temperature = values.get(key)
+            if temperature is not None:
+                return temperature
+        return None
 
     @property
     def target_temperature(self):

--- a/custom_components/qvantum/climate.py
+++ b/custom_components/qvantum/climate.py
@@ -75,11 +75,18 @@ class QvantumIndoorClimateEntity(QvantumAccessMixin, CoordinatorEntity, ClimateE
         """Set new target hvac mode."""
         _LOGGER.debug(hvac_mode)
 
+    def _sensor_mode(self):
+        """HTTP `sensor_mode`, falling back to Modbus `use_operation_sensor`."""
+        values = (self.coordinator.data or {}).get("values", {})
+        sensor_mode = values.get("sensor_mode")
+        if sensor_mode is None:
+            return values.get("use_operation_sensor")
+        return sensor_mode
+
     @property
     def supported_features(self):
         """Return the list of supported features."""
-        values = (self.coordinator.data or {}).get("values", {})
-        if SensorMode.allows_target_temperature(values.get("sensor_mode")):
+        if SensorMode.allows_target_temperature(self._sensor_mode()):
             return ClimateEntityFeature.TARGET_TEMPERATURE
 
         return {}
@@ -93,10 +100,7 @@ class QvantumIndoorClimateEntity(QvantumAccessMixin, CoordinatorEntity, ClimateE
     def current_temperature(self):
         """Return the indoor temperature from the selected sensor."""
         values = (self.coordinator.data or {}).get("values", {})
-        sensor_mode = values.get("sensor_mode")
-        if sensor_mode is None:
-            sensor_mode = values.get("use_operation_sensor")
-        for key in SensorMode.current_temperature_keys(sensor_mode):
+        for key in SensorMode.current_temperature_keys(self._sensor_mode()):
             temperature = values.get(key)
             if temperature is not None:
                 return temperature

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -60,6 +60,22 @@ class SensorMode(IntEnum):
             return value in (cls.BT2, cls.EXTERNAL)
         return False
 
+    @classmethod
+    def current_temperature_keys(cls, value: object) -> tuple[str, ...]:
+        """Coordinator value keys for climate current temperature.
+
+        BT2 uses ``bt2``. External room sensor uses the Modbus holding
+        ``room_temp_external`` or the HTTP metric ``room_temp_ext``.
+        Missing ``sensor_mode`` falls back to BT2. Other modes have no indoor reading.
+        """
+        if isinstance(value, bool):
+            return ()
+        if value is None or value in (cls.BT2, SENSOR_MODE_HTTP_BT2):
+            return ("bt2",)
+        if value in (cls.EXTERNAL, SENSOR_MODE_HTTP_EXT_ROOM_SENSOR):
+            return ("room_temp_external", "room_temp_ext")
+        return ()
+
 
 VERSION = "2026.9.10"
 CONFIG_VERSION = 7
@@ -228,7 +244,8 @@ DEFAULT_DISABLED_MODBUS_METRICS = [
 # tap_water_start/stop are settings (HTTP settings API / Modbus holdings), not /values
 # metrics. Requesting them as HTTP metrics logs "Metric X not found in response data".
 REQUIRED_METRICS = [
-    "bt2",  # Required by climate component for current temperature
+    "bt2",  # Required by climate when sensor_mode is BT2
+    "room_temp_ext",  # Required by climate when sensor_mode is external (HTTP)
     "man_mode",  # Required by switch component
     "op_man_addition",  # Required by switch component
     "op_man_dhw",  # Required by switch component

--- a/docs/modbus-feature-gap-analysis.md
+++ b/docs/modbus-feature-gap-analysis.md
@@ -137,7 +137,7 @@ If `modbus_write` is off, current local is **read-only**. Previous Modbus with w
 
 `start_cooling_temp` (38) is **readable** as a sensor; there is no number entity to write it.
 
-Climate is heat-only. `async_set_hvac_mode` is a no-op in **all** modes. Target-temperature is offered when `sensor_mode` is BT2 (`bt2` / `1`) or external room sensor (`ext_room_sensor` / `4`).
+Climate is heat-only. `async_set_hvac_mode` is a no-op in **all** modes. Target-temperature is offered when `sensor_mode` is BT2 (`bt2` / `1`) or external room sensor (`ext_room_sensor` / `4`). Current temperature follows the same source: `bt2`, or `room_temp_external` (Modbus holding 14) / `room_temp_ext` (HTTP). Mode resolution uses `sensor_mode`, falling back to `use_operation_sensor`.
 
 ### Not writable locally (HTTP / previous hybrid still can)
 

--- a/tests/test_climate_working.py
+++ b/tests/test_climate_working.py
@@ -138,6 +138,29 @@ class TestSensorMode:
     def test_disallows_target_temperature(self, value):
         assert SensorMode.allows_target_temperature(value) is False
 
+    @pytest.mark.parametrize(
+        ("value", "keys"),
+        [
+            (None, ("bt2",)),
+            (SENSOR_MODE_HTTP_BT2, ("bt2",)),
+            (SensorMode.BT2, ("bt2",)),
+            (1, ("bt2",)),
+            (
+                SENSOR_MODE_HTTP_EXT_ROOM_SENSOR,
+                ("room_temp_external", "room_temp_ext"),
+            ),
+            (SensorMode.EXTERNAL, ("room_temp_external", "room_temp_ext")),
+            (4, ("room_temp_external", "room_temp_ext")),
+            (SensorMode.DISABLED, ()),
+            (SensorMode.BT3, ()),
+            (SensorMode.AUX, ()),
+            (True, ()),
+            (False, ()),
+        ],
+    )
+    def test_current_temperature_keys(self, value, keys):
+        assert SensorMode.current_temperature_keys(value) == keys
+
 
 class TestQvantumIndoorClimateEntity:
     """Test the QvantumIndoorClimateEntity class."""
@@ -158,6 +181,49 @@ class TestQvantumIndoorClimateEntity:
         """Test getting current temperature."""
         entity = QvantumIndoorClimateEntity(mock_coordinator, mock_device)
         assert entity.current_temperature == 22.5
+
+    def test_current_temperature_uses_bt2_for_bt2_mode(
+        self, mock_coordinator, mock_device
+    ):
+        """BT2 mode reads bt2 even when an external reading is also present."""
+        mock_coordinator.data["values"]["sensor_mode"] = SENSOR_MODE_HTTP_BT2
+        mock_coordinator.data["values"]["bt2"] = 22.5
+        mock_coordinator.data["values"]["room_temp_ext"] = 19.0
+        entity = QvantumIndoorClimateEntity(mock_coordinator, mock_device)
+        assert entity.current_temperature == 22.5
+
+    def test_current_temperature_uses_http_external_sensor(
+        self, mock_coordinator, mock_device
+    ):
+        """HTTP ext_room_sensor mode reads room_temp_ext, not bt2."""
+        mock_coordinator.data["values"]["sensor_mode"] = (
+            SENSOR_MODE_HTTP_EXT_ROOM_SENSOR
+        )
+        mock_coordinator.data["values"]["bt2"] = 22.5
+        mock_coordinator.data["values"]["room_temp_ext"] = 19.4
+        entity = QvantumIndoorClimateEntity(mock_coordinator, mock_device)
+        assert entity.current_temperature == 19.4
+
+    def test_current_temperature_uses_modbus_external_sensor(
+        self, mock_coordinator, mock_device
+    ):
+        """Modbus EXTERNAL mode reads room_temp_external, not bt2."""
+        mock_coordinator.data["values"]["sensor_mode"] = SensorMode.EXTERNAL
+        mock_coordinator.data["values"]["bt2"] = 22.5
+        mock_coordinator.data["values"]["room_temp_external"] = 18.7
+        entity = QvantumIndoorClimateEntity(mock_coordinator, mock_device)
+        assert entity.current_temperature == 18.7
+
+    def test_current_temperature_falls_back_to_use_operation_sensor(
+        self, mock_coordinator, mock_device
+    ):
+        """If sensor_mode is missing, use_operation_sensor selects the reading."""
+        del mock_coordinator.data["values"]["sensor_mode"]
+        mock_coordinator.data["values"]["use_operation_sensor"] = SensorMode.EXTERNAL
+        mock_coordinator.data["values"]["bt2"] = 22.5
+        mock_coordinator.data["values"]["room_temp_external"] = 18.1
+        entity = QvantumIndoorClimateEntity(mock_coordinator, mock_device)
+        assert entity.current_temperature == 18.1
 
     def test_target_temperature(self, mock_coordinator, mock_device):
         """Test getting target temperature."""
@@ -253,6 +319,28 @@ class TestQvantumIndoorClimateEntity:
         mock_coordinator.data["values"]["bt2"] = None
         entity = QvantumIndoorClimateEntity(mock_coordinator, mock_device)
         assert entity.available is False
+
+    def test_available_true_external_without_bt2(
+        self, mock_coordinator, mock_device
+    ):
+        """External mode is available from the external reading, even without bt2."""
+        mock_coordinator.data["values"]["sensor_mode"] = SensorMode.EXTERNAL
+        del mock_coordinator.data["values"]["bt2"]
+        mock_coordinator.data["values"]["room_temp_external"] = 19.0
+        entity = QvantumIndoorClimateEntity(mock_coordinator, mock_device)
+        assert entity.available is True
+
+    def test_available_false_external_without_room_temp(
+        self, mock_coordinator, mock_device
+    ):
+        """External mode is unavailable when the external reading is missing."""
+        mock_coordinator.data["values"]["sensor_mode"] = (
+            SENSOR_MODE_HTTP_EXT_ROOM_SENSOR
+        )
+        mock_coordinator.data["values"]["bt2"] = 22.5
+        entity = QvantumIndoorClimateEntity(mock_coordinator, mock_device)
+        assert entity.available is False
+        assert entity.current_temperature is None
 
     @pytest.mark.asyncio
     async def test_async_set_temperature(self, mock_coordinator, mock_device):

--- a/tests/test_climate_working.py
+++ b/tests/test_climate_working.py
@@ -214,16 +214,15 @@ class TestQvantumIndoorClimateEntity:
         entity = QvantumIndoorClimateEntity(mock_coordinator, mock_device)
         assert entity.current_temperature == 18.7
 
-    def test_current_temperature_falls_back_to_use_operation_sensor(
-        self, mock_coordinator, mock_device
-    ):
-        """If sensor_mode is missing, use_operation_sensor selects the reading."""
+    def test_falls_back_to_use_operation_sensor(self, mock_coordinator, mock_device):
+        """If sensor_mode is missing, use_operation_sensor selects reading and features."""
         del mock_coordinator.data["values"]["sensor_mode"]
         mock_coordinator.data["values"]["use_operation_sensor"] = SensorMode.EXTERNAL
         mock_coordinator.data["values"]["bt2"] = 22.5
         mock_coordinator.data["values"]["room_temp_external"] = 18.1
         entity = QvantumIndoorClimateEntity(mock_coordinator, mock_device)
         assert entity.current_temperature == 18.1
+        assert entity.supported_features == 1  # TARGET_TEMPERATURE
 
     def test_target_temperature(self, mock_coordinator, mock_device):
         """Test getting target temperature."""


### PR DESCRIPTION
## Summary
- Climate \`current_temperature\` always came from BT2, so an external room sensor never showed on the climate card.
- BT2 mode still reads \`bt2\`. External mode (\`ext_room_sensor\` / \`SensorMode.EXTERNAL\`) reads \`room_temp_external\` (Modbus) or \`room_temp_ext\` (HTTP).
- Availability follows the selected sensor, so climate stays available with an external reading even if BT2 is missing.
- \`room_temp_ext\` is now a required HTTP metric so the external reading is fetched even when that sensor entity is disabled.

## Test plan
- [x] \`pytest tests/test_climate_working.py --no-cov\`
- [ ] In HA with sensor mode BT2, climate current temp matches BT2
- [ ] Switch to external room sensor and confirm climate shows the external temperature, not BT2
- [ ] Confirm climate remains available if BT2 is disconnected while the external reading is present