### PR TITLE
feat: Add QvantumCloudClient and delegate HTTP I/O from QvantumAPI

### DIFF
--- a/custom_components/qvantum/api.py
+++ b/custom_components/qvantum/api.py
@@ -26,6 +26,18 @@ from .client.exceptions import (
     APIConnectionError,
     APIRateLimitError,
 )
+from .client.cloud import QvantumCloudClient
+from .client.cloud.endpoints import (
+    API_INTERNAL_URL,
+    API_URL,
+    AUTH_URL,
+    DEFAULT_TOKEN_BUFFER_SECONDS,
+    DEFAULT_TOKEN_EXPIRY_SECONDS,
+    FIREBASE_API_KEY,
+    METRICS_TIMEOUT_SECONDS,
+    TOKEN_URL,
+    VENTILATION_BOOST_MINUTES,
+)
 from .client.modbus import QvantumModbusClient
 from .const import (
     DEFAULT_ENABLED_HTTP_METRICS,
@@ -37,20 +49,27 @@ from .modbus_device import QvantumModbusDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-# API Configuration
-AUTH_URL = "https://identitytoolkit.googleapis.com"
-TOKEN_URL = "https://securetoken.googleapis.com"
-API_URL = "https://api.qvantum.com"
-API_INTERNAL_URL = "https://internal-api.qvantum.com"
-
-# Timeouts and buffers
-DEFAULT_TOKEN_BUFFER_SECONDS = 60
-DEFAULT_TOKEN_EXPIRY_SECONDS = 3540
-METRICS_TIMEOUT_SECONDS = 12
-VENTILATION_BOOST_MINUTES = 120
-
-# Firebase API Key (consider moving to config if needed)
-FIREBASE_API_KEY = "AIzaSyCLQ22XHjH8LmId-PB1DY8FBsN53rWTpFw"
+_CLOUD_ATTRS = frozenset(
+    {
+        "_api_url",
+        "_auth_url",
+        "_device_metadata",
+        "_device_metadata_etag",
+        "_metrics_data",
+        "_metrics_etag",
+        "_password",
+        "_refreshtoken",
+        "_session",
+        "_session_owner",
+        "_settings_data",
+        "_settings_etag",
+        "_token",
+        "_token_expiry",
+        "_token_url",
+        "_user_agent",
+        "_username",
+    }
+)
 
 
 class QvantumAPI:
@@ -70,12 +89,6 @@ class QvantumAPI:
         modbus_write: bool = False,
     ) -> None:
         """Initialise."""
-        self._auth_url = AUTH_URL
-        self._token_url = TOKEN_URL
-        self._api_url = API_URL
-        self._username = username
-        self._password = password
-        self._user_agent = user_agent
         self.hass = None
         self._modbus_tcp = modbus_tcp
         self._modbus_host = modbus_host
@@ -88,32 +101,57 @@ class QvantumAPI:
             if modbus_tcp
             else None
         )
+        self._cloud_client = (
+            None
+            if modbus_tcp
+            else QvantumCloudClient(
+                username, password, user_agent=user_agent, session=session
+            )
+        )
         self._fallback_lock = asyncio.Lock()
         self._closed = False
         self._extra_dhw_unsub = None
         self._extra_dhw_restore_at: float | None = None
         self._extra_dhw_armed_at: float | None = None
         self._extra_dhw_store = None
-        # Modbus-only mode never opens an HTTP session, even if a caller
-        # injects one. Cloud mode owns a session unless a test injects it.
         if modbus_tcp:
             self._session = None
             self._session_owner = False
-        elif session is not None:
-            self._session = session
-            self._session_owner = False
-        else:
-            self._session = aiohttp.ClientSession(
-                headers={
-                    "Content-Type": "application/json",
-                    "User-Agent": self._user_agent,
-                }
+            self._reset_state()
+
+    def __getattr__(self, name: str):
+        if name in _CLOUD_ATTRS:
+            client = self.__dict__.get("_cloud_client")
+            if client is not None:
+                return getattr(client, name)
+            if name == "_session_owner":
+                return False
+            if name in ("_settings_data", "_metrics_data", "_device_metadata"):
+                return {}
+            return None
+        raise AttributeError(f"{type(self).__name__!r} has no attribute {name!r}")
+
+    def __setattr__(self, name: str, value) -> None:
+        if name in _CLOUD_ATTRS:
+            client = self.__dict__.get("_cloud_client")
+            if client is not None:
+                setattr(client, name, value)
+                return
+        object.__setattr__(self, name, value)
+
+    def _require_cloud(self) -> QvantumCloudClient:
+        self._ensure_open()
+        if self._cloud_client is None:
+            raise APIConnectionError(
+                None, "HTTP API is not available in Modbus mode"
             )
-            self._session_owner = True
-        self._reset_state()
+        return self._cloud_client
 
     def _reset_state(self):
         """Reset authentication and cached API data."""
+        if self._cloud_client is not None:
+            self._cloud_client._reset_state()
+            return
         self._token = None
         self._refreshtoken = None
         self._token_expiry = None
@@ -194,6 +232,9 @@ class QvantumAPI:
 
         if self._modbus_client is not None:
             await self._modbus_client.close()
+        if self._cloud_client is not None:
+            await self._cloud_client.close()
+            return
 
         # Only close the session if we created it; externally-provided sessions
         # should be closed by their owner.
@@ -264,13 +305,7 @@ class QvantumAPI:
 
     async def _handle_response(self, response: aiohttp.ClientResponse):
         """Handle API response, raising exceptions for errors."""
-        if not response.ok:
-            if response.status == 401:
-                raise APIAuthError(response.status)
-            elif response.status == 429:
-                raise APIRateLimitError(response.status)
-            else:
-                raise APIConnectionError(response.status)
+        return await self._require_cloud()._handle_response(response)
 
     async def unauthenticate(self):
         """Unauthenticate from the API."""
@@ -283,91 +318,22 @@ class QvantumAPI:
         payload: Optional[dict] = None,
         validate_status: bool = False,
     ) -> dict[str, Any]:
-        """Send an authenticated request and return parsed JSON response.
-
-        By default, this helper does not validate HTTP status codes and will try
-        to parse JSON regardless of response status. Set ``validate_status=True``
-        to enforce ``_handle_response`` before reading the response body.
-        """
-        await self._ensure_valid_token()
-        request = getattr(self._session, method)
-        kwargs: dict[str, Any] = {"headers": self._request_headers()}
-        if payload is not None:
-            kwargs["json"] = payload
-
-        async with request(url, **kwargs) as response:
-            if validate_status:
-                await self._handle_response(response)
-            data = await response.json()
-            _LOGGER.debug("Response received %s: %s", response.status, data)
-            return data
+        """Send an authenticated request and return parsed JSON response."""
+        return await self._require_cloud()._request_json(
+            method, url, payload=payload, validate_status=validate_status
+        )
 
     async def authenticate(self):
         """Authenticate with the API using username and password to retrieve a token."""
-        self._ensure_open()
-        self._ensure_http()
-        payload = {
-            "returnSecureToken": "true",
-            "email": self._username,
-            "password": self._password,
-            "clientType": "CLIENT_TYPE_WEB",
-        }
-
-        async with self._session.post(
-            f"{self._auth_url}/v1/accounts:signInWithPassword?key={FIREBASE_API_KEY}",
-            json=payload,
-        ) as response:
-            match response.status:
-                case 200:
-                    _LOGGER.debug("Authentication successful: %s", response.status)
-                    auth_data = await response.json()
-                    self._token = auth_data.get("idToken")
-                    self._refreshtoken = auth_data.get("refreshToken")
-                    expires_in = auth_data.get(
-                        "expiresIn", DEFAULT_TOKEN_EXPIRY_SECONDS
-                    )
-                    self._token_expiry = datetime.now() + timedelta(
-                        seconds=int(expires_in) - DEFAULT_TOKEN_BUFFER_SECONDS
-                    )
-                    return True
-                case _:
-                    _LOGGER.error("Authentication failed: %s", response.status)
-                    raise APIAuthError(response.status)
+        return await self._require_cloud().authenticate()
 
     async def _refresh_authentication_token(self):
         """Refresh the authentication token."""
-        self._ensure_open()
-
-        if not self._refreshtoken:
-            return
-
-        payload = {"grant_type": "refresh_token", "refresh_token": self._refreshtoken}
-
-        self._token = None
-
-        async with self._session.post(
-            f"{self._token_url}/v1/token?key={FIREBASE_API_KEY}",
-            json=payload,
-        ) as response:
-            match response.status:
-                case 200:
-                    _LOGGER.debug("Token refreshed successfully: %s", response.status)
-                    auth_data = await response.json()
-                    self._token = auth_data.get("access_token")
-                    self._refreshtoken = auth_data.get("refresh_token")
-                    expires_in = auth_data.get(
-                        "expires_in", DEFAULT_TOKEN_EXPIRY_SECONDS
-                    )
-                    self._token_expiry = datetime.now() + timedelta(
-                        seconds=int(expires_in) - DEFAULT_TOKEN_BUFFER_SECONDS
-                    )
-                case _:
-                    _LOGGER.error("Token refresh failed: %s", response.status)
-                    # Don't raise exception here, let _ensure_valid_token handle it
+        return await self._require_cloud()._refresh_authentication_token()
 
     def _ensure_http(self) -> None:
         """Raise if this client has no HTTP session (Modbus-only mode)."""
-        if self._session is None:
+        if self._cloud_client is None or self._session is None:
             raise APIConnectionError(
                 None, "HTTP API is not available in Modbus mode"
             )
@@ -394,16 +360,13 @@ class QvantumAPI:
                             None, "Failed to obtain authentication token"
                         )
             except APIAuthError:
-                # If refresh fails, try fresh authentication
                 await self.authenticate()
                 if not self._token:
                     raise APIAuthError(None, "Failed to obtain authentication token")
 
     def _request_headers(self):
         """Get request headers for API calls."""
-        return {
-            "Authorization": f"Bearer {self._token}",
-        }
+        return self._require_cloud()._request_headers()
 
     def _cancel_extra_dhw_timer(self, *, clear_store: bool = False) -> None:
         """Cancel a pending extra-DHW restore callback."""
@@ -591,159 +554,28 @@ class QvantumAPI:
 
     async def _update_settings(self, device_id: str, payload: dict):
         """Update one or several settings."""
-
-        _LOGGER.debug(json.dumps(payload))
-        return await self._request_json(
-            "patch",
-            f"{self._api_url}/api/device-info/v1/devices/{device_id}/settings?dispatch=false",
-            payload,
-        )
+        return await self._require_cloud()._update_settings(device_id, payload)
 
     async def _send_command(self, device_id: str, payload: dict):
         """Send a command to a device."""
-
-        wrapped_payload = {"command": payload}
-        _LOGGER.debug(json.dumps(wrapped_payload))
-        return await self._request_json(
-            "post",
-            f"{self._api_url}/api/commands/v1/devices/{device_id}/commands?wait=true&use_internal_names=true",
-            wrapped_payload,
-        )
+        return await self._require_cloud()._send_command(device_id, payload)
 
     async def elevate_access(self, device_id: str):
         """Elevate access for a device."""
-
-        await self._ensure_valid_token()
-
-        async with self._session.get(
-            f"{API_INTERNAL_URL}/api/internal/v1/auth/device/{device_id}/my-access-level?use_internal_names=true",
-            headers=self._request_headers(),
-        ) as response:
-            await self._handle_response(response)
-            data = await response.json()
-            _LOGGER.debug("Response received %s: %s", response.status, data)
-
-            expires_at = data.get("expiresAt")
-            has_sufficient_access = data.get("writeAccessLevel", 0) >= 20
-            if not has_sufficient_access and expires_at:
-                try:
-                    expires_at_dt = datetime.fromisoformat(
-                        expires_at.replace("Z", "+00:00")
-                    )
-                    if expires_at_dt < datetime.now(timezone.utc) + timedelta(days=1):
-                        has_sufficient_access = True
-                except ValueError:
-                    pass
-            if has_sufficient_access:
-                return data
-
-            # Access insufficient, elevate it
-            code_data = await self._generate_code(device_id)
-            if not code_data:
-                return None
-            access_code = code_data.get("accessCode")
-            if not access_code:
-                return None
-
-            claim_status = await self._claim_grant(device_id, access_code)
-            if not claim_status:
-                return None
-
-            approve_status = await self._approve_access(device_id, access_code)
-            if not approve_status:
-                return None
-
-            # Get updated access level
-            async with self._session.get(
-                f"{API_INTERNAL_URL}/api/internal/v1/auth/device/{device_id}/my-access-level?use_internal_names=true",
-                headers=self._request_headers(),
-            ) as response:
-                await self._handle_response(response)
-                data = await response.json()
-                _LOGGER.debug("Response received %s: %s", response.status, data)
-                return data
+        return await self._require_cloud().elevate_access(device_id)
 
     async def get_access_level(self, device_id: str):
         """Get current access level for a device."""
-
-        await self._ensure_valid_token()
-
-        async with self._session.get(
-            f"{API_INTERNAL_URL}/api/internal/v1/auth/device/{device_id}/my-access-level?use_internal_names=true",
-            headers=self._request_headers(),
-        ) as response:
-            await self._handle_response(response)
-            data = await response.json()
-            _LOGGER.debug(
-                "Access level response received %s: %s", response.status, data
-            )
-            return data
+        return await self._require_cloud().get_access_level(device_id)
 
     async def _generate_code(self, device_id: str):
-        """Generate an access code for a device."""
-
-        await self._ensure_valid_token()
-
-        async with self._session.post(
-            f"{API_INTERNAL_URL}/api/internal/v1/auth/device/{device_id}/generate-access-code?use_internal_names=true",
-            headers=self._request_headers(),
-        ) as response:
-            if response.ok:
-                data = await response.json()
-                _LOGGER.debug("Response received %s: %s", response.status, data)
-                return data
-            else:
-                _LOGGER.error(
-                    "Failed to generate access code for device %s, status: %s",
-                    device_id,
-                    response.status,
-                )
-                return None
+        return await self._require_cloud()._generate_code(device_id)
 
     async def _claim_grant(self, device_id: str, access_code: str):
-        """Claim a grant for a device."""
-
-        await self._ensure_valid_token()
-
-        _LOGGER.debug(
-            "Claiming grant for device %s with access code %s.", device_id, access_code
-        )
-
-        async with self._session.post(
-            f"{API_INTERNAL_URL}/api/internal/v1/auth/device/claim-grant?access_code={access_code}&use_internal_names=true",
-            headers=self._request_headers(),
-        ) as response:
-            if response.ok:
-                data = await response.json()
-                _LOGGER.debug("Response received %s: %s", response.status, data)
-                return True
-            else:
-                _LOGGER.error(
-                    "Failed to claim grant for device %s, status: %s",
-                    device_id,
-                    response.status,
-                )
-                return False
+        return await self._require_cloud()._claim_grant(device_id, access_code)
 
     async def _approve_access(self, device_id: str, access_code: str):
-        """Approve an access grant for a device."""
-
-        await self._ensure_valid_token()
-
-        async with self._session.post(
-            f"{API_INTERNAL_URL}/api/internal/v1/auth/device/{device_id}/access-grants?access_code={access_code}&approve=true&use_internal_names=true",
-            headers=self._request_headers(),
-        ) as response:
-            if response.ok:
-                _LOGGER.debug("Access approved for device %s.", device_id)
-            else:
-                _LOGGER.error(
-                    "Failed to approve access for device %s, status: %s",
-                    device_id,
-                    response.status,
-                )
-
-            return response.ok
+        return await self._require_cloud()._approve_access(device_id, access_code)
 
     async def set_smartcontrol(self, device_id: str, sh: int, dhw: int):
         """Update smartcontrol setting."""
@@ -935,36 +767,7 @@ class QvantumAPI:
 
     async def get_device_metadata(self, device_id: str):
         """Fetch data from the API with authentication."""
-
-        await self._ensure_valid_token()
-        headers = self._request_headers()
-        if self._device_metadata_etag:
-            headers["If-None-Match"] = self._device_metadata_etag
-
-        async with self._session.get(
-            f"{self._api_url}/api/device-info/v1/devices/{device_id}/status",
-            headers=headers,
-        ) as response:
-            match response.status:
-                case 200:
-                    self._device_metadata = await response.json()
-                    self._device_metadata_etag = response.headers.get("ETag")
-                case 403:
-                    await self.unauthenticate()
-                    raise APIAuthError(response.status)
-                case 304:
-                    _LOGGER.debug("Device metadata not modified, using cached data.")
-                case 500:
-                    _LOGGER.error("Internal server error, clearing data...")
-                    raise APIConnectionError(response.status)
-                case _:
-                    _LOGGER.error(
-                        f"Failed to fetch device metadata, status: {response.status}"
-                    )
-                    self._device_metadata = {}
-
-        _LOGGER.debug("Device metadata fetched: %s", self._device_metadata)
-        return self._device_metadata
+        return await self._require_cloud().get_device_metadata(device_id)
 
     async def get_metrics(
         self, device_id: str, method="now", enabled_metrics: Optional[list[str]] = None
@@ -996,35 +799,12 @@ class QvantumAPI:
             return self._metrics_data
 
         # HTTP cloud mode.
-        http_values, etag, total_latency = await self._get_http_values(
-            device_id, names, etag_header=self._metrics_etag
-        )
-
-        if http_values is not None:
-            metrics: dict = {"hpid": device_id}
-            metrics["latency"] = total_latency
-            for metric_name in names:
-                if metric_name in http_values:
-                    metrics[metric_name] = http_values[metric_name]
-                    if metric_name == "fan0_10v":
-                        metrics[metric_name] = int(float(metrics[metric_name]) * 10)
-                else:
-                    _LOGGER.warning(f"Metric {metric_name} not found in response data.")
-            self._metrics_data = {"metrics": metrics}
-            self._metrics_etag = etag
-
-        _LOGGER.debug("HTTP metrics read: %s", self._metrics_data)
+        self._metrics_data = await self._require_cloud().get_metrics(device_id, names)
         return self._metrics_data
 
     async def get_http_metrics(self, device_id: str, metric_names: list[str]) -> dict:
         """Fetch specific metrics from the HTTP API, bypassing Modbus."""
-        http_values, _, _ = await self._get_http_values(device_id, metric_names)
-        if not http_values:
-            return {"metrics": {}}
-        metrics = {
-            name: http_values[name] for name in metric_names if name in http_values
-        }
-        return {"metrics": metrics}
+        return await self._require_cloud().get_http_metrics(device_id, metric_names)
 
     async def _get_http_values(
         self,
@@ -1032,48 +812,10 @@ class QvantumAPI:
         metric_names: list[str],
         etag_header: Optional[str] = None,
     ) -> tuple[dict | None, str | None, int | None]:
-        """Perform a raw HTTP values fetch and return (values_dict, etag, total_latency).
-
-        Returns (None, None, None) on 304 Not Modified and on any other
-        unhandled non-200 response status.
-        Raises APIAuthError on 403, APIConnectionError on 500.
-        """
-        self._ensure_open()
-        await self._ensure_valid_token()
-        headers = self._request_headers()
-        if etag_header:
-            headers["If-None-Match"] = etag_header
-
-        names_list = "".join(f"&names[]={name}" for name in metric_names)
-        async with self._session.get(
-            f"{API_INTERNAL_URL}/api/internal/v1/devices/{device_id}/values"
-            f"?use_internal_names=true&timeout={METRICS_TIMEOUT_SECONDS}{names_list}",
-            headers=headers,
-        ) as response:
-            match response.status:
-                case 200:
-                    data = await response.json()
-                    _LOGGER.debug("HTTP values fetched: %s", data)
-                    return (
-                        data.get("values", {}),
-                        response.headers.get("ETag"),
-                        data.get("total_latency"),
-                    )
-                case 403:
-                    _LOGGER.error("Authentication failure: %s", response.status)
-                    await self.unauthenticate()
-                    raise APIAuthError(response.status)
-                case 304:
-                    _LOGGER.debug("HTTP values not modified, using cached data.")
-                    return None, None, None
-                case 500:
-                    _LOGGER.error("Internal server error: %s", response.status)
-                    raise APIConnectionError(response.status)
-                case _:
-                    _LOGGER.error(
-                        "Failed to fetch HTTP values, status: %s", response.status
-                    )
-                    return None, None, None
+        """Perform a raw HTTP values fetch and return (values_dict, etag, total_latency)."""
+        return await self._require_cloud()._get_http_values(
+            device_id, metric_names, etag_header=etag_header
+        )
 
     async def get_settings(self, device_id: str):
         """Fetch settings from the API or Modbus."""
@@ -1087,77 +829,12 @@ class QvantumAPI:
             ]
             return await self._read_modbus_settings(device_id, settings_to_read)
 
-        # HTTP cloud mode.
-        await self._ensure_valid_token()
-        headers = self._request_headers()
-        if self._settings_etag:
-            headers["If-None-Match"] = self._settings_etag
-
-        async with self._session.get(
-            f"{self._api_url}/api/device-info/v1/devices/{device_id}/settings",
-            headers=headers,
-        ) as response:
-            match response.status:
-                case 200:
-                    self._settings_data = await response.json()
-                    self._settings_etag = response.headers.get("ETag")
-                    _LOGGER.debug("HTTP Settings fetched: %s", self._settings_data)
-                case 403:
-                    await self.unauthenticate()
-                    raise APIAuthError(response.status)
-                case 304:
-                    _LOGGER.debug("HTTP Settings not modified, using cached data.")
-                case 500:
-                    _LOGGER.error("Internal server error, clearing data...")
-                    raise APIConnectionError(response.status)
-                case _:
-                    _LOGGER.error(
-                        "Failed to fetch HTTP settings, status: %s", response.status
-                    )
-                    self._settings_data = {}
-
-        _LOGGER.debug("HTTP Settings read: %s", self._settings_data)
-        return self._settings_data
+        return await self._require_cloud().get_settings(device_id)
 
     async def get_primary_device(self):
         """Fetch device from the API with authentication."""
-
-        devices = await self.get_devices()
-        if not devices:
-            _LOGGER.error("No devices found.")
-            return None
-
-        device = devices[0]
-
-        metadata = await self.get_device_metadata(device.get("id"))
-        if metadata:
-            device = {**device, **metadata}
-
-        _LOGGER.debug("Primary device fetched: %s", device)
-
-        return device
+        return await self._require_cloud().get_primary_device()
 
     async def get_devices(self):
         """Fetch devices from the API with authentication."""
-
-        await self._ensure_valid_token()
-
-        async with self._session.get(
-            f"{self._api_url}/api/inventory/v1/users/me/devices",
-            headers=self._request_headers(),
-        ) as response:
-            match response.status:
-                case 200:
-                    devices_data = await response.json()
-                    _LOGGER.debug("Devices fetched successfully: %s", devices_data)
-                    return devices_data.get("devices") if devices_data else None
-                case 403:
-                    await self.unauthenticate()
-                    raise APIAuthError(response.status)
-                case _:
-                    _LOGGER.error(
-                        "Failed to fetch devices, status: %s", response.status
-                    )
-                    raise APIConnectionError(
-                        response.status, "Failed to fetch devices"
-                    )
+        return await self._require_cloud().get_devices()

--- a/custom_components/qvantum/client/__init__.py
+++ b/custom_components/qvantum/client/__init__.py
@@ -32,6 +32,7 @@ from .exceptions import (
     RateLimitError,
 )
 from .models import ApplyResult, Device, MetricsPayload, SettingsPayload
+from .cloud import QvantumCloudClient
 from .modbus import (
     IdentityProbeError,
     QvantumModbusClient,
@@ -63,6 +64,7 @@ __all__ = [
     "IdentityProbeError",
     "MetricsPayload",
     "QvantumClient",
+    "QvantumCloudClient",
     "QvantumModbusClient",
     "QvantumModbusDevice",
     "async_probe_identity",

--- a/custom_components/qvantum/client/cloud/__init__.py
+++ b/custom_components/qvantum/client/cloud/__init__.py
@@ -1,0 +1,22 @@
+"""Qvantum cloud HTTP client."""
+
+from . import auth as _auth  # noqa: F401
+from .client import QvantumCloudClient
+from .endpoints import (
+    API_INTERNAL_URL,
+    API_URL,
+    AUTH_URL,
+    FIREBASE_API_KEY,
+    TOKEN_URL,
+    VENTILATION_BOOST_MINUTES,
+)
+
+__all__ = [
+    "API_INTERNAL_URL",
+    "API_URL",
+    "AUTH_URL",
+    "FIREBASE_API_KEY",
+    "QvantumCloudClient",
+    "TOKEN_URL",
+    "VENTILATION_BOOST_MINUTES",
+]

--- a/custom_components/qvantum/client/cloud/auth.py
+++ b/custom_components/qvantum/client/cloud/auth.py
@@ -1,0 +1,11 @@
+"""Firebase auth used by ``QvantumCloudClient``.
+
+Sign-in and token refresh live on the client (``authenticate`` /
+``_refresh_authentication_token``) so the session and token cache stay
+together. This module holds the identity-platform URLs imported by tests
+and documentation.
+"""
+
+from .endpoints import AUTH_URL, FIREBASE_API_KEY, TOKEN_URL
+
+__all__ = ["AUTH_URL", "FIREBASE_API_KEY", "TOKEN_URL"]

--- a/custom_components/qvantum/client/cloud/client.py
+++ b/custom_components/qvantum/client/cloud/client.py
@@ -1,0 +1,606 @@
+"""HTTP cloud client for the Qvantum heat pump API."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+import aiohttp
+
+from ..constants import TAP_WATER_CAPACITY_MAPPINGS
+from ..exceptions import AuthError, ConnectionError, RateLimitError
+from .endpoints import (
+    API_INTERNAL_URL,
+    API_URL,
+    AUTH_URL,
+    DEFAULT_TOKEN_BUFFER_SECONDS,
+    DEFAULT_TOKEN_EXPIRY_SECONDS,
+    FIREBASE_API_KEY,
+    HTTP_TIMEOUT,
+    METRICS_TIMEOUT_SECONDS,
+    TOKEN_URL,
+    VENTILATION_BOOST_MINUTES,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_CUSTOM_CAPACITIES = {1, 6, 7}
+
+
+class QvantumCloudClient:
+    """Qvantum cloud API (Firebase auth + REST)."""
+
+    def __init__(
+        self,
+        username: str | None = None,
+        password: str | None = None,
+        user_agent: str = "",
+        session: aiohttp.ClientSession | None = None,
+        *,
+        firebase_api_key: str = FIREBASE_API_KEY,
+    ) -> None:
+        self._auth_url = AUTH_URL
+        self._token_url = TOKEN_URL
+        self._api_url = API_URL
+        self._username = username
+        self._password = password
+        self._user_agent = user_agent
+        self._firebase_api_key = firebase_api_key
+        self._closed = False
+        if session is not None:
+            self._session = session
+            self._session_owner = False
+        else:
+            self._session = aiohttp.ClientSession(
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": self._user_agent,
+                },
+                timeout=HTTP_TIMEOUT,
+            )
+            self._session_owner = True
+        self._reset_state()
+
+    def _reset_state(self) -> None:
+        self._token = None
+        self._refreshtoken = None
+        self._token_expiry = None
+        self._settings_data: dict = {}
+        self._settings_etag = None
+        self._metrics_data: dict = {}
+        self._metrics_etag = None
+        self._device_metadata: dict = {}
+        self._device_metadata_etag = None
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise ConnectionError(None, "API client is closed")
+
+    async def close(self) -> None:
+        """Close an owned HTTP session. Injected sessions are left to the owner."""
+        if self._closed:
+            return
+        self._closed = True
+        if getattr(self, "_session_owner", False) and self._session:
+            try:
+                await self._session.close()
+            except asyncio.CancelledError:
+                self._session = None
+                raise
+            except Exception as exc:
+                _LOGGER.debug("Error closing HTTP session: %s", exc)
+            self._session = None
+
+    async def unauthenticate(self) -> None:
+        self._reset_state()
+
+    async def _handle_response(self, response: aiohttp.ClientResponse) -> None:
+        if not response.ok:
+            if response.status == 401:
+                raise AuthError(response.status)
+            if response.status == 429:
+                raise RateLimitError(response.status)
+            raise ConnectionError(response.status)
+
+    def _request_headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._token}"}
+
+    async def authenticate(self) -> bool:
+        """Sign in with email/password and store tokens."""
+        self._ensure_open()
+        payload = {
+            "returnSecureToken": "true",
+            "email": self._username,
+            "password": self._password,
+            "clientType": "CLIENT_TYPE_WEB",
+        }
+        async with self._session.post(
+            f"{self._auth_url}/v1/accounts:signInWithPassword?key={self._firebase_api_key}",
+            json=payload,
+        ) as response:
+            match response.status:
+                case 200:
+                    _LOGGER.debug("Authentication successful: %s", response.status)
+                    auth_data = await response.json()
+                    self._token = auth_data.get("idToken")
+                    self._refreshtoken = auth_data.get("refreshToken")
+                    expires_in = auth_data.get(
+                        "expiresIn", DEFAULT_TOKEN_EXPIRY_SECONDS
+                    )
+                    self._token_expiry = datetime.now() + timedelta(
+                        seconds=int(expires_in) - DEFAULT_TOKEN_BUFFER_SECONDS
+                    )
+                    return True
+                case _:
+                    _LOGGER.error("Authentication failed: %s", response.status)
+                    raise AuthError(response.status)
+
+    async def _refresh_authentication_token(self) -> None:
+        self._ensure_open()
+        if not self._refreshtoken:
+            return
+        payload = {"grant_type": "refresh_token", "refresh_token": self._refreshtoken}
+        self._token = None
+        async with self._session.post(
+            f"{self._token_url}/v1/token?key={self._firebase_api_key}",
+            json=payload,
+        ) as response:
+            match response.status:
+                case 200:
+                    _LOGGER.debug("Token refreshed successfully: %s", response.status)
+                    auth_data = await response.json()
+                    self._token = auth_data.get("access_token")
+                    self._refreshtoken = auth_data.get("refresh_token")
+                    expires_in = auth_data.get(
+                        "expires_in", DEFAULT_TOKEN_EXPIRY_SECONDS
+                    )
+                    self._token_expiry = datetime.now() + timedelta(
+                        seconds=int(expires_in) - DEFAULT_TOKEN_BUFFER_SECONDS
+                    )
+                case _:
+                    _LOGGER.error("Token refresh failed: %s", response.status)
+
+    async def _ensure_valid_token(self) -> None:
+        self._ensure_open()
+        if not self._token or datetime.now() >= self._token_expiry:
+            try:
+                await self._refresh_authentication_token()
+                if not self._token:
+                    await self.authenticate()
+                    if not self._token:
+                        raise AuthError(None, "Failed to obtain authentication token")
+            except AuthError:
+                await self.authenticate()
+                if not self._token:
+                    raise AuthError(None, "Failed to obtain authentication token")
+
+    async def _request_json(
+        self,
+        method: str,
+        url: str,
+        payload: Optional[dict] = None,
+        validate_status: bool = False,
+    ) -> dict[str, Any]:
+        await self._ensure_valid_token()
+        request = getattr(self._session, method)
+        kwargs: dict[str, Any] = {"headers": self._request_headers()}
+        if payload is not None:
+            kwargs["json"] = payload
+        async with request(url, **kwargs) as response:
+            if validate_status:
+                await self._handle_response(response)
+            data = await response.json()
+            _LOGGER.debug("Response received %s: %s", response.status, data)
+            return data
+
+    async def _update_settings(self, device_id: str, payload: dict) -> dict[str, Any]:
+        _LOGGER.debug(json.dumps(payload))
+        return await self._request_json(
+            "patch",
+            f"{self._api_url}/api/device-info/v1/devices/{device_id}/settings?dispatch=false",
+            payload,
+        )
+
+    async def _send_command(self, device_id: str, payload: dict) -> dict[str, Any]:
+        wrapped_payload = {"command": payload}
+        _LOGGER.debug(json.dumps(wrapped_payload))
+        return await self._request_json(
+            "post",
+            f"{self._api_url}/api/commands/v1/devices/{device_id}/commands?wait=true&use_internal_names=true",
+            wrapped_payload,
+        )
+
+    async def update_setting(
+        self, device_id: str, name: str, value: Any
+    ) -> dict[str, Any]:
+        return await self._send_command(device_id, {"update_settings": {name: value}})
+
+    async def update_settings(
+        self, device_id: str, settings: dict
+    ) -> dict[str, Any]:
+        return await self._send_command(device_id, {"update_settings": settings})
+
+    async def set_smartcontrol(self, device_id: str, sh: int, dhw: int) -> dict[str, Any]:
+        use_adaptive = sh != -1 and dhw != -1
+        if not use_adaptive:
+            payload = {"use_adaptive": False}
+        else:
+            payload = {
+                "use_adaptive": use_adaptive,
+                "smart_sh_mode": sh,
+                "smart_dhw_mode": dhw,
+            }
+        return await self.update_settings(device_id, payload)
+
+    async def set_extra_tap_water(self, device_id: str, minutes: int) -> dict[str, Any]:
+        current_time = datetime.now()
+        if minutes == 0:
+            stop_time = int(current_time.timestamp())
+            indefinite = False
+            cancel = True
+        elif minutes > 0:
+            stop_time = int((current_time + timedelta(minutes=minutes)).timestamp())
+            indefinite = False
+            cancel = False
+        else:
+            stop_time = -1
+            indefinite = True
+            cancel = False
+        payload = {
+            "set_additional_hot_water": {
+                "stopTime": stop_time,
+                "indefinite": indefinite,
+                "cancel": cancel,
+            }
+        }
+        return await self._send_command(device_id, payload)
+
+    async def set_indoor_temperature_offset(
+        self, device_id: str, value: int
+    ) -> dict[str, Any]:
+        payload = {"settings": [{"name": "indoor_temperature_offset", "value": value}]}
+        return await self._update_settings(device_id, payload)
+
+    async def set_indoor_temperature_target(
+        self, device_id: str, temperature: float
+    ) -> dict[str, Any]:
+        payload = {
+            "settings": [{"name": "indoor_temperature_target", "value": temperature}]
+        }
+        return await self._update_settings(device_id, payload)
+
+    async def set_fanspeedselector(
+        self, device_id: str, preset_mode: str
+    ) -> dict[str, Any]:
+        current_time = datetime.now()
+        match preset_mode:
+            case "off":
+                payload = {"set_fan_mode": {"mode": 0}}
+            case "normal":
+                payload = {
+                    "set_fan_mode": {
+                        "stopTime": int(current_time.timestamp()),
+                        "indefinite": False,
+                    }
+                }
+            case "extra":
+                stop_time = int(
+                    (
+                        current_time + timedelta(minutes=VENTILATION_BOOST_MINUTES)
+                    ).timestamp()
+                )
+                payload = {
+                    "set_fan_mode": {"stopTime": stop_time, "indefinite": False}
+                }
+            case _:
+                raise ValueError(f"Invalid preset_mode: {preset_mode}")
+        return await self._send_command(device_id, payload)
+
+    async def set_tap_water(
+        self, device_id: str, start: int = 0, stop: int = 0
+    ) -> dict[str, Any] | None:
+        if stop == 0 and start == 0:
+            _LOGGER.debug("No tap water settings to update, both stop and start are 0.")
+            return None
+        payload: dict[str, Any] = {"settings": []}
+        if stop:
+            payload["settings"].append({"name": "tap_water_stop", "value": stop})
+        if start:
+            payload["settings"].append({"name": "tap_water_start", "value": start})
+        return await self._update_settings(device_id, payload)
+
+    async def set_tap_water_capacity_target(
+        self, device_id: str, capacity: int
+    ) -> dict[str, Any] | None:
+        if capacity in _CUSTOM_CAPACITIES:
+            capacity_to_stop_start = {v: k for k, v in TAP_WATER_CAPACITY_MAPPINGS.items()}
+            start, stop = capacity_to_stop_start[capacity]
+            _LOGGER.debug(
+                "Setting tap water capacity %s maps to stop %s and start %s.",
+                capacity,
+                stop,
+                start,
+            )
+            return await self.set_tap_water(device_id, start=start, stop=stop)
+        payload = {
+            "settings": [{"name": "tap_water_capacity_target", "value": capacity}]
+        }
+        _LOGGER.debug("Setting tap water capacity target to %s.", capacity)
+        return await self._update_settings(device_id, payload)
+
+    async def get_device_metadata(self, device_id: str) -> dict[str, Any]:
+        await self._ensure_valid_token()
+        headers = self._request_headers()
+        if self._device_metadata_etag:
+            headers["If-None-Match"] = self._device_metadata_etag
+        async with self._session.get(
+            f"{self._api_url}/api/device-info/v1/devices/{device_id}/status",
+            headers=headers,
+        ) as response:
+            match response.status:
+                case 200:
+                    self._device_metadata = await response.json()
+                    self._device_metadata_etag = response.headers.get("ETag")
+                case 403:
+                    await self.unauthenticate()
+                    raise AuthError(response.status)
+                case 304:
+                    _LOGGER.debug("Device metadata not modified, using cached data.")
+                case 500:
+                    _LOGGER.error("Internal server error, clearing data...")
+                    raise ConnectionError(response.status)
+                case _:
+                    _LOGGER.error(
+                        "Failed to fetch device metadata, status: %s", response.status
+                    )
+                    self._device_metadata = {}
+        _LOGGER.debug("Device metadata fetched: %s", self._device_metadata)
+        return self._device_metadata
+
+    async def get_metrics(
+        self, device_id: str, enabled_metrics: list[str] | None = None
+    ) -> dict[str, Any]:
+        self._ensure_open()
+        names = enabled_metrics or []
+        http_values, etag, total_latency = await self._get_http_values(
+            device_id, names, etag_header=self._metrics_etag
+        )
+        if http_values is not None:
+            metrics: dict = {"hpid": device_id, "latency": total_latency}
+            for metric_name in names:
+                if metric_name in http_values:
+                    metrics[metric_name] = http_values[metric_name]
+                    if metric_name == "fan0_10v":
+                        metrics[metric_name] = int(float(metrics[metric_name]) * 10)
+                else:
+                    _LOGGER.warning("Metric %s not found in response data.", metric_name)
+            self._metrics_data = {"metrics": metrics}
+            self._metrics_etag = etag
+        _LOGGER.debug("HTTP metrics read: %s", self._metrics_data)
+        return self._metrics_data
+
+    async def get_http_metrics(
+        self, device_id: str, metric_names: list[str]
+    ) -> dict[str, Any]:
+        http_values, _, _ = await self._get_http_values(device_id, metric_names)
+        if not http_values:
+            return {"metrics": {}}
+        metrics = {
+            name: http_values[name] for name in metric_names if name in http_values
+        }
+        return {"metrics": metrics}
+
+    async def _get_http_values(
+        self,
+        device_id: str,
+        metric_names: list[str],
+        etag_header: Optional[str] = None,
+    ) -> tuple[dict | None, str | None, int | None]:
+        self._ensure_open()
+        await self._ensure_valid_token()
+        headers = self._request_headers()
+        if etag_header:
+            headers["If-None-Match"] = etag_header
+        names_list = "".join(f"&names[]={name}" for name in metric_names)
+        async with self._session.get(
+            f"{API_INTERNAL_URL}/api/internal/v1/devices/{device_id}/values"
+            f"?use_internal_names=true&timeout={METRICS_TIMEOUT_SECONDS}{names_list}",
+            headers=headers,
+        ) as response:
+            match response.status:
+                case 200:
+                    data = await response.json()
+                    _LOGGER.debug("HTTP values fetched: %s", data)
+                    return (
+                        data.get("values", {}),
+                        response.headers.get("ETag"),
+                        data.get("total_latency"),
+                    )
+                case 403:
+                    _LOGGER.error("Authentication failure: %s", response.status)
+                    await self.unauthenticate()
+                    raise AuthError(response.status)
+                case 304:
+                    _LOGGER.debug("HTTP values not modified, using cached data.")
+                    return None, None, None
+                case 500:
+                    _LOGGER.error("Internal server error: %s", response.status)
+                    raise ConnectionError(response.status)
+                case _:
+                    _LOGGER.error(
+                        "Failed to fetch HTTP values, status: %s", response.status
+                    )
+                    return None, None, None
+
+    async def get_settings(self, device_id: str) -> dict[str, Any]:
+        self._ensure_open()
+        await self._ensure_valid_token()
+        headers = self._request_headers()
+        if self._settings_etag:
+            headers["If-None-Match"] = self._settings_etag
+        async with self._session.get(
+            f"{self._api_url}/api/device-info/v1/devices/{device_id}/settings",
+            headers=headers,
+        ) as response:
+            match response.status:
+                case 200:
+                    self._settings_data = await response.json()
+                    self._settings_etag = response.headers.get("ETag")
+                    _LOGGER.debug("HTTP Settings fetched: %s", self._settings_data)
+                case 403:
+                    await self.unauthenticate()
+                    raise AuthError(response.status)
+                case 304:
+                    _LOGGER.debug("HTTP Settings not modified, using cached data.")
+                case 500:
+                    _LOGGER.error("Internal server error, clearing data...")
+                    raise ConnectionError(response.status)
+                case _:
+                    _LOGGER.error(
+                        "Failed to fetch HTTP settings, status: %s", response.status
+                    )
+                    self._settings_data = {}
+        _LOGGER.debug("HTTP Settings read: %s", self._settings_data)
+        return self._settings_data
+
+    async def get_devices(self) -> list | None:
+        await self._ensure_valid_token()
+        async with self._session.get(
+            f"{self._api_url}/api/inventory/v1/users/me/devices",
+            headers=self._request_headers(),
+        ) as response:
+            match response.status:
+                case 200:
+                    devices_data = await response.json()
+                    _LOGGER.debug("Devices fetched successfully: %s", devices_data)
+                    return devices_data.get("devices") if devices_data else None
+                case 403:
+                    await self.unauthenticate()
+                    raise AuthError(response.status)
+                case _:
+                    _LOGGER.error(
+                        "Failed to fetch devices, status: %s", response.status
+                    )
+                    raise ConnectionError(response.status, "Failed to fetch devices")
+
+    async def get_primary_device(self) -> dict[str, Any] | None:
+        devices = await self.get_devices()
+        if not devices:
+            _LOGGER.error("No devices found.")
+            return None
+        device = devices[0]
+        metadata = await self.get_device_metadata(device.get("id"))
+        if metadata:
+            device = {**device, **metadata}
+        _LOGGER.debug("Primary device fetched: %s", device)
+        return device
+
+    async def get_access_level(self, device_id: str) -> dict[str, Any]:
+        await self._ensure_valid_token()
+        async with self._session.get(
+            f"{API_INTERNAL_URL}/api/internal/v1/auth/device/{device_id}/my-access-level?use_internal_names=true",
+            headers=self._request_headers(),
+        ) as response:
+            await self._handle_response(response)
+            data = await response.json()
+            _LOGGER.debug(
+                "Access level response received %s: %s", response.status, data
+            )
+            return data
+
+    async def _generate_code(self, device_id: str) -> dict[str, Any] | None:
+        await self._ensure_valid_token()
+        async with self._session.post(
+            f"{API_INTERNAL_URL}/api/internal/v1/auth/device/{device_id}/generate-access-code?use_internal_names=true",
+            headers=self._request_headers(),
+        ) as response:
+            if response.ok:
+                data = await response.json()
+                _LOGGER.debug("Response received %s: %s", response.status, data)
+                return data
+            _LOGGER.error(
+                "Failed to generate access code for device %s, status: %s",
+                device_id,
+                response.status,
+            )
+            return None
+
+    async def _claim_grant(self, device_id: str, access_code: str) -> bool:
+        await self._ensure_valid_token()
+        _LOGGER.debug(
+            "Claiming grant for device %s with access code %s.", device_id, access_code
+        )
+        async with self._session.post(
+            f"{API_INTERNAL_URL}/api/internal/v1/auth/device/claim-grant?access_code={access_code}&use_internal_names=true",
+            headers=self._request_headers(),
+        ) as response:
+            if response.ok:
+                data = await response.json()
+                _LOGGER.debug("Response received %s: %s", response.status, data)
+                return True
+            _LOGGER.error(
+                "Failed to claim grant for device %s, status: %s",
+                device_id,
+                response.status,
+            )
+            return False
+
+    async def _approve_access(self, device_id: str, access_code: str) -> bool:
+        await self._ensure_valid_token()
+        async with self._session.post(
+            f"{API_INTERNAL_URL}/api/internal/v1/auth/device/{device_id}/access-grants?access_code={access_code}&approve=true&use_internal_names=true",
+            headers=self._request_headers(),
+        ) as response:
+            if response.ok:
+                _LOGGER.debug("Access approved for device %s.", device_id)
+            else:
+                _LOGGER.error(
+                    "Failed to approve access for device %s, status: %s",
+                    device_id,
+                    response.status,
+                )
+            return response.ok
+
+    async def elevate_access(self, device_id: str) -> dict[str, Any] | None:
+        await self._ensure_valid_token()
+        async with self._session.get(
+            f"{API_INTERNAL_URL}/api/internal/v1/auth/device/{device_id}/my-access-level?use_internal_names=true",
+            headers=self._request_headers(),
+        ) as response:
+            await self._handle_response(response)
+            data = await response.json()
+            _LOGGER.debug("Response received %s: %s", response.status, data)
+            expires_at = data.get("expiresAt")
+            has_sufficient_access = data.get("writeAccessLevel", 0) >= 20
+            if not has_sufficient_access and expires_at:
+                try:
+                    expires_at_dt = datetime.fromisoformat(
+                        expires_at.replace("Z", "+00:00")
+                    )
+                    if expires_at_dt < datetime.now(timezone.utc) + timedelta(days=1):
+                        has_sufficient_access = True
+                except ValueError:
+                    pass
+            if has_sufficient_access:
+                return data
+            code_data = await self._generate_code(device_id)
+            if not code_data:
+                return None
+            access_code = code_data.get("accessCode")
+            if not access_code:
+                return None
+            if not await self._claim_grant(device_id, access_code):
+                return None
+            if not await self._approve_access(device_id, access_code):
+                return None
+            async with self._session.get(
+                f"{API_INTERNAL_URL}/api/internal/v1/auth/device/{device_id}/my-access-level?use_internal_names=true",
+                headers=self._request_headers(),
+            ) as response:
+                await self._handle_response(response)
+                data = await response.json()
+                _LOGGER.debug("Response received %s: %s", response.status, data)
+                return data

--- a/custom_components/qvantum/client/cloud/endpoints.py
+++ b/custom_components/qvantum/client/cloud/endpoints.py
@@ -1,0 +1,19 @@
+"""Qvantum cloud HTTP endpoints and timeouts."""
+
+from __future__ import annotations
+
+import aiohttp
+
+AUTH_URL = "https://identitytoolkit.googleapis.com"
+TOKEN_URL = "https://securetoken.googleapis.com"
+API_URL = "https://api.qvantum.com"
+API_INTERNAL_URL = "https://internal-api.qvantum.com"
+
+FIREBASE_API_KEY = "AIzaSyCLQ22XHjH8LmId-PB1DY8FBsN53rWTpFw"
+
+DEFAULT_TOKEN_BUFFER_SECONDS = 60
+DEFAULT_TOKEN_EXPIRY_SECONDS = 3540
+METRICS_TIMEOUT_SECONDS = 12
+VENTILATION_BOOST_MINUTES = 120
+
+HTTP_TIMEOUT = aiohttp.ClientTimeout(total=20, connect=10)


### PR DESCRIPTION
## Summary
- Adds `QvantumCloudClient` under `client/cloud/` (endpoints, Firebase auth, REST).
- Owned HTTP sessions use `aiohttp.ClientTimeout(total=20, connect=10)`.
- `QvantumAPI` constructs the cloud client in HTTP mode, forwards token/session attributes used by tests, and delegates authenticate, metrics, settings, commands, and elevate-access.
- Extra-DHW timer policy remains on `QvantumAPI`.

Depends on #209.

## Test plan
- [x] `pytest` — 722 passed, 89% coverage