### PR TITLE
feat: Extract client package skeleton and protocol exceptions

### DIFF
--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -10,9 +10,7 @@ from typing import Any, Optional
 
 from modbus_connection import ModbusError, ModbusUnit
 
-from .const import (
-    DEFAULT_ENABLED_HTTP_METRICS,
-    DEFAULT_ENABLED_MODBUS_METRICS,
+from .client.constants import (
     DHW_MODE_EXTRA,
     DHW_MODE_NORMAL,
     FAN_SPEED_STATE_EXTRA,
@@ -22,6 +20,15 @@ from .const import (
     FAN_SPEED_VALUE_NORMAL,
     FAN_SPEED_VALUE_OFF,
     TAP_WATER_CAPACITY_MAPPINGS,
+)
+from .client.exceptions import (
+    APIAuthError,
+    APIConnectionError,
+    APIRateLimitError,
+)
+from .const import (
+    DEFAULT_ENABLED_HTTP_METRICS,
+    DEFAULT_ENABLED_MODBUS_METRICS,
 )
 from .modbus import MODBUS_HOLDING_REGISTER_MAP, MODBUS_HOLDING_TO_SETTINGS_MAP
 from .modbus_device import (
@@ -228,11 +235,11 @@ class QvantumAPI:
         """Handle API response, raising exceptions for errors."""
         if not response.ok:
             if response.status == 401:
-                raise APIAuthError(response)
+                raise APIAuthError(response.status)
             elif response.status == 429:
-                raise APIRateLimitError(response)
+                raise APIRateLimitError(response.status)
             else:
-                raise APIConnectionError(response)
+                raise APIConnectionError(response.status)
 
     async def unauthenticate(self):
         """Unauthenticate from the API."""
@@ -294,7 +301,7 @@ class QvantumAPI:
                     return True
                 case _:
                     _LOGGER.error("Authentication failed: %s", response.status)
-                    raise APIAuthError(response)
+                    raise APIAuthError(response.status)
 
     async def _refresh_authentication_token(self):
         """Refresh the authentication token."""
@@ -931,12 +938,12 @@ class QvantumAPI:
                     self._device_metadata_etag = response.headers.get("ETag")
                 case 403:
                     await self.unauthenticate()
-                    raise APIAuthError(response)
+                    raise APIAuthError(response.status)
                 case 304:
                     _LOGGER.debug("Device metadata not modified, using cached data.")
                 case 500:
                     _LOGGER.error("Internal server error, clearing data...")
-                    raise APIConnectionError(response)
+                    raise APIConnectionError(response.status)
                 case _:
                     _LOGGER.error(
                         f"Failed to fetch device metadata, status: {response.status}"
@@ -1042,13 +1049,13 @@ class QvantumAPI:
                 case 403:
                     _LOGGER.error("Authentication failure: %s", response.status)
                     await self.unauthenticate()
-                    raise APIAuthError(response)
+                    raise APIAuthError(response.status)
                 case 304:
                     _LOGGER.debug("HTTP values not modified, using cached data.")
                     return None, None, None
                 case 500:
                     _LOGGER.error("Internal server error: %s", response.status)
-                    raise APIConnectionError(response)
+                    raise APIConnectionError(response.status)
                 case _:
                     _LOGGER.error(
                         "Failed to fetch HTTP values, status: %s", response.status
@@ -1084,12 +1091,12 @@ class QvantumAPI:
                     _LOGGER.debug("HTTP Settings fetched: %s", self._settings_data)
                 case 403:
                     await self.unauthenticate()
-                    raise APIAuthError(response)
+                    raise APIAuthError(response.status)
                 case 304:
                     _LOGGER.debug("HTTP Settings not modified, using cached data.")
                 case 500:
                     _LOGGER.error("Internal server error, clearing data...")
-                    raise APIConnectionError(response)
+                    raise APIConnectionError(response.status)
                 case _:
                     _LOGGER.error(
                         "Failed to fetch HTTP settings, status: %s", response.status
@@ -1133,65 +1140,11 @@ class QvantumAPI:
                     return devices_data.get("devices") if devices_data else None
                 case 403:
                     await self.unauthenticate()
-                    raise APIAuthError(response)
+                    raise APIAuthError(response.status)
                 case _:
                     _LOGGER.error(
                         "Failed to fetch devices, status: %s", response.status
                     )
                     raise APIConnectionError(
-                        response=response, message="Failed to fetch devices"
+                        response.status, "Failed to fetch devices"
                     )
-
-
-class APIAuthError(Exception):
-    """Exception raised for authentication errors."""
-
-    def __init__(
-        self,
-        response: Optional[aiohttp.ClientResponse],
-        message: str = "Authentication failed",
-    ):
-        if response is not None:
-            self.response = response
-            self.status = response.status
-            super().__init__(f"{message}: {response.status}")
-        else:
-            self.response = None
-            self.status = None
-            super().__init__(message)
-
-
-class APIConnectionError(Exception):
-    """Exception raised for connection/API errors."""
-
-    def __init__(
-        self,
-        response: Optional[aiohttp.ClientResponse],
-        message: str = "API request failed",
-    ):
-        if response is not None:
-            self.response = response
-            self.status = response.status
-            super().__init__(f"{message}: {response.status}")
-        else:
-            self.response = None
-            self.status = None
-            super().__init__(message)
-
-
-class APIRateLimitError(Exception):
-    """Exception raised for rate limiting."""
-
-    def __init__(
-        self,
-        response: Optional[aiohttp.ClientResponse],
-        message: str = "Rate limit exceeded",
-    ):
-        if response is not None:
-            self.response = response
-            self.status = response.status
-            super().__init__(f"{message}: {response.status}")
-        else:
-            self.response = None
-            self.status = None
-            super().__init__(message)

--- a/custom_components/qvantum/client/__init__.py
+++ b/custom_components/qvantum/client/__init__.py
@@ -1,0 +1,66 @@
+"""Vendored Qvantum communication library (HTTP + Modbus).
+
+This package must not import Home Assistant. It is the seed of a future
+standalone ``qvantum-client`` distribution.
+"""
+
+from .constants import (
+    BASE_SYSTEM_POWER_W,
+    DHW_MODE_ECO,
+    DHW_MODE_EXTRA,
+    DHW_MODE_NORMAL,
+    DHW_MODE_SMART,
+    FAN_SPEED_STATE_EXTRA,
+    FAN_SPEED_STATE_NORMAL,
+    FAN_SPEED_STATE_OFF,
+    FAN_SPEED_VALUE_EXTRA,
+    FAN_SPEED_VALUE_NORMAL,
+    FAN_SPEED_VALUE_OFF,
+    RELAY_HEAT_L1_POWER_W,
+    RELAY_HEAT_L2_POWER_W,
+    RELAY_HEAT_L3_POWER_W,
+    RELAY_STAGE_POWER_MAP,
+    SETTING_UPDATE_APPLIED,
+    TAP_WATER_CAPACITY_MAPPINGS,
+)
+from .exceptions import (
+    APIAuthError,
+    APIConnectionError,
+    APIRateLimitError,
+    AuthError,
+    ConnectionError,
+    RateLimitError,
+)
+from .models import ApplyResult, Device, MetricsPayload, SettingsPayload
+from .protocol import QvantumClient
+
+__all__ = [
+    "APIAuthError",
+    "APIConnectionError",
+    "APIRateLimitError",
+    "ApplyResult",
+    "AuthError",
+    "BASE_SYSTEM_POWER_W",
+    "ConnectionError",
+    "DHW_MODE_ECO",
+    "DHW_MODE_EXTRA",
+    "DHW_MODE_NORMAL",
+    "DHW_MODE_SMART",
+    "Device",
+    "FAN_SPEED_STATE_EXTRA",
+    "FAN_SPEED_STATE_NORMAL",
+    "FAN_SPEED_STATE_OFF",
+    "FAN_SPEED_VALUE_EXTRA",
+    "FAN_SPEED_VALUE_NORMAL",
+    "FAN_SPEED_VALUE_OFF",
+    "MetricsPayload",
+    "QvantumClient",
+    "RELAY_HEAT_L1_POWER_W",
+    "RELAY_HEAT_L2_POWER_W",
+    "RELAY_HEAT_L3_POWER_W",
+    "RELAY_STAGE_POWER_MAP",
+    "RateLimitError",
+    "SETTING_UPDATE_APPLIED",
+    "SettingsPayload",
+    "TAP_WATER_CAPACITY_MAPPINGS",
+]

--- a/custom_components/qvantum/client/constants.py
+++ b/custom_components/qvantum/client/constants.py
@@ -1,0 +1,41 @@
+"""Protocol constants shared by the HTTP and Modbus clients."""
+
+SETTING_UPDATE_APPLIED = "APPLIED"
+
+FAN_SPEED_STATE_OFF = "off"
+FAN_SPEED_STATE_NORMAL = "normal"
+FAN_SPEED_STATE_EXTRA = "extra"
+FAN_SPEED_VALUE_OFF = 0
+FAN_SPEED_VALUE_NORMAL = 1
+FAN_SPEED_VALUE_EXTRA = 2
+
+# QAD EN 2609-AXC holding 53 (DHW Mode).
+DHW_MODE_ECO = 0
+DHW_MODE_NORMAL = 1
+DHW_MODE_EXTRA = 2
+DHW_MODE_SMART = 3
+
+# Tap water capacity mappings (start, stop) -> capacity.
+TAP_WATER_CAPACITY_MAPPINGS = {
+    (52, 58): 1,
+    (52, 62): 2,
+    (55, 69): 3,
+    (55, 70): 4,
+    (55, 71): 5,
+    (55, 74): 6,
+    (55, 76): 7,
+}
+
+# Relay power constants (watts) used to compute total power from relay stages.
+# The base system power is an estimate of the constant power draw of the heat
+# pump when no relays are active (circulation pumps, controls, auxiliaries).
+BASE_SYSTEM_POWER_W = 160.0
+RELAY_HEAT_L1_POWER_W = 2000.0
+RELAY_HEAT_L2_POWER_W = 2000.0
+RELAY_HEAT_L3_POWER_W = 1000.0
+
+RELAY_STAGE_POWER_MAP = {
+    "picpin_relay_heat_l1": RELAY_HEAT_L1_POWER_W,
+    "picpin_relay_heat_l2": RELAY_HEAT_L2_POWER_W,
+    "picpin_relay_heat_l3": RELAY_HEAT_L3_POWER_W,
+}

--- a/custom_components/qvantum/client/exceptions.py
+++ b/custom_components/qvantum/client/exceptions.py
@@ -1,0 +1,59 @@
+"""Transport-agnostic errors for the Qvantum client.
+
+Exceptions store an optional HTTP/protocol ``status`` and a message. They
+never hold an ``aiohttp`` response object so the library stays free of
+session/lifecycle coupling.
+"""
+
+from __future__ import annotations
+
+
+class AuthError(Exception):
+    """Authentication failed (login, token refresh, or HTTP 401/403)."""
+
+    def __init__(
+        self,
+        status: int | None = None,
+        message: str = "Authentication failed",
+    ) -> None:
+        self.status = status
+        if status is not None:
+            super().__init__(f"{message}: {status}")
+        else:
+            super().__init__(message)
+
+
+class ConnectionError(Exception):
+    """Transport or remote API failure."""
+
+    def __init__(
+        self,
+        status: int | None = None,
+        message: str = "API request failed",
+    ) -> None:
+        self.status = status
+        if status is not None:
+            super().__init__(f"{message}: {status}")
+        else:
+            super().__init__(message)
+
+
+class RateLimitError(Exception):
+    """Remote API returned HTTP 429."""
+
+    def __init__(
+        self,
+        status: int | None = None,
+        message: str = "Rate limit exceeded",
+    ) -> None:
+        self.status = status
+        if status is not None:
+            super().__init__(f"{message}: {status}")
+        else:
+            super().__init__(message)
+
+
+# Compatibility aliases used by the Home Assistant integration and tests.
+APIAuthError = AuthError
+APIConnectionError = ConnectionError
+APIRateLimitError = RateLimitError

--- a/custom_components/qvantum/client/models.py
+++ b/custom_components/qvantum/client/models.py
@@ -1,0 +1,43 @@
+"""Shared payload shapes for the Qvantum client.
+
+These TypedDicts document the HTTP-shaped dicts both transports return.
+They are not runtime-validated; coordinators still consume plain dicts.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+
+class MetricsPayload(TypedDict, total=False):
+    """``get_metrics`` result: ``{"metrics": {name: value, ...}}``."""
+
+    metrics: dict[str, Any]
+
+
+class SettingItem(TypedDict):
+    name: str
+    value: Any
+
+
+class SettingsPayload(TypedDict, total=False):
+    """``get_settings`` result: ``{"settings": [{"name", "value"}, ...]}``."""
+
+    settings: list[SettingItem]
+
+
+class ApplyResult(TypedDict, total=False):
+    """Write result. Success is ``status`` or ``heatpump_status`` == ``APPLIED``."""
+
+    status: str
+    heatpump_status: str
+
+
+class Device(TypedDict, total=False):
+    """Identity returned by cloud inventory or a Modbus probe."""
+
+    id: str
+    serial: str
+    vendor: str
+    model: str
+    sw_version: str | None

--- a/custom_components/qvantum/client/protocol.py
+++ b/custom_components/qvantum/client/protocol.py
@@ -1,0 +1,75 @@
+"""Shared client protocol implemented by cloud HTTP and local Modbus."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from .models import ApplyResult, MetricsPayload, SettingsPayload
+
+
+class QvantumClient(Protocol):
+    """Transport-agnostic heat-pump client.
+
+    Cloud and Modbus both speak canonical metric/setting names and return
+    HTTP-shaped payloads so Home Assistant coordinators stay protocol-blind.
+    """
+
+    async def get_metrics(
+        self,
+        device_id: str,
+        enabled_metrics: list[str] | None = None,
+    ) -> MetricsPayload:
+        """Fetch live metrics for ``device_id``."""
+        ...
+
+    async def get_settings(self, device_id: str) -> SettingsPayload:
+        """Fetch settings for ``device_id``."""
+        ...
+
+    async def update_setting(
+        self, device_id: str, name: str, value: Any
+    ) -> ApplyResult:
+        """Write a single named setting."""
+        ...
+
+    async def set_indoor_temperature_target(
+        self, device_id: str, temperature: float
+    ) -> ApplyResult:
+        """Write the indoor temperature setpoint."""
+        ...
+
+    async def set_indoor_temperature_offset(
+        self, device_id: str, value: int
+    ) -> ApplyResult:
+        """Write the indoor temperature offset."""
+        ...
+
+    async def set_tap_water(
+        self, device_id: str, start: int = 0, stop: int = 0
+    ) -> ApplyResult:
+        """Write DHW start/stop temperatures."""
+        ...
+
+    async def set_tap_water_capacity_target(
+        self, device_id: str, capacity: int
+    ) -> ApplyResult:
+        """Write the DHW capacity level (1–7)."""
+        ...
+
+    async def set_fanspeedselector(
+        self, device_id: str, preset_mode: str
+    ) -> ApplyResult:
+        """Write fan preset (``off`` / ``normal`` / ``extra``)."""
+        ...
+
+    async def set_extra_tap_water(self, device_id: str, minutes: int) -> ApplyResult:
+        """Request extra DHW.
+
+        Cloud encodes duration on the wire. Modbus writes Extra/Normal only;
+        any restore timer belongs to the caller.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Release owned resources. Must not close injected connections."""
+        ...

--- a/custom_components/qvantum/const.py
+++ b/custom_components/qvantum/const.py
@@ -2,13 +2,32 @@
 
 from enum import IntEnum
 
+from .client.constants import (
+    BASE_SYSTEM_POWER_W,
+    DHW_MODE_ECO,
+    DHW_MODE_EXTRA,
+    DHW_MODE_NORMAL,
+    DHW_MODE_SMART,
+    FAN_SPEED_STATE_EXTRA,
+    FAN_SPEED_STATE_NORMAL,
+    FAN_SPEED_STATE_OFF,
+    FAN_SPEED_VALUE_EXTRA,
+    FAN_SPEED_VALUE_NORMAL,
+    FAN_SPEED_VALUE_OFF,
+    RELAY_HEAT_L1_POWER_W,
+    RELAY_HEAT_L2_POWER_W,
+    RELAY_HEAT_L3_POWER_W,
+    RELAY_STAGE_POWER_MAP,
+    SETTING_UPDATE_APPLIED,
+    TAP_WATER_CAPACITY_MAPPINGS,
+)
+
 DOMAIN = "qvantum"
 DEFAULT_SCAN_INTERVAL = 120
 MIN_SCAN_INTERVAL = 60
 # Modbus poll interval. Default matches the previous hard cap.
 DEFAULT_MODBUS_SCAN_INTERVAL = 15
 MIN_MODBUS_SCAN_INTERVAL = 5
-SETTING_UPDATE_APPLIED = "APPLIED"
 
 # Heat pump status values (hp_status metric)
 HP_STATUS_IDLE = 0
@@ -16,17 +35,6 @@ HP_STATUS_DEFROSTING = 1
 HP_STATUS_HOT_WATER = 2
 HP_STATUS_HEATING = 3
 HP_STATUS_COOLING = 4
-FAN_SPEED_STATE_OFF = "off"
-FAN_SPEED_STATE_NORMAL = "normal"
-FAN_SPEED_STATE_EXTRA = "extra"
-FAN_SPEED_VALUE_OFF = 0
-FAN_SPEED_VALUE_NORMAL = 1
-FAN_SPEED_VALUE_EXTRA = 2
-# QAD EN 2609-AXC holding 53 (DHW Mode).
-DHW_MODE_ECO = 0
-DHW_MODE_NORMAL = 1
-DHW_MODE_EXTRA = 2
-DHW_MODE_SMART = 3
 
 # Cloud/HTTP `sensor_mode` setting names (same meanings as SensorMode).
 SENSOR_MODE_HTTP_BT2 = "bt2"
@@ -348,34 +356,6 @@ DHW_MAX_SHOWER_HISTORY_SIZE = (
 DHW_EMA_ALPHA = (
     0.3  # EMA smoothing factor for tap_water_cap (0=no change, 1=no smoothing)
 )
-
-# Tap water capacity mappings (start, stop) -> capacity
-TAP_WATER_CAPACITY_MAPPINGS = {
-    (52, 58): 1,  # Capacity 1
-    (52, 62): 2,  # Capacity 2
-    (55, 69): 3,  # Capacity 3
-    (55, 70): 4,  # Capacity 4
-    (55, 71): 5,  # Capacity 5
-    (55, 74): 6,  # Capacity 6
-    (55, 76): 7,  # Capacity 7
-}
-
-# Relay power constants (watts) used to compute total power from relay stages.
-# NOTE:
-# The base system power is an estimate of the constant power draw of the heat pump system when no relays are active.
-# This includes circulation pumps, controls and other auxiliary loads that are always on when the system is running.
-# The relay heat stage power values are actual ratings for the heater stages.
-BASE_SYSTEM_POWER_W = 160.0  # Base system consumption when relays are off (W)
-RELAY_HEAT_L1_POWER_W = 2000.0  # Heater stage L1 rating (W)
-RELAY_HEAT_L2_POWER_W = 2000.0  # Heater stage L2 rating (W)
-RELAY_HEAT_L3_POWER_W = 1000.0  # Heater stage L3 rating (W)
-
-# Relay stage wattage map used in Modbus metrics translation
-RELAY_STAGE_POWER_MAP = {
-    "picpin_relay_heat_l1": RELAY_HEAT_L1_POWER_W,
-    "picpin_relay_heat_l2": RELAY_HEAT_L2_POWER_W,
-    "picpin_relay_heat_l3": RELAY_HEAT_L3_POWER_W,
-}
 
 # Binary sensor names
 BINARY_SENSOR_NAMES = [

--- a/tests/test_client_package.py
+++ b/tests/test_client_package.py
@@ -1,0 +1,89 @@
+"""Tests for the vendored Qvantum client package skeleton."""
+
+import ast
+from pathlib import Path
+
+from custom_components.qvantum.client.exceptions import (
+    APIAuthError,
+    APIConnectionError,
+    APIRateLimitError,
+    AuthError,
+    ConnectionError,
+    RateLimitError,
+)
+from custom_components.qvantum.const import (
+    BASE_SYSTEM_POWER_W,
+    DHW_MODE_EXTRA,
+    FAN_SPEED_STATE_OFF,
+    RELAY_STAGE_POWER_MAP,
+    SETTING_UPDATE_APPLIED,
+    TAP_WATER_CAPACITY_MAPPINGS,
+)
+from custom_components.qvantum import client as qvantum_client
+from custom_components.qvantum.client import constants as client_constants
+
+
+CLIENT_ROOT = (
+    Path(__file__).resolve().parents[1] / "custom_components" / "qvantum" / "client"
+)
+
+
+def _imported_modules(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.append(node.module)
+    return names
+
+
+def test_client_package_does_not_import_homeassistant():
+    """The vendored library must stay free of Home Assistant imports."""
+    py_files = sorted(CLIENT_ROOT.rglob("*.py"))
+    assert py_files, f"no Python files under {CLIENT_ROOT}"
+    leaks: list[str] = []
+    for path in py_files:
+        for name in _imported_modules(path):
+            if name == "homeassistant" or name.startswith("homeassistant."):
+                leaks.append(f"{path.relative_to(CLIENT_ROOT.parent)}:{name}")
+    assert leaks == []
+
+
+def test_exception_aliases_match_canonical_types():
+    assert APIAuthError is AuthError
+    assert APIConnectionError is ConnectionError
+    assert APIRateLimitError is RateLimitError
+
+
+def test_auth_error_without_status_keeps_message():
+    err = AuthError(None, "Invalid credentials")
+    assert err.status is None
+    assert str(err) == "Invalid credentials"
+
+
+def test_connection_error_with_status_appends_code():
+    err = ConnectionError(500, "API request failed")
+    assert err.status == 500
+    assert str(err) == "API request failed: 500"
+
+
+def test_rate_limit_error_default_message():
+    err = RateLimitError(429)
+    assert err.status == 429
+    assert str(err) == "Rate limit exceeded: 429"
+
+
+def test_const_reexports_client_protocol_constants():
+    assert SETTING_UPDATE_APPLIED is client_constants.SETTING_UPDATE_APPLIED
+    assert TAP_WATER_CAPACITY_MAPPINGS is client_constants.TAP_WATER_CAPACITY_MAPPINGS
+    assert RELAY_STAGE_POWER_MAP is client_constants.RELAY_STAGE_POWER_MAP
+    assert DHW_MODE_EXTRA == 2
+    assert FAN_SPEED_STATE_OFF == "off"
+    assert BASE_SYSTEM_POWER_W == 160.0
+
+
+def test_client_package_exports_protocol():
+    assert hasattr(qvantum_client, "QvantumClient")
+    assert hasattr(qvantum_client, "MetricsPayload")


### PR DESCRIPTION
## Summary
- Adds vendored `custom_components/qvantum/client/` as the seed of a standalone Qvantum communication library (HTTP + Modbus later).
- Moves protocol exceptions (`AuthError` / `ConnectionError` / `RateLimitError`) and protocol constants (DHW modes, fan presets, capacity map, relay power) into that package.
- Exceptions now store `status: int | None` instead of an `aiohttp` response object.
- `api.py` and `const.py` re-export the previous names so the rest of the integration is unchanged.

This is PR 1 of the client-extraction plan. Follow-ups: move Modbus maps into `client.modbus`, then split `QvantumAPI` into `QvantumCloudClient` and `QvantumModbusClient`.

## Test plan
- [x] `pytest` — 714 passed, 91% coverage
- [x] New `tests/test_client_package.py` asserts the client package does not import Home Assistant
- [x] Existing API/config-flow/services tests still import `APIAuthError` from `api.py`