### PR TITLE
feat: Add QvantumModbusClient and delegate Modbus I/O from QvantumAPI

### DIFF
--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 import logging
 from typing import Any, Optional
 
-from modbus_connection import ModbusError, ModbusUnit
+from modbus_connection import ModbusUnit
 
 from .client.constants import (
     DHW_MODE_EXTRA,
@@ -26,16 +26,13 @@ from .client.exceptions import (
     APIConnectionError,
     APIRateLimitError,
 )
+from .client.modbus import QvantumModbusClient
 from .const import (
     DEFAULT_ENABLED_HTTP_METRICS,
     DEFAULT_ENABLED_MODBUS_METRICS,
 )
 from .modbus import MODBUS_HOLDING_REGISTER_MAP, MODBUS_HOLDING_TO_SETTINGS_MAP
-from .modbus_device import (
-    IdentityProbeError,
-    QvantumModbusDevice,
-    holding_field_for_metric,
-)
+from .modbus_device import QvantumModbusDevice
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -85,9 +82,13 @@ class QvantumAPI:
         self._modbus_port = modbus_port
         self._modbus_unit_id = modbus_unit_id
         self._modbus_unit = modbus_unit
-        self._modbus_write = bool(modbus_write)
-        self._modbus_device: QvantumModbusDevice | None = None
-        self._modbus_lock = asyncio.Lock()
+        self._modbus_write_flag = bool(modbus_write)
+        self._modbus_client = (
+            QvantumModbusClient(modbus_unit, writable=self._modbus_write_flag)
+            if modbus_tcp
+            else None
+        )
+        self._fallback_lock = asyncio.Lock()
         self._closed = False
         self._extra_dhw_unsub = None
         self._extra_dhw_restore_at: float | None = None
@@ -123,22 +124,53 @@ class QvantumAPI:
         self._device_metadata = {}
         self._device_metadata_etag = None
 
+    @property
+    def _modbus_write(self) -> bool:
+        return self._modbus_write_flag
+
+    @_modbus_write.setter
+    def _modbus_write(self, value: bool) -> None:
+        self._modbus_write_flag = bool(value)
+        if self._modbus_client is not None:
+            self._modbus_client.writable = self._modbus_write_flag
+
+    @property
+    def _modbus_lock(self) -> asyncio.Lock:
+        if self._modbus_client is not None:
+            return self._modbus_client._lock
+        return self._fallback_lock
+
+    @property
+    def _modbus_device(self) -> QvantumModbusDevice | None:
+        if self._modbus_client is None:
+            return None
+        return self._modbus_client.device
+
+    @_modbus_device.setter
+    def _modbus_device(self, value: QvantumModbusDevice | None) -> None:
+        if self._modbus_client is not None:
+            self._modbus_client._device = value
+
     def _ensure_open(self) -> None:
         """Raise if the API client has been closed (e.g. during config reload)."""
         if self._closed:
             raise APIConnectionError(None, "API client is closed")
 
+    def _sync_modbus_unit(self) -> None:
+        """Attach a unit assigned after construct (tests) onto the client."""
+        client = self._modbus_client
+        if client is None or client.device is not None:
+            return
+        if self._modbus_unit is None:
+            return
+        client.attach_unit(self._modbus_unit)
+
     def _ensure_modbus_device(self) -> QvantumModbusDevice | None:
         """Return the device wrapper for the Home Assistant-owned Modbus unit."""
-        if self._closed:
+        if self._closed or self._modbus_client is None:
             return None
-        if not self._modbus_tcp:
-            return None
-        if self._modbus_device is None:
-            if self._modbus_unit is None:
-                return None
-            self._modbus_device = QvantumModbusDevice(self._modbus_unit)
-        return self._modbus_device
+        self._sync_modbus_unit()
+        return self._modbus_client._ensure_device()
 
     async def _reset_modbus_client(self):
         """Drop the device wrapper. The shared connection is owned by ``modbus``.
@@ -160,9 +192,8 @@ class QvantumAPI:
         self._closed = True
         self._cancel_extra_dhw_timer()
 
-        # Wait for any in-flight Modbus operation, then drop the wrapper.
-        async with self._modbus_lock:
-            await self._reset_modbus_client()
+        if self._modbus_client is not None:
+            await self._modbus_client.close()
 
         # Only close the session if we created it; externally-provided sessions
         # should be closed by their owner.
@@ -186,30 +217,22 @@ class QvantumAPI:
     ):
         """Run a Modbus device operation under the lock, mapping errors."""
         self._ensure_open()
-        async with self._modbus_lock:
-            self._ensure_open()
-            device = self._ensure_modbus_device()
-            if not device:
-                raise APIConnectionError(None, missing_client_message)
-            try:
-                return await operation(device)
-            except asyncio.CancelledError:
-                # Reload/unload cancels in-flight polls. Do not close or
-                # disconnect the shared connection; other consumers may hold it.
-                raise
-            except ModbusError as err:
-                _LOGGER.error("Modbus error %s: %s", error_label, err)
-                raise APIConnectionError(None, f"{failure_prefix}: {err}") from err
-            except (APIConnectionError, ValueError, IdentityProbeError):
-                raise
-            except Exception as err:
-                _LOGGER.error(
-                    "Unexpected error %s: %s", error_label, err, exc_info=True
-                )
-                raise APIConnectionError(None, f"{failure_prefix}: {err}") from err
+        if self._modbus_client is None:
+            raise APIConnectionError(None, missing_client_message)
+        self._sync_modbus_unit()
+        return await self._modbus_client._run(
+            operation,
+            error_label=error_label,
+            missing_client_message=missing_client_message,
+            failure_prefix=failure_prefix,
+        )
 
     async def _read_modbus_metrics(self, device_id: str, enabled_metrics: list[str]):
-        """Read metrics from Modbus TCP."""
+        """Read metrics from Modbus TCP without injecting poll latency."""
+        self._ensure_open()
+        if self._modbus_client is None:
+            raise APIConnectionError(None, "Modbus client not initialized")
+        self._sync_modbus_unit()
 
         async def _update(device: QvantumModbusDevice):
             await device.async_update_inputs()
@@ -220,16 +243,24 @@ class QvantumAPI:
             )
             return payload
 
-        return await self._run_modbus(_update, error_label="reading input registers")
+        return await self._modbus_client._run(
+            _update, error_label="reading input registers"
+        )
 
     async def _read_modbus_settings(self, device_id: str, enabled_settings: list[str]):
         """Read settings from Modbus TCP holding registers."""
+        self._ensure_open()
+        if self._modbus_client is None:
+            raise APIConnectionError(None, "Modbus client not initialized")
+        self._sync_modbus_unit()
 
         async def _update(device: QvantumModbusDevice):
             await device.async_update_settings()
             return device.settings_payload(enabled_settings)
 
-        return await self._run_modbus(_update, error_label="reading holding registers")
+        return await self._modbus_client._run(
+            _update, error_label="reading holding registers"
+        )
 
     async def _handle_response(self, response: aiohttp.ClientResponse):
         """Handle API response, raising exceptions for errors."""
@@ -343,20 +374,11 @@ class QvantumAPI:
 
     async def async_probe_identity(self) -> dict[str, Any]:
         """Read serial and firmware from the heat pump over Modbus."""
-
-        async def _probe(device: QvantumModbusDevice):
-            await device.async_update_identity()
-            serial = device.serial_number
-            if not serial:
-                raise IdentityProbeError("Heat pump did not return a serial number")
-            return {
-                "id": serial,
-                "serial": serial,
-                "vendor": "Qvantum",
-                "sw_version": device.sw_version,
-            }
-
-        return await self._run_modbus(_probe, error_label="probing identity")
+        self._ensure_open()
+        if self._modbus_client is None:
+            raise APIConnectionError(None, "Modbus client not initialized")
+        self._sync_modbus_unit()
+        return await self._modbus_client.probe_identity()
 
     async def _ensure_valid_token(self):
         """Ensure a valid token is available, refreshing if expired."""
@@ -545,36 +567,27 @@ class QvantumAPI:
         self, device_id: str, register_address: int, value: int
     ) -> dict:
         """Write a single Modbus holding register and return a status dict."""
-        self._ensure_modbus_write_allowed()
-
-        async def _write(device: QvantumModbusDevice):
-            await device.write_holding_register(register_address, int(value))
-            return {"status": "APPLIED"}
-
-        return await self._run_modbus(
-            _write,
-            error_label=f"writing holding register {register_address} for device {device_id}",
-            missing_client_message=f"Modbus client not initialized for device {device_id}",
-            failure_prefix="Modbus write failed",
+        self._ensure_open()
+        if self._modbus_client is None:
+            raise APIConnectionError(
+                None, f"Modbus client not initialized for device {device_id}"
+            )
+        self._sync_modbus_unit()
+        return await self._modbus_client.write_holding_register(
+            device_id, register_address, value
         )
 
     async def write_holding_register_for_metric(
         self, device_id: str, metric_key: str, value: float
     ) -> dict:
         """Write a Modbus holding register looked up by metric key."""
-        self._ensure_modbus_write_allowed()
-        holding_field_for_metric(metric_key)
-
-        async def _write(device: QvantumModbusDevice):
-            await device.write_metric(metric_key, value)
-            return {"status": "APPLIED"}
-
-        return await self._run_modbus(
-            _write,
-            error_label=f"writing metric {metric_key} for device {device_id}",
-            missing_client_message=f"Modbus client not initialized for device {device_id}",
-            failure_prefix="Modbus write failed",
-        )
+        self._ensure_open()
+        if self._modbus_client is None:
+            raise APIConnectionError(
+                None, f"Modbus client not initialized for device {device_id}"
+            )
+        self._sync_modbus_unit()
+        return await self._modbus_client.write_metric(device_id, metric_key, value)
 
     async def _update_settings(self, device_id: str, payload: dict):
         """Update one or several settings."""
@@ -1069,7 +1082,7 @@ class QvantumAPI:
         if self._modbus_tcp:
             settings_to_read = [
                 setting_key
-                for setting_key in MODBUS_HOLDING_TO_SETTINGS_MAP.keys()
+                for setting_key in MODBUS_HOLDING_TO_SETTINGS_MAP
                 if setting_key in MODBUS_HOLDING_REGISTER_MAP
             ]
             return await self._read_modbus_settings(device_id, settings_to_read)

--- a/custom_components/qvantum/client/__init__.py
+++ b/custom_components/qvantum/client/__init__.py
@@ -34,6 +34,7 @@ from .exceptions import (
 from .models import ApplyResult, Device, MetricsPayload, SettingsPayload
 from .modbus import (
     IdentityProbeError,
+    QvantumModbusClient,
     QvantumModbusDevice,
     async_probe_identity,
     holding_field_for_metric,
@@ -62,6 +63,7 @@ __all__ = [
     "IdentityProbeError",
     "MetricsPayload",
     "QvantumClient",
+    "QvantumModbusClient",
     "QvantumModbusDevice",
     "async_probe_identity",
     "holding_field_for_metric",

--- a/custom_components/qvantum/client/modbus/__init__.py
+++ b/custom_components/qvantum/client/modbus/__init__.py
@@ -1,5 +1,6 @@
 """Qvantum Modbus maps, typed components, and HTTP-shaped adapter."""
 
+from .client import QvantumModbusClient
 from .device import (
     IdentityProbeError,
     QvantumModbusDevice,
@@ -28,6 +29,7 @@ __all__ = [
     "MODBUS_INPUT_REGISTER_MAP",
     "QvantumIdentity",
     "QvantumInputs",
+    "QvantumModbusClient",
     "QvantumModbusDevice",
     "QvantumSettings",
     "RELAY_BIT_MAP",

--- a/custom_components/qvantum/client/modbus/client.py
+++ b/custom_components/qvantum/client/modbus/client.py
@@ -1,0 +1,282 @@
+"""Modbus TCP client for a Qvantum heat pump.
+
+Accepts an injected ``ModbusUnit``. The client never opens or closes the TCP
+connection; Home Assistant (or a test) owns that.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Callable, Awaitable
+
+from modbus_connection import ModbusError, ModbusUnit
+
+from ..constants import (
+    DHW_MODE_EXTRA,
+    DHW_MODE_NORMAL,
+    FAN_SPEED_STATE_EXTRA,
+    FAN_SPEED_STATE_NORMAL,
+    FAN_SPEED_STATE_OFF,
+    FAN_SPEED_VALUE_EXTRA,
+    FAN_SPEED_VALUE_NORMAL,
+    FAN_SPEED_VALUE_OFF,
+    SETTING_UPDATE_APPLIED,
+    TAP_WATER_CAPACITY_MAPPINGS,
+)
+from ..exceptions import ConnectionError
+from .device import IdentityProbeError, QvantumModbusDevice, holding_field_for_metric
+from .maps import MODBUS_HOLDING_REGISTER_MAP, MODBUS_HOLDING_TO_SETTINGS_MAP
+
+_LOGGER = logging.getLogger(__name__)
+
+_APPLIED = {"status": SETTING_UPDATE_APPLIED}
+_FAN_PRESETS = {
+    FAN_SPEED_STATE_OFF: FAN_SPEED_VALUE_OFF,
+    FAN_SPEED_STATE_NORMAL: FAN_SPEED_VALUE_NORMAL,
+    FAN_SPEED_STATE_EXTRA: FAN_SPEED_VALUE_EXTRA,
+}
+class QvantumModbusClient:
+    """Qvantum heat pump reached over an injected ``ModbusUnit``."""
+
+    def __init__(
+        self,
+        unit: ModbusUnit | None = None,
+        *,
+        writable: bool = False,
+    ) -> None:
+        self._unit = unit
+        self._writable = bool(writable)
+        self._device: QvantumModbusDevice | None = (
+            QvantumModbusDevice(unit) if unit is not None else None
+        )
+        self._lock = asyncio.Lock()
+        self._closed = False
+
+    @property
+    def device(self) -> QvantumModbusDevice | None:
+        """Device wrapper for the current unit, if any."""
+        return self._device
+
+    @property
+    def unit(self) -> ModbusUnit | None:
+        """Injected Modbus unit, if any."""
+        return self._unit
+
+    @property
+    def writable(self) -> bool:
+        """Whether holding-register writes are allowed."""
+        return self._writable
+
+    @writable.setter
+    def writable(self, value: bool) -> None:
+        self._writable = bool(value)
+
+    def attach_unit(self, unit: ModbusUnit) -> QvantumModbusDevice:
+        """Bind a unit (used by tests that inject a mock after construct)."""
+        self._unit = unit
+        self._device = QvantumModbusDevice(unit)
+        return self._device
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise ConnectionError(None, "API client is closed")
+
+    def _ensure_device(self) -> QvantumModbusDevice | None:
+        if self._closed:
+            return None
+        if self._device is None:
+            if self._unit is None:
+                return None
+            self._device = QvantumModbusDevice(self._unit)
+        return self._device
+
+    def _ensure_writable(self) -> None:
+        if not self._writable:
+            raise ConnectionError(None, "Modbus writing is disabled")
+
+    async def close(self) -> None:
+        """Drop the device wrapper. Does not close the injected TCP unit."""
+        if self._closed:
+            return
+        self._closed = True
+        async with self._lock:
+            self._device = None
+
+    async def _run(
+        self,
+        operation: Callable[[QvantumModbusDevice], Awaitable[Any]],
+        *,
+        error_label: str,
+        missing_client_message: str = "Modbus client not initialized",
+        failure_prefix: str = "Modbus communication failed",
+    ):
+        """Run a device operation under the lock, mapping errors."""
+        self._ensure_open()
+        async with self._lock:
+            self._ensure_open()
+            device = self._ensure_device()
+            if not device:
+                raise ConnectionError(None, missing_client_message)
+            try:
+                return await operation(device)
+            except asyncio.CancelledError:
+                raise
+            except ModbusError as err:
+                _LOGGER.error("Modbus error %s: %s", error_label, err)
+                raise ConnectionError(None, f"{failure_prefix}: {err}") from err
+            except (ConnectionError, ValueError, IdentityProbeError):
+                raise
+            except Exception as err:
+                _LOGGER.error(
+                    "Unexpected error %s: %s", error_label, err, exc_info=True
+                )
+                raise ConnectionError(None, f"{failure_prefix}: {err}") from err
+
+    async def get_metrics(
+        self, device_id: str, enabled_metrics: list[str] | None = None
+    ) -> dict[str, Any]:
+        """Read input registers and return an HTTP-shaped metrics payload."""
+
+        async def _update(device: QvantumModbusDevice):
+            await device.async_update_inputs()
+            payload = device.metrics_payload(device_id, enabled_metrics)
+            _LOGGER.debug(
+                "Raw Modbus metrics read: %s",
+                sorted(payload.get("metrics", {}).items()),
+            )
+            return payload
+
+        start = asyncio.get_running_loop().time()
+        payload = await self._run(_update, error_label="reading input registers")
+        latency = int((asyncio.get_running_loop().time() - start) * 1000)
+        if isinstance(payload, dict) and "metrics" in payload:
+            payload["metrics"]["latency"] = latency
+        return payload
+
+    async def get_settings(self, device_id: str) -> dict[str, Any]:
+        """Read holding registers exposed as HTTP-shaped settings."""
+        enabled = [
+            key
+            for key in MODBUS_HOLDING_TO_SETTINGS_MAP
+            if key in MODBUS_HOLDING_REGISTER_MAP
+        ]
+
+        async def _update(device: QvantumModbusDevice):
+            await device.async_update_settings()
+            return device.settings_payload(enabled)
+
+        return await self._run(_update, error_label="reading holding registers")
+
+    async def probe_identity(self) -> dict[str, Any]:
+        """Read serial and firmware from the identity island."""
+
+        async def _probe(device: QvantumModbusDevice):
+            await device.async_update_identity()
+            serial = device.serial_number
+            if not serial:
+                raise IdentityProbeError("Heat pump did not return a serial number")
+            return {
+                "id": serial,
+                "serial": serial,
+                "vendor": "Qvantum",
+                "sw_version": device.sw_version,
+            }
+
+        return await self._run(_probe, error_label="probing identity")
+
+    async def write_holding_register(
+        self, device_id: str, register_address: int, value: int
+    ) -> dict[str, str]:
+        """Write a raw holding register (FC06)."""
+        self._ensure_writable()
+
+        async def _write(device: QvantumModbusDevice):
+            await device.write_holding_register(register_address, int(value))
+            return dict(_APPLIED)
+
+        return await self._run(
+            _write,
+            error_label=f"writing holding register {register_address} for device {device_id}",
+            missing_client_message=f"Modbus client not initialized for device {device_id}",
+            failure_prefix="Modbus write failed",
+        )
+
+    async def write_metric(
+        self, device_id: str, metric_key: str, value: float
+    ) -> dict[str, str]:
+        """Write a holding field by HTTP/settings metric name."""
+        self._ensure_writable()
+        holding_field_for_metric(metric_key)
+
+        async def _write(device: QvantumModbusDevice):
+            await device.write_metric(metric_key, value)
+            return dict(_APPLIED)
+
+        return await self._run(
+            _write,
+            error_label=f"writing metric {metric_key} for device {device_id}",
+            missing_client_message=f"Modbus client not initialized for device {device_id}",
+            failure_prefix="Modbus write failed",
+        )
+
+    async def update_setting(
+        self, device_id: str, name: str, value: Any
+    ) -> dict[str, str]:
+        """Write one setting, coercing bools to 0/1."""
+        if isinstance(value, bool):
+            value = int(value)
+        return await self.write_metric(device_id, name, value)
+
+    async def set_indoor_temperature_target(
+        self, device_id: str, temperature: float
+    ) -> dict[str, str]:
+        return await self.write_metric(
+            device_id, "indoor_temperature_target", temperature
+        )
+
+    async def set_indoor_temperature_offset(
+        self, device_id: str, value: int
+    ) -> dict[str, str]:
+        return await self.write_metric(device_id, "indoor_temperature_offset", value)
+
+    async def set_tap_water(
+        self, device_id: str, start: int = 0, stop: int = 0
+    ) -> dict[str, str] | None:
+        if stop == 0 and start == 0:
+            _LOGGER.debug("No tap water settings to update, both stop and start are 0.")
+            return None
+        if stop:
+            await self.write_metric(device_id, "tap_water_stop", stop)
+        if start:
+            await self.write_metric(device_id, "tap_water_start", start)
+        return dict(_APPLIED)
+
+    async def set_tap_water_capacity_target(
+        self, device_id: str, capacity: int
+    ) -> dict[str, str] | None:
+        capacity_to_stop_start = {v: k for k, v in TAP_WATER_CAPACITY_MAPPINGS.items()}
+        start, stop = capacity_to_stop_start[capacity]
+        _LOGGER.debug(
+            "Setting tap water capacity %s maps to stop %s and start %s.",
+            capacity,
+            stop,
+            start,
+        )
+        return await self.set_tap_water(device_id, start=start, stop=stop)
+
+    async def set_fanspeedselector(
+        self, device_id: str, preset_mode: str
+    ) -> dict[str, str]:
+        if preset_mode not in _FAN_PRESETS:
+            raise ValueError(f"Invalid preset_mode: {preset_mode}")
+        return await self.write_metric(
+            device_id, "fanspeedselector", _FAN_PRESETS[preset_mode]
+        )
+
+    async def set_extra_tap_water(
+        self, device_id: str, minutes: int
+    ) -> dict[str, str]:
+        """Write DHW Extra if minutes != 0 else Normal. No restore timer."""
+        mode = DHW_MODE_NORMAL if minutes == 0 else DHW_MODE_EXTRA
+        return await self.write_metric(device_id, "extra_tap_water", mode)

--- a/tests/test_modbus_client.py
+++ b/tests/test_modbus_client.py
@@ -1,0 +1,105 @@
+"""Direct tests for QvantumModbusClient."""
+
+import pytest
+from modbus_connection.mock import MockModbusConnection
+
+from custom_components.qvantum.client.constants import (
+    DHW_MODE_EXTRA,
+    DHW_MODE_NORMAL,
+)
+from custom_components.qvantum.client.exceptions import ConnectionError
+from custom_components.qvantum.client.modbus import QvantumModbusClient
+
+
+def _client(*, writable: bool = True) -> tuple[MockModbusConnection, QvantumModbusClient]:
+    connection = MockModbusConnection()
+    unit = connection.for_unit(1)
+    return connection, QvantumModbusClient(unit, writable=writable)
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_decodes_scaled_input_and_sets_latency():
+    _connection, client = _client()
+    client.unit.input[0] = 256  # bt1, scale 0.1
+
+    payload = await client.get_metrics("dev1", ["bt1"])
+
+    assert payload["metrics"]["bt1"] == 25.6
+    assert payload["metrics"]["hpid"] == "dev1"
+    assert isinstance(payload["metrics"]["latency"], int)
+
+
+@pytest.mark.asyncio
+async def test_write_metric_rejected_when_not_writable():
+    _connection, client = _client(writable=False)
+
+    with pytest.raises(ConnectionError, match="Modbus writing is disabled"):
+        await client.write_metric("dev1", "indoor_temperature_target", 21.5)
+
+
+@pytest.mark.asyncio
+async def test_set_extra_tap_water_writes_extra_or_normal():
+    _connection, client = _client()
+
+    await client.set_extra_tap_water("dev1", 60)
+    assert client.unit.holding[53] == DHW_MODE_EXTRA
+
+    await client.set_extra_tap_water("dev1", 0)
+    assert client.unit.holding[53] == DHW_MODE_NORMAL
+
+
+@pytest.mark.asyncio
+async def test_probe_identity_from_serial_words():
+    _connection, client = _client()
+    client.unit.input[180] = 12
+    client.unit.input[181] = 3
+    client.unit.input[182] = 45
+    client.unit.input[183] = 6
+    client.unit.input[184] = 7
+    client.unit.input[191] = 1
+    client.unit.input[192] = 2
+    client.unit.input[193] = 3
+
+    identity = await client.probe_identity()
+
+    assert identity["id"] == "12003045006007"
+    assert identity["sw_version"] == "1.2.3"
+
+
+@pytest.mark.asyncio
+async def test_close_drops_device_but_not_unit():
+    _connection, client = _client()
+    unit = client.unit
+    await client.close()
+    assert client.device is None
+    assert unit is not None
+
+
+@pytest.mark.asyncio
+async def test_update_setting_coerces_bool_and_writes():
+    _connection, client = _client()
+    await client.update_setting("dev1", "man_mode", True)
+    assert client.unit.holding[2] == 1
+
+
+@pytest.mark.asyncio
+async def test_set_fanspeedselector_and_tap_water():
+    _connection, client = _client()
+    await client.set_fanspeedselector("dev1", "extra")
+    assert client.unit.holding[68] == 2
+
+    await client.set_tap_water("dev1", start=52, stop=62)
+    assert client.unit.holding[56] == 52
+    assert client.unit.holding[57] == 62
+
+    await client.set_tap_water_capacity_target("dev1", 2)
+    assert client.unit.holding[56] == 52
+    assert client.unit.holding[57] == 62
+
+
+@pytest.mark.asyncio
+async def test_get_metrics_after_close_raises():
+    _connection, client = _client()
+    await client.close()
+    with pytest.raises(ConnectionError, match="API client is closed"):
+        await client.get_metrics("dev1", ["bt1"])


### PR DESCRIPTION
## Summary
- Adds `QvantumModbusClient` in `client/modbus/client.py` with metrics/settings reads, identity probe, holding writes, and high-level setters.
- `QvantumAPI` constructs the client when `modbus_tcp=True` and delegates register I/O through it.
- Extra-DHW restore timer stays on `QvantumAPI`. Compatibility properties (`_modbus_device`, `_modbus_lock`, `_modbus_write`) keep existing tests working.
- Direct client tests in `tests/test_modbus_client.py`.

Depends on #208.

## Test plan
- [x] `pytest` — 722 passed, 90% coverage